### PR TITLE
pkg-config for libvmaf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ install:
   - pip install --upgrade scikit-learn
   - pip install --upgrade h5py
 script:
-  - make lib
+  - make
   - sudo make install
   - make testlib
-  - make
   - export PYTHONPATH=$PWD/python/src:$PYTHONPATH
   - python -m unittest discover -s python/test -p '*_test.py'
   - python -m unittest discover -s python/test/lib -p '*_libtest.py'

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ all:
 	done
 
 	cd libsvm; $(MAKE) lib; cd ..;
+	cd ptools; $(MAKE); cd ..;
+	cd wrapper; $(MAKE) libvmaf.a; cd ..;
 
 clean:
 	-for dir in $(TARGETS); do \
@@ -18,10 +20,6 @@ clean:
 
 test:
 	@echo hello;
-
-lib:
-	cd ptools; $(MAKE); cd ..;
-	cd wrapper; $(MAKE) libvmaf.a; cd ..;
 
 install:
 	cd wrapper; $(MAKE) install; cd ..;

--- a/README.md
+++ b/README.md
@@ -396,13 +396,9 @@ Note that *vmafossexec* depends on a shared library *ptools/libptools.so* (or on
 
 ## Usage through libvmaf
 
-VMAF is now packaged into a library called *libvmaf*. You can install the library built using object files under wrapper/obj and ptools. To create the library (*libvmaf.a*) run:
+VMAF is now packaged into a library called *libvmaf*. You can install the library built using object files under wrapper/obj and ptools.
 
-```
-make lib
-```
-
-To install the library run:
+To install the library (*libvmaf.a*) run:
 
 ```
 make install

--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -116,7 +116,7 @@ $(OBJDIR)/svm.o: $(SRCDIR)/svm.cpp
 
 $(OBJDIR)/libvmaf.o: $(SRCDIR)/libvmaf.cpp
 	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) -I $(SRCDIR) -I $(FEATURESRCDIR)/common $<
- 
+
 $(OBJDIR)/main.o: $(SRCDIR)/main.cpp
 	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common $<
 
@@ -131,18 +131,18 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.c
 $(OBJDIR)/%.o: $(SRCDIR)/pugixml/%.cpp
 	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) $<
 
-vmafossexec: $(OBJS)
-ifeq ($(shell uname),Darwin)
-	$(CXX) -o $@ $(LDFLAGS) $^ -L$(PTOOLSDIR) $(LIBS) -Wl
-else
-	$(CXX) -o $@ $(LDFLAGS) $^ -L$(PTOOLSDIR) $(LIBS) -Wl,-rpath=$(PTOOLSDIR)
-endif
-
 PREFIX = /usr/local
 
 lib = libvmaf.a
 $(lib): $(OBJS) $(wildcard ../ptools/*.o)
 	ar rcs $@ $^
+
+vmafossexec: $(lib)
+ifeq ($(shell uname),Darwin)
+	$(CXX) -o $@ $(LDFLAGS) $^ -L$(PTOOLSDIR) $(LIBS) -Wl
+else
+	$(CXX) -o $@ $(LDFLAGS) $^ -L$(PTOOLSDIR) $(LIBS) -Wl,-rpath=$(PTOOLSDIR)
+endif
 
 .PHONY: install
 install:
@@ -150,9 +150,11 @@ install:
 	mkdir -p $(DESTDIR)$(PREFIX)/lib
 	mkdir -p $(DESTDIR)$(PREFIX)/include
 	mkdir -p $(DESTDIR)$(PREFIX)/share
+	mkdir -p $(DESTDIR)$(PREFIX)/lib/pkgconfig
 	cp $(lib) $(DESTDIR)$(PREFIX)/lib/$(lib)
 	cp src/libvmaf.h $(DESTDIR)$(PREFIX)/include/
 	cp -r ../model $(DESTDIR)$(PREFIX)/share/
+	cp libvmaf.pc $(DESTDIR)$(PREFIX)/lib/pkgconfig/
 
 .PHONY: uninstall
 uninstall:
@@ -160,6 +162,7 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(lib)
 	rm -f $(DESTDIR)$(PREFIX)/include/libvmaf.h
 	rm -fr $(DESTDIR)$(PREFIX)/share/model
+	rm -f $(DESTDIR)$(PREFIX)/lib/pkgconfig/libvmaf.pc
 
 testlib: $(SRCDIR)/main.cpp
 	$(CXX) -o $@  $(CXXFLAGS) $^ -I $(FEATURESRCDIR) -I $(DESTDIR)$(PREFIX)/include -L$(DESTDIR)$(PREFIX)/lib -lvmaf -pthread

--- a/wrapper/libvmaf.pc
+++ b/wrapper/libvmaf.pc
@@ -1,0 +1,15 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: libvmaf
+Description: Netflix's VMAF library
+Version: 0.6.1
+URL: https://github.com/Netflix/vmaf
+Requires:
+Requires.private:
+Conflicts:
+Libs: -L${libdir} -lvmaf -lstdc++ -lpthread -lm
+Libs.private:
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi, added **pkg-config** for libvmaf to allow external programs to query libvmaf and to check if it's installed.
Also merged **make lib** with **make** so creation of both **libvmaf.a** and **vmafossexec**  takes place on running **make**.
Linked vmafossexec to libvmaf.a , so vmaf also uses the libvmaf library. Updated readme.
I am ready to revert any changes that are not consistent.
