### PR TITLE
Remove reduntant object file generation for psnr

### DIFF
--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -34,7 +34,6 @@ OBJS = \
 	$(OBJDIR)/ssim.o \
 	$(OBJDIR)/ms_ssim.o \
 	$(OBJDIR)/moment.o \
-	$(OBJDIR)/psnr.o \
 	$(OBJDIR)/svm.o \
 	$(OBJDIR)/combo.o \
 	$(OBJDIR)/all.o \
@@ -127,9 +126,6 @@ $(OBJDIR)/ms_ssim.o: $(FEATURESRCDIR)/ms_ssim.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/moment.o: $(FEATURESRCDIR)/moment.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
-
-$(OBJDIR)/psnr.o: $(FEATURESRCDIR)/psnr.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/all.o: $(FEATURESRCDIR)/all.c


### PR DESCRIPTION
While using libvmaf, the following warnings resulted in segmentation fault in (line 634) wrapper/src/combo.c
To build static library:
Command : sudo make install
Makefile:133: warning: overriding recipe for target '/home/vmaf/wrapper/obj/psnr.o'
Makefile:109: warning: ignoring old recipe for target '/home/vmaf/wrapper/obj/psnr.o'

psnr.o is generated twice.
This solves the issue #247 