### PR TITLE
Fix implicit declarations of functions

### DIFF
--- a/feature/src/adm_tools.h
+++ b/feature/src/adm_tools.h
@@ -17,6 +17,7 @@
  */
 
 #define M_PI 3.14159265358979323846264338327
+#include <math.h>
 #include "common/macros.h"
 
 #pragma once

--- a/feature/src/common/blur_array.c
+++ b/feature/src/common/blur_array.c
@@ -5,6 +5,7 @@
  *      Author: thomas
  */
 
+#include <string.h>
 #include "blur_array.h"
 
 /*

--- a/feature/src/common/file_io.h
+++ b/feature/src/common/file_io.h
@@ -25,6 +25,7 @@
 //#define OPT_RANGE_PIXEL_OFFSET 0
 #define OPT_RANGE_PIXEL_OFFSET (-128)
 
+float apply_frame_differencing(const float *current_frame, const float *previous_frame, float *frame_difference, int width, int height, int stride);
 int read_image(FILE *rfile, void *buf, int width, int height, int stride, int elem_size);
 int write_image(FILE *wfile, const void *buf, int width, int height, int stride, int elem_size);
 

--- a/feature/src/common/frame.c
+++ b/feature/src/common/frame.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "file_io.h"
 #include "frame.h"
 

--- a/feature/src/psnr_tools.c
+++ b/feature/src/psnr_tools.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "psnr_tools.h"
 
 /*

--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -34,6 +34,7 @@
 #include "adm_options.h"
 #include "combo.h"
 #include "debug.h"
+#include "psnr_tools.h"
 
 #ifdef MULTI_THREADING
 #include "common/blur_array.h"


### PR DESCRIPTION
I'm making VMAF run in iPhone & Android using LLVM.
First of all, I fix implicit declarations of functions to follow C99.