### PR TITLE
Output per bootstrap model scores in vmafossexec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## (12/17/2018) [1.3.11]
+
+**New features:**
+- Revise number of bootstrap models definition: model/vmaf_rb_v0.6.3/vmaf_rb_v0.6.3.pkl has 21 models (20 bootstrap models and one using the full data). From these 21 models, the 20 of them are same as v0.6.2, only added an additional bootstrap model.
+- Output the per bootstrap model predictions from wrapper/vmafossexec.
+
 ## (9/13/2018) [1.3.10]
 
 **New features:**

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-VMAF Development Kit (VDK) Version 1.3.10
+VMAF Development Kit (VDK) Version 1.3.11
 VMAF Version 0.6.1

--- a/python/src/vmaf/core/quality_runner.py
+++ b/python/src/vmaf/core/quality_runner.py
@@ -701,7 +701,20 @@ class VmafossExecQualityRunner(QualityRunner):
         tree = ElementTree.parse(log_file_path)
         root = tree.getroot()
         scores = []
+
+        num_bootstrap_models = np.int(root.findall('params')[0].attrib['num_bootstrap_models'])
+        bootstrap_model_prefix = root.findall('params')[0].attrib['bootstrap_model_prefix']
+
+        bootstrap_model_list = []
+        for bootstrap_ind in range(num_bootstrap_models):
+            # NOTE: bootstrap model indices start from 1
+            bootstrap_model_list.append('{}{:04d}'.format(bootstrap_model_prefix, bootstrap_ind + 1))
+
+        # augment the feature set with any bootstrap models
+        self.FEATURES += bootstrap_model_list
+
         feature_scores = [[] for _ in self.FEATURES]
+
         for frame in root.findall('frames/frame'):
             scores.append(float(frame.attrib['vmaf']))
             for i_feature, feature in enumerate(self.FEATURES):

--- a/python/test/vmafossexec_test.py
+++ b/python/test/vmafossexec_test.py
@@ -529,6 +529,12 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ci95_high_score'], 74.85038125, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ci95_high_score'], 99.99736666666666, places=4)
 
+        # per model score checks
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0001_score'], 73.26853333333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0002_score'], 70.38517916666667, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0003_score'], 71.59264583333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0020_score'], 73.15570625, places=3)
+
     def test_run_vmafossexec_runner_with_ci_and_custom_model(self):
         print 'test on running VMAFOSSEXEC runner with conf interval and custom model...'
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -564,7 +570,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             delete_workdir=True,
             result_store=None,
             optional_dict={
-                'model_filepath': VmafConfig.model_path("vmaf_rb_v0.6.2", "vmaf_rb_v0.6.2.pkl"),
+                'model_filepath': VmafConfig.model_path("vmaf_rb_v0.6.3", "vmaf_rb_v0.6.3.pkl"),
                 'phone_model':True,
                 'ci': True,
             },
@@ -575,10 +581,17 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 91.723012127641823, places=4)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_bagging_score'], 90.129761531349985, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_bagging_score'], 90.13159583333334, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_bagging_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_stddev_score'], 0.85880437658259945, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_stddev_score'], 0.8371132083333332, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_stddev_score'], 0.0, places=4)
+
+        # per model score checks
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0001_score'], 90.25032499999999, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0002_score'], 88.18534583333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0003_score'], 89.04952291666666, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0020_score'], 90.16633958333334, places=3)
+
 
 class VmafossexecQualityRunnerSubsamplingTest(unittest.TestCase):
 

--- a/wrapper/libvmaf.pc
+++ b/wrapper/libvmaf.pc
@@ -5,7 +5,7 @@ includedir=/usr/local/include
 
 Name: libvmaf
 Description: Netflix's VMAF library
-Version: 1.3.9
+Version: 1.3.11
 URL: https://github.com/Netflix/vmaf
 Requires:
 Requires.private:

--- a/wrapper/src/vmaf.h
+++ b/wrapper/src/vmaf.h
@@ -63,6 +63,10 @@ class StatVector
 public:
     StatVector() {}
     StatVector(std::vector<double> l): l(l) {}
+    std::vector<double> getVector()
+    {
+        return l;
+    }
     double mean()
     {
         _assert_size();
@@ -214,13 +218,19 @@ enum VmafPredictionReturnType
     MINUS_DELTA
 };
 
