### PR TITLE
always call user defined read_frame() callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## (8/7/2018) [1.3.9]
+- libvmaf: fix case where user defined read_frame() callback was being ignored.
+
 ## (6/21/2018) [1.3.8]
 
 **Fixed bugs:**

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-VMAF Development Kit (VDK) Version 1.3.8
+VMAF Development Kit (VDK) Version 1.3.9
 VMAF Version 0.6.1

--- a/wrapper/libvmaf.pc
+++ b/wrapper/libvmaf.pc
@@ -5,7 +5,7 @@ includedir=/usr/local/include
 
 Name: libvmaf
 Description: Netflix's VMAF library
-Version: 1.3.8
+Version: 1.3.9
 URL: https://github.com/Netflix/vmaf
 Requires:
 Requires.private:

--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -174,7 +174,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         {
             // read frame from file
 
-            ret = read_frame(ref_buf, dis_buf, temp_buf, stride, user_data);
+            ret = thread_data->read_frame(ref_buf, dis_buf, temp_buf, stride, user_data);
             if (ret == 1)
             {
 #ifdef MULTI_THREADING
@@ -230,7 +230,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         }
 #endif
 
-        ret = read_frame(next_ref_buf, next_dis_buf, temp_buf, stride, user_data);
+        ret = thread_data->read_frame(next_ref_buf, next_dis_buf, temp_buf, stride, user_data);
         if (ret == 1)
         {
 #ifdef MULTI_THREADING


### PR DESCRIPTION
Once this is merged and we cut a new release, I also have a patch for ffmpeg-devel that fixes the libvmaf FFmpeg filter.