### PR TITLE
Unbreak ptools compilation on MinGW

### DIFF
--- a/ptools/Makefile
+++ b/ptools/Makefile
@@ -1,1 +1,1 @@
-Makefile.VMAF
+include Makefile.VMAF

--- a/ptools/Makefile
+++ b/ptools/Makefile
@@ -1,1 +1,1 @@
-include Makefile.VMAF
+-include Makefile.VMAF


### PR DESCRIPTION
At present, on MinGW, make fails in /ptools with "Makefile:1: *** missing separator.  Stop.". Use of include directive lets 'make' proceed.