### PR TITLE
recommend pip, add ffmpeg2vmaf info and reorganize prerequisite insta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,28 +29,30 @@ It also requires a number of Python packages:
   - [scikit-learn](http://scikit-learn.org/stable/) (>=0.18.1)
   - [h5py](http://www.h5py.org/) (>=2.6.0)
 
-You will need to install gfortran, freetype, pkg-config, freetype and hdf5 (these can't be compiled from source here):
-- on OSX: `brew install gcc freetype pkg-config homebrew/science/hdf5` (`gcc` has the `gfortran` compiler needed for scipy)
-- on linux: `sudo apt-get install -y pkg-config gfortran libhdf5-dev libfreetype6-dev liblapack-dev`
+You will need to install *gfortran* for compiling *scipy*, *freetype* and *pkg-config* required by *matplotlib*, and *hdf5* required by *h5py* (C header files needed). These can't be compiled from source here.
 
-Why is this needed?
-- gfortran compiler is needed in order to compile scipy
-- freetype and pkg-config are required by matplotlib
-- hdf5 is required by h5py (C header files needed)
+### Prerequisite Installation
+First install *gfortran*, *freetype*, *pkg-config* and *hdf5*:
+- on OSX: `brew install gcc freetype pkg-config homebrew/science/hdf5` (`gcc` has the `gfortran` compiler)
+- on linux (Ubuntu): `sudo apt-get install -y pkg-config gfortran libhdf5-dev libfreetype6-dev liblapack-dev`
 
-Follow [this link](http://www.scipy.org/install.html) to install the *numpy/scipy/matplotlib/pandas* suite. To install *scikit-learn*, first [install](http://python-packaging-user-guide.readthedocs.org/en/latest/installing/) package manager *pip*, then run:
+We recommend package manager *pip* for installing required Python packages. To install *pip*:
+- on OSX: `sudo easy_install pip`
+- on Ubuntu: `sudo apt-get install python-pip`
 
+Upgrade *pip* by `python -m pip install --upgrade pip`. Then install the required packages:
 ```
+pip install --user numpy scipy matplotlib pandas
 sudo pip install --upgrade scikit-learn
-```
-
-To install *h5py*, run:
-
-```
 sudo pip install --upgrade h5py
 ```
+Make sure your user install executable directory is on your PATH:
+- on OSX: add `export PATH="$PATH:/Users/your_user/Library/Python/2.7/bin"` to the end of `~/.bash_profile`
+- on Ubuntu: add `export PATH="$PATH:/home/your_user/.local/bin"` to the end of `~/.bashrc`
 
-#### Troubleshooting
+Please refer to the [official document](http://www.scipy.org/install.html) if you encounter any problem.
+
+### Troubleshooting
 
 You can verify if these packages are properly installed and its version/location by:
 
@@ -133,6 +135,12 @@ This will generate output like:
 ```
 
 where *VMAF_score* is the final score and the others are the scores for elementary metrics. *adm2*, *vif_scalex* scores range from 0 (worst) to 1 (best), and *motion2* score typically ranges from 0 (static) to 20 (high-motion).
+
+There is also a *ffmpeg2vmaf* script by which you can compare any file format supported by *ffmpeg* (you need *ffmpeg* installed):
+
+```
+./ffmpeg2vmaf width height reference_path distorted_path [--out-fmt output_format]
+```
 
 To run VMAF in batch mode, create an input text file with each line of format (check examples in [example_batch_input](example_batch_input)):
 


### PR DESCRIPTION
Recommend pip for:

1. I installed numpy by ```apt install numpy``` mentioned in the official document, but the version is old, so I changed to pip
2. After all, we use pip to install scikit and h5py, so let's just use pip from the start

Add ffmpeg2vmaf info for:

1.  It is easy to test MP4 files with ffmpeg2vmaf. I believe this info is useful for many new users

Reorganize prerequisite installation for:

1.  I hope it lets new users be able to try vmaf as fast as possible

When I install vmaf I had to install *python-tk*, I am not sure if I should add that info. Also, I had to add ffmpeg path, but that may due to the way I installed ffmpeg