+struct VmafPredictionStruct
+{
+    std::map<VmafPredictionReturnType, double> vmafPrediction;
+    std::vector<double> vmafMultiModelPrediction;
+};
+
 class LibsvmNusvrTrainTestModel
 {
 public:
     LibsvmNusvrTrainTestModel(const char *model_path): model_path(model_path) {}
     Val feature_names, norm_type, slopes, intercepts, score_clip, score_transform;
     virtual void load_model();
-    virtual std::map<VmafPredictionReturnType, double> predict(svm_node* nodes);
+    virtual VmafPredictionStruct predict(svm_node* nodes);
     void populate_and_normalize_nodes_at_frm(size_t i_frm,
             svm_node*& nodes, StatVector& adm2,
             StatVector& adm_scale0, StatVector& adm_scale1,
@@ -245,7 +255,7 @@ class BootstrapLibsvmNusvrTrainTestModel: public LibsvmNusvrTrainTestModel {
 public:
     BootstrapLibsvmNusvrTrainTestModel(const char *model_path): LibsvmNusvrTrainTestModel(model_path) {}
     virtual void load_model();
-    virtual std::map<VmafPredictionReturnType, double> predict(svm_node* nodes);
+    virtual VmafPredictionStruct predict(svm_node* nodes);
     virtual ~BootstrapLibsvmNusvrTrainTestModel() {}
 private:
     std::vector<std::unique_ptr<svm_model, SvmDelete>> bootstrap_svm_model_ptrs;
@@ -267,16 +277,16 @@ protected:
     static void _transform_value(LibsvmNusvrTrainTestModel& model, double& prediction);
     static void _clip_value(LibsvmNusvrTrainTestModel& model, double& prediction);
     virtual void _set_prediction_result(
-            std::vector<std::map<VmafPredictionReturnType, double> > predictionMaps,
+            std::vector<VmafPredictionStruct> predictionStructs,
             Result& result);
 private:
     const char *model_path;
     static const int INIT_FRAMES = 1000;
     virtual std::unique_ptr<LibsvmNusvrTrainTestModel> _load_model(const char *model_path);
-    virtual void _postproc_predict(std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _transform_score(LibsvmNusvrTrainTestModel& model, std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _clip_score(LibsvmNusvrTrainTestModel& model, std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _postproc_transform_clip(std::map<VmafPredictionReturnType, double>& predictionMap);
+    virtual void _postproc_predict(VmafPredictionStruct& predictionStruct);
+    virtual void _transform_score(LibsvmNusvrTrainTestModel& model, VmafPredictionStruct& predictionStruct);
+    virtual void _clip_score(LibsvmNusvrTrainTestModel& model, VmafPredictionStruct& predictionStruct);
+    virtual void _postproc_transform_clip(VmafPredictionStruct& predictionStruct);
     void _normalize_predict_denormalize_transform_clip(LibsvmNusvrTrainTestModel& model,
             size_t num_frms, StatVector& adm2,
             StatVector& adm_scale0, StatVector& adm_scale1,
@@ -284,7 +294,7 @@ private:
             StatVector& vif_scale0, StatVector& vif_scale1,
             StatVector& vif_scale2, StatVector& vif_scale3, StatVector& vif,
             StatVector& motion2, bool enable_transform, bool disable_clip,
-            std::vector<std::map<VmafPredictionReturnType, double>>& predictionMaps);
+            std::vector<VmafPredictionStruct>& predictionStructs);
 };
 
 class BootstrapVmafQualityRunner: public VmafQualityRunner
@@ -295,12 +305,12 @@ public:
 private:
     static constexpr double DELTA = 0.01;
     virtual std::unique_ptr<LibsvmNusvrTrainTestModel> _load_model(const char *model_path);
-    virtual void _postproc_predict(std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _transform_score(LibsvmNusvrTrainTestModel& model, std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _clip_score(LibsvmNusvrTrainTestModel& model, std::map<VmafPredictionReturnType, double>& predictionMap);
-    virtual void _postproc_transform_clip(std::map<VmafPredictionReturnType, double>& predictionMap);
+    virtual void _postproc_predict(VmafPredictionStruct& predictionStruct);
+    virtual void _transform_score(LibsvmNusvrTrainTestModel& model, VmafPredictionStruct& predictionStruct);
+    virtual void _clip_score(LibsvmNusvrTrainTestModel& model, VmafPredictionStruct& predictionStruct);
+    virtual void _postproc_transform_clip(VmafPredictionStruct& predictionStruct);
     virtual void _set_prediction_result(
-            std::vector<std::map<VmafPredictionReturnType, double> > predictionMaps,
+            std::vector<VmafPredictionStruct> predictionStructs,
             Result& result);
 };
 


### PR DESCRIPTION
Changes to the C++ code so that the output of vmafossexec in xml and json format reports the per bootstrap model scores.