### PR TITLE
Remove unneeded dependencies in Dockerfile, fixes #115

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM        ubuntu
-RUN apt-get update -qq && apt-get install -y \
-      build-essential git gcc python-numpy python-scipy python-matplotlib \
-      ipython ipython-notebook python-pandas python-sympy python-nose \
-      python2.7 python-setuptools python-dev
+FROM ubuntu
+RUN apt-get update -qq
+RUN apt-get install -y build-essential git
+
+RUN apt-get install -y python python-setuptools python-dev python-tk
+
 RUN easy_install pip
-RUN pip install --upgrade scikit-learn
-RUN pip install --upgrade h5py
+RUN pip install numpy scipy matplotlib notebook pandas sympy nose scikit-learn h5py
+
 RUN git clone --depth 1 https://github.com/Netflix/vmaf.git vmaf
 ENV PYTHONPATH=/vmaf/python/src:$PYTHONPATH
 ENV PYTHONPATH=/vmaf:$PYTHONPATH
 ENV PATH=/vmaf:/vmaf/wrapper:$PATH
 RUN cd /vmaf && make
-# For the UserWarning: Matplotlib is building ... fc-list please see https://github.com/matplotlib/matplotlib/issues/5836

--- a/README.md
+++ b/README.md
@@ -442,11 +442,11 @@ docker run --rm vmaf [CLI]
 For example, if you are under root, to run *run_vmaf* on a sample reference/distorted video pair under *resource/yuv*:
 
 ```
-docker run --rm -v $(PWD):/files vmaf run_vmaf yuv420p 576 324 /files/python/test/resource/yuv/src01_hrc00_576x324.yuv /files/python/test/resource/yuv/src01_hrc01_576x324.yuv --out-fmt json
+docker run --rm -v $(pwd):/files vmaf run_vmaf yuv420p 576 324 /files/python/test/resource/yuv/src01_hrc00_576x324.yuv /files/python/test/resource/yuv/src01_hrc01_576x324.yuv --out-fmt json
 ```
 
 Under root, to run *vmafossexec* with a specified model file:
 
 ```
-docker run --rm -v $(PWD):/files vmaf vmafossexec yuv420p 576 324 /files/python/test/resource/yuv/src01_hrc00_576x324.yuv /files/python/test/resource/yuv/src01_hrc01_576x324.yuv /files/model/nflxall_vmafv4.pkl
+docker run --rm -v $(pwd):/files vmaf vmafossexec yuv420p 576 324 /files/python/test/resource/yuv/src01_hrc00_576x324.yuv /files/python/test/resource/yuv/src01_hrc01_576x324.yuv /files/model/nflxall_vmafv4.pkl
 ```


### PR DESCRIPTION
This shrinks the size of the resulting Docker image from around 3.5 GB to 1.5 GB by removing unneeded dependencies (e.g. texlive).

Tests still pass.

The `$(PWD)` command has been changed to `$(pwd)` – the former doesn't work as `$PWD` is an environment variable whereas `pwd` is a shell builtin.