### PR TITLE
Add automated Windows builds with AppVeyor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 VMAF - Video Multi-Method Assessment Fusion
 ===================
-[![Build Status](https://travis-ci.org/Netflix/vmaf.svg?branch=master)](https://travis-ci.org/Netflix/vmaf)
+[![Build Status](https://travis-ci.org/Netflix/vmaf.svg?branch=master)](https://travis-ci.org/Netflix/vmaf) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Netflix/vmaf?branch=master&svg=true)](https://ci.appveyor.com/project/Netflix/vmaf)
 
 VMAF is a perceptual video quality assessment algorithm developed by Netflix. VMAF Development Kit (VDK) is a software package that contains the VMAF algorithm implementation, as well as a set of tools that allows a user to train and test a custom VMAF model. Read [this](https://medium.com/netflix-techblog/toward-a-practical-perceptual-video-quality-metric-653f208b9652) techblog post for an overview, or [this](https://medium.com/netflix-techblog/vmaf-the-journey-continues-44b51ee9ed12) post for the latest updates and tips for best practices.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+image: Visual Studio 2017
+configuration: Release
+
+build:
+  project: vmaf.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: "vmaf-win-x64.zip","examples.bat","libvmaf.lib","vmafossexec.exe","vmaf.exe"
+    artifact: vmaf-win-x64.zip,examples.bat,libvmaf.lib,vmafossexec.exe,vmaf.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ artifacts:
     - path: vmaf-win-x64.zip
     - path: x64\Release\*.*
 
-deploy:
-  - provider: GitHub
-    artifact: vmaf-win-x64.zip,examples.bat,libvmaf.lib,vmafossexec.exe,vmaf.exe
-    auth_token:
-      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
-    prerelease: true
-    on:
-      appveyor_repo_tag: true
+#deploy:
+#  - provider: GitHub
+#    artifact: vmaf-win-x64.zip,examples.bat,libvmaf.lib,vmafossexec.exe,vmaf.exe
+#    auth_token:
+#      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+#    prerelease: true
+#    on:
+#      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifacts: 
-     - x64\Release\examples.bat
-     - x64\Release\libvmaf.lib
-     - x64\Release\vmafossexec.exe
-     - x64\Release\vmaf.exe
+    artifacts: x64\Release\examples.bat,x64\Release\libvmaf.lib,x64\Release\vmafossexec.exe,x64\Release\vmaf.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifacts: vmaf-win-x64.zip,x64\Release\examples.bat,x64\Release\libvmaf.lib,x64\Release\vmafossexec.exe,x64\Release\vmaf.exe
+    artifact: "vmaf-win-x64.zip","examples.bat","libvmaf.lib","vmafossexec.exe","vmaf.exe"
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,15 @@ configuration: Release
 build:
   project: vmaf.sln
 
+after_build: 7z a vmaf-win-x64.zip x64\Release\*.*
+
 artifacts:
+    - path: vmaf-win-x64.zip
     - path: x64\Release\*.*
 
 deploy:
   - provider: GitHub
-    artifacts: x64\Release\examples.bat,x64\Release\libvmaf.lib,x64\Release\vmafossexec.exe,x64\Release\vmaf.exe
+    artifacts: vmaf-win-x64.zip,x64\Release\examples.bat,x64\Release\libvmaf.lib,x64\Release\vmafossexec.exe,x64\Release\vmaf.exe
     auth_token:
       secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,4 +6,16 @@ build:
 
 artifacts:
     - path: x64\Release\*.*
-      name: $(APPVEYOR_PROJECT_NAME)
+
+ deploy:
+  - provider: GitHub
+    artifact: 
+     - x64\Release\examples.bat
+     - x64\Release\libvmaf.lib
+     - x64\Release\vmafossexec.exe
+     - x64\Release\vmaf.exe
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,3 +3,7 @@ configuration: Release
 
 build:
   project: vmaf.sln
+
+artifacts:
+    - path: x64\Release\*.*
+      name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
-    artifact: 
+    artifacts: 
      - x64\Release\examples.bat
      - x64\Release\libvmaf.lib
      - x64\Release\vmafossexec.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ build:
 artifacts:
     - path: x64\Release\*.*
 
- deploy:
+deploy:
   - provider: GitHub
     artifact: 
      - x64\Release\examples.bat

--- a/resource/doc/BuildForWindows.md
+++ b/resource/doc/BuildForWindows.md
@@ -1,4 +1,4 @@
-# Prepare
+# Prepare  [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Netflix/vmaf?branch=master&svg=true)](https://ci.appveyor.com/project/Netflix/vmaf)
   - Visual Studio 2015 on Windows
   
 # Steps


### PR DESCRIPTION
This PR adds an [AppVeyor configuration](https://ci.appveyor.com/project/EwoutH/vmaf/history) that produces automated Windows builds using Visual Studio 2017. 

For optimal integration AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub marketplace.

All files in the `x64/release` folder are uploaded to AppVeyor as artifacts. In a future PR I will also add a deploy function to automatically upload artifacts to GitHub Releases ([example](https://github.com/EwoutH/vmaf/releases)).