### PR TITLE
fix w10 error with using uninitialized offset_flag variable

### DIFF
--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -99,7 +99,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
     int ret = 0;
     bool next_frame_read;
 
-    bool offset_flag;
+    bool offset_flag = false;
 
 #ifdef MULTI_THREADING
     float *prev_blur_buf_ = 0;


### PR DESCRIPTION
After building the project, there are some errors executing vmafossexec (pop up windows saying variable is used without being initialized. A window per each processor or thread), it is required to ignore them so that the threads continue working. Not sure the right initialization is true or false but now it works.