### PR TITLE
Replace with regular Makefile that includes active Makefile

### DIFF
--- a/ptools/Makefile
+++ b/ptools/Makefile
@@ -1,1 +1,1 @@
-Makefile.VMAF
+include Makefile.VMAF


### PR DESCRIPTION
On Windows, symlinks are checkout as regular files. This breaks ptools compilation.