### PR TITLE
Libvmaf changes and multiple model support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## (9/9/2019) [1.4.0]
+
+**New features:**
+- Support for multiple models.
+- Libvmaf interface changes.
+
 ## (9/8/2019) [1.3.15]
 
 **Fixed bugs:**

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-VMAF Development Kit (VDK) Version 1.3.15
+VMAF Development Kit (VDK) Version 1.4.0
 VMAF Version 0.6.1

--- a/feature/Makefile
+++ b/feature/Makefile
@@ -6,6 +6,8 @@ SRCDIR  = $(TOP)/src
 OBJDIR  = $(TOP)/obj
 TOOLDIR = $(TOP)/tool
 LIBVMAF = $(TOP)/../wrapper/libvmaf.a
+
+# TODO: improve on the circular dependency introduced with feature/src/common, wrapper and libvmaf.h
 LIBVMAF_HEADER = $(TOP)/../wrapper/src
 
 CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic

--- a/feature/Makefile
+++ b/feature/Makefile
@@ -6,6 +6,7 @@ SRCDIR  = $(TOP)/src
 OBJDIR  = $(TOP)/obj
 TOOLDIR = $(TOP)/tool
 LIBVMAF = $(TOP)/../wrapper/libvmaf.a
+LIBVMAF_HEADER = $(TOP)/../wrapper/src
 
 CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic
 # CFLAGS_COMMON = -g -O0 -fPIC -Wall -Wextra -pedantic
@@ -19,19 +20,19 @@ LDFLAGS  := $(LDFLAGS)
 $(AVX_OBJS): EXTRA_CFLAGS := -mavx
 
 $(OBJDIR)/vmaf_main.o: $(SRCDIR)/vmaf_main.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/psnr_main.o: $(SRCDIR)/psnr_main.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/moment_main.o: $(SRCDIR)/moment_main.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/ssim_main.o: $(SRCDIR)/ssim_main.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/ms_ssim_main.o: $(SRCDIR)/ms_ssim_main.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) $(EXTRA_CFLAGS) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 vmaf: $(OBJDIR)/vmaf_main.o $(LIBVMAF)
 	$(CXX) -s -o $@ $(LDFLAGS) $^ $(LIBS) -pthread

--- a/feature/msvc/moment.vcxproj
+++ b/feature/msvc/moment.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -59,6 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/feature/msvc/ms_ssim.vcxproj
+++ b/feature/msvc/ms_ssim.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -59,6 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/feature/msvc/psnr.vcxproj
+++ b/feature/msvc/psnr.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -59,6 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/feature/msvc/ssim.vcxproj
+++ b/feature/msvc/ssim.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -59,6 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/feature/msvc/vmaf.vcxproj
+++ b/feature/msvc/vmaf.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -59,6 +60,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>..\..\wrapper\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>

--- a/feature/src/adm.c
+++ b/feature/src/adm.c
@@ -274,7 +274,7 @@ fail:
 	return ret;
 }
 
-int adm(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt)
+int adm(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h)
 {
     double score = 0;
     double score_num = 0;

--- a/feature/src/all.c
+++ b/feature/src/all.c
@@ -45,7 +45,7 @@ int compute_motion(const float *ref, const float *dis, int w, int h, int ref_str
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-int all(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt)
+int all(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt_enum)
 {
     double score = 0;
     double score2 = 0;
@@ -83,10 +83,10 @@ int all(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, i
         goto fail_or_end;
     }
 
-    ret = psnr_constants(fmt, &peak, &psnr_max);
+    ret = psnr_constants(fmt_enum, &peak, &psnr_max);
     if (ret)
     {
-        printf("error: unknown format %s.\n", fmt);
+        printf("error: unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         fflush(stdout);
         goto fail_or_end;
     }

--- a/feature/src/ansnr.c
+++ b/feature/src/ansnr.c
@@ -117,7 +117,7 @@ fail:
     return ret;
 }
 
-int ansnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt)
+int ansnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt_enum)
 {
     double score = 0;
     double score_psnr = 0;
@@ -142,10 +142,10 @@ int ansnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
         goto fail_or_end;
     }
 
-    ret = psnr_constants(fmt, &peak, &psnr_max);
+    ret = psnr_constants(fmt_enum, &peak, &psnr_max);
     if (ret)
     {
-        printf("error: unknown format %s.\n", fmt);
+        printf("error: unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         fflush(stdout);
         goto fail_or_end;
     }

--- a/feature/src/common/file_io.c
+++ b/feature/src/common/file_io.c
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "libvmaf.h"
+
 /**
  * Note: stride is in terms of bytes
  */
@@ -209,3 +211,27 @@ int offset_image_s(float *buf, float off, int width, int height, int stride)
 	return ret;
 }
 
+int offset_vmaf_picture(VmafPicture *vmaf_pict, float off)
+{
+    char *byte_ptr = (char *)(vmaf_pict->data[0]);
+	unsigned int ret = 1;
+	int i, j;
+
+//	unsigned int channel = 0;
+
+	for (i = 0; i < vmaf_pict->h[0]; ++i)
+	{
+		float *row_ptr = (float *)byte_ptr;
+
+		for (j = 0; j < vmaf_pict->w[0]; ++j)
+		{
+			row_ptr[j] += off;
+		}
+
+		byte_ptr += vmaf_pict->stride_byte[0];
+	}
+
+	ret = 0;
+
+	return ret;
+}

--- a/feature/src/common/frame.c
+++ b/feature/src/common/frame.c
@@ -82,7 +82,7 @@ const char* get_fmt_str_from_fmt_enum(enum VmafPixelFormat fmt_enum)
 int read_vmaf_picture(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *s)
 {
     struct data *user_data = (struct data *)s;
-    bool use_color = user_data->use_color;
+    bool use_chroma = user_data->use_chroma;
     enum VmafPixelFormat format = user_data->format;
     unsigned int w = user_data->width;
     unsigned int h = user_data->height;
@@ -96,20 +96,20 @@ int read_vmaf_picture(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, fl
     dis_vmaf_pict->w[0] = w;
     dis_vmaf_pict->h[0] = h;
 
-    int color_resolution_ret = get_color_resolution(ref_vmaf_pict->pix_fmt, ref_vmaf_pict->w[0],
+    int chroma_resolution_ret = get_chroma_resolution(ref_vmaf_pict->pix_fmt, ref_vmaf_pict->w[0],
         ref_vmaf_pict->h[0], &(ref_vmaf_pict->w[1]), &(ref_vmaf_pict->h[1]),
         &(ref_vmaf_pict->w[2]), &(ref_vmaf_pict->h[2]));
 
-    if (color_resolution_ret) {
-        fprintf(stderr, "Calculating resolutions for color channels for ref failed.\n");
+    if (chroma_resolution_ret) {
+        fprintf(stderr, "Calculating resolutions for chroma channels for ref failed.\n");
         return 1;
     }
-    color_resolution_ret = get_color_resolution(dis_vmaf_pict->pix_fmt, dis_vmaf_pict->w[0],
+    chroma_resolution_ret = get_chroma_resolution(dis_vmaf_pict->pix_fmt, dis_vmaf_pict->w[0],
         dis_vmaf_pict->h[0], &(dis_vmaf_pict->w[1]), &(dis_vmaf_pict->h[1]),
         &(dis_vmaf_pict->w[2]), &(dis_vmaf_pict->h[2]));
 
-    if (color_resolution_ret) {
-        fprintf(stderr, "Calculating resolutions for color channels for dis failed.\n");
+    if (chroma_resolution_ret) {
+        fprintf(stderr, "Calculating resolutions for chroma channels for dis failed.\n");
         return 1;
     }
 
@@ -172,7 +172,7 @@ int read_vmaf_picture(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, fl
         return ret;
     }
 
-    if (!use_color)
+    if (!use_chroma)
     {
         // ref skip u and v
         if (ref_fmt == VMAF_PIX_FMT_YUV420P || ref_fmt == VMAF_PIX_FMT_YUV422P || ref_fmt == VMAF_PIX_FMT_YUV444P)
@@ -510,7 +510,7 @@ int get_frame_offset(enum VmafPixelFormat fmt, int w, int h, size_t *offset)
     return 0;
 }
 
-int get_color_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v) {
+int get_chroma_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v) {
 
     // check that both width and height are positive
     if ((w <= 0) || (h <= 0))

--- a/feature/src/common/frame.c
+++ b/feature/src/common/frame.c
@@ -322,23 +322,23 @@ fail_or_end:
 int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_byte, void *s)
 {
     struct data *user_data = (struct data *)s;
-    enum VmafPixelFormat fmt = user_data->format;
+    enum VmafPixelFormat fmt_enum = user_data->format;
     int w = user_data->width;
     int h = user_data->height;
     int ret;
 
     // read ref y
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         ret = read_image_b(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt));
+        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         return 1;
     }
     if (ret)
@@ -351,17 +351,17 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     }
 
     // read dis y
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt));
+        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         return 1;
     }
     if (ret)
@@ -374,7 +374,7 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     }
 
     // ref skip u and v
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         if (fread(temp_data, 1, user_data->offset, user_data->ref_rfile) != (size_t)user_data->offset)
         {
@@ -382,7 +382,7 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
             goto fail_or_end;
         }
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         if (fread(temp_data, 2, user_data->offset, user_data->ref_rfile) != (size_t)user_data->offset)
         {
@@ -392,12 +392,12 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt));
+        fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         goto fail_or_end;
     }
 
     // dis skip u and v
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         if (fread(temp_data, 1, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -405,7 +405,7 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
             goto fail_or_end;
         }
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -415,7 +415,7 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt));
+        fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         goto fail_or_end;
     }
     
@@ -428,23 +428,23 @@ fail_or_end:
 int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s)
 {
     struct noref_data *user_data = (struct noref_data *)s;
-    enum VmafPixelFormat fmt = user_data->format;
+    enum VmafPixelFormat fmt_enum = user_data->format;
     int w = user_data->width;
     int h = user_data->height;
     int ret;
 
     // read dis y
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", fmt);
+        fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         return 1;
     }
     if (ret)
@@ -457,7 +457,7 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     }
 
     // dis skip u and v
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV444P)
+    if (fmt_enum == VMAF_PIX_FMT_YUV420P || fmt_enum == VMAF_PIX_FMT_YUV422P || fmt_enum == VMAF_PIX_FMT_YUV444P)
     {
         if (fread(temp_data, 1, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -465,7 +465,7 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
             goto fail_or_end;
         }
     }
-    else if (fmt == VMAF_PIX_FMT_YUV420P10LE || fmt == VMAF_PIX_FMT_YUV422P10LE || fmt == VMAF_PIX_FMT_YUV444P10LE)
+    else if (fmt_enum == VMAF_PIX_FMT_YUV420P10LE || fmt_enum == VMAF_PIX_FMT_YUV422P10LE || fmt_enum == VMAF_PIX_FMT_YUV444P10LE)
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -475,7 +475,7 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", fmt);
+        fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
         goto fail_or_end;
     }
 
@@ -483,34 +483,42 @@ fail_or_end:
     return ret;
 }
 
-int get_frame_offset(enum VmafPixelFormat fmt, int w, int h, size_t *offset)
+int get_frame_offset(enum VmafPixelFormat fmt_enum, int w, int h, size_t *offset)
 {
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV420P10LE)
+    switch (fmt_enum)
     {
-        if ((w * h) % 2 != 0)
-        {
-            fprintf(stderr, "(width * height) %% 2 != 0, width = %d, height = %d.\n", w, h);
+        case VMAF_PIX_FMT_YUV420P:
+        case VMAF_PIX_FMT_YUV420P10LE:
+
+            if ((w * h) % 2 != 0)
+            {
+                fprintf(stderr, "(width * height) %% 2 != 0, width = %d, height = %d.\n", w, h);
+                return 1;
+            }
+            *offset = w * h / 2;
+            break;
+
+        case VMAF_PIX_FMT_YUV422P:
+        case VMAF_PIX_FMT_YUV422P10LE:
+
+            *offset = w * h;
+            break;
+
+        case VMAF_PIX_FMT_YUV444P:
+        case VMAF_PIX_FMT_YUV444P10LE:
+
+            *offset = w * h * 2;
+            break;
+
+        default:
+
+            fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
             return 1;
-        }
-        *offset = w * h / 2;
-    }
-    else if (fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV422P10LE)
-    {
-        *offset = w * h;
-    }
-    else if (fmt == VMAF_PIX_FMT_YUV444P || fmt == VMAF_PIX_FMT_YUV444P10LE)
-    {
-        *offset = w * h * 2;
-    }
-    else
-    {
-        fprintf(stderr, "unknown format %s.\n", fmt);
-        return 1;
     }
     return 0;
 }
 
-int get_chroma_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v) {
+int get_chroma_resolution(enum VmafPixelFormat fmt_enum, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v) {
 
     // check that both width and height are positive
     if ((w <= 0) || (h <= 0))
@@ -519,38 +527,44 @@ int get_chroma_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int
         return 1;
     }
 
-    if (fmt == VMAF_PIX_FMT_YUV420P || fmt == VMAF_PIX_FMT_YUV420P10LE)
+    switch (fmt_enum)
     {
-        // check that both width and height are even, i.e., their product is divisible by 2
-        if ((w * h) % 2 != 0)
-        {
-            fprintf(stderr, "(width * height) %% 2 != 0, width = %d, height = %d.\n", w, h);
+        case VMAF_PIX_FMT_YUV420P:
+        case VMAF_PIX_FMT_YUV420P10LE:
+            // check that both width and height are even, i.e., their product is divisible by 2
+            if ((w * h) % 2 != 0)
+            {
+                fprintf(stderr, "(width * height) %% 2 != 0, width = %d, height = %d.\n", w, h);
+                return 1;
+            }
+            *w_u = w / 2;
+            *w_v = w / 2;
+            *h_u = h / 2;
+            *h_v = h / 2;
+            break;
+
+        case VMAF_PIX_FMT_YUV422P:
+        case VMAF_PIX_FMT_YUV422P10LE:
+
+            // need to double check this
+            *w_u = w / 2;
+            *w_v = w / 2;
+            *h_u = h;
+            *h_v = h;
+            break;
+
+        case VMAF_PIX_FMT_YUV444P:
+        case VMAF_PIX_FMT_YUV444P10LE:
+
+            *w_u = w;
+            *w_v = w;
+            *h_u = h;
+            *h_v = h;
+            break;
+
+        default:
+            fprintf(stderr, "Unknown format %s.\n", get_fmt_str_from_fmt_enum(fmt_enum));
             return 1;
-        }
-        *w_u = w / 2;
-        *w_v = w / 2;
-        *h_u = h / 2;
-        *h_v = h / 2;
-    }
-    else if (fmt == VMAF_PIX_FMT_YUV422P || fmt == VMAF_PIX_FMT_YUV422P10LE)
-    {
-        // need to double check this
-        *w_u = w / 2;
-        *w_v = w / 2;
-        *h_u = h;
-        *h_v = h;
-    }
-    else if (fmt == VMAF_PIX_FMT_YUV444P || fmt == VMAF_PIX_FMT_YUV444P10LE)
-    {
-        *w_u = w;
-        *w_v = w;
-        *h_u = h;
-        *h_v = h;
-    }
-    else
-    {
-        fprintf(stderr, "unknown format %s.\n", fmt);
-        return 1;
     }
 
     if (*w_u <= 0 || *h_u <= 0 || (size_t)*w_u > ALIGN_FLOOR(INT_MAX) / sizeof(float))

--- a/feature/src/common/frame.h
+++ b/feature/src/common/frame.h
@@ -32,7 +32,6 @@ struct data
     FILE *ref_rfile;
     FILE *dis_rfile;
     int num_frames;
-    int use_chroma;
 };
 
 struct noref_data

--- a/feature/src/common/frame.h
+++ b/feature/src/common/frame.h
@@ -32,7 +32,7 @@ struct data
     FILE *ref_rfile;
     FILE *dis_rfile;
     int num_frames;
-    int use_color;
+    int use_chroma;
 };
 
 struct noref_data
@@ -52,7 +52,7 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
 
 int get_frame_offset(enum VmafPixelFormat fmt, int w, int h, size_t *offset);
 
-int get_color_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v);
+int get_chroma_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v);
 
 int get_stride_byte_from_width(unsigned int w);
 

--- a/feature/src/common/frame.h
+++ b/feature/src/common/frame.h
@@ -19,20 +19,25 @@
 #ifndef FRAME_H_
 #define FRAME_H_
 
+#include <string.h>
+#include "alloc.h"
+#include "libvmaf.h"
+
 struct data
 {
-    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
+    enum VmafPixelFormat format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
     int width;
     int height;
     size_t offset;
     FILE *ref_rfile;
     FILE *dis_rfile;
     int num_frames;
+    int use_color;
 };
 
 struct noref_data
 {
-    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
+    enum VmafPixelFormat format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
     int width;
     int height;
     size_t offset;
@@ -41,8 +46,16 @@ struct noref_data
 
 int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_byte, void *s);
 
+int read_vmaf_picture(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *s);
+
 int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s);
 
-int get_frame_offset(const char *fmt, int w, int h, size_t *offset);
+int get_frame_offset(enum VmafPixelFormat fmt, int w, int h, size_t *offset);
+
+int get_color_resolution(enum VmafPixelFormat fmt, unsigned int w, unsigned int h, unsigned int *w_u, unsigned int *h_u, unsigned int *w_v, unsigned int *h_v);
+
+int get_stride_byte_from_width(unsigned int w);
+
+enum VmafPixelFormat get_pix_fmt_from_input_char_ptr(const char *pix_fmt_option);
 
 #endif /* FRAME_H_ */

--- a/feature/src/moment.c
+++ b/feature/src/moment.c
@@ -76,7 +76,7 @@ int compute_2nd_moment(const float *pic, int w, int h, int stride, double *score
     return 0;
 }
 
-int moment(int (*read_noref_frame)(float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt, int order)
+int moment(int (*read_noref_frame)(float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, int order)
 {
     double score = 0;
     float *pic_buf = 0;

--- a/feature/src/moment_main.c
+++ b/feature/src/moment_main.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include "common/frame.h"
 
-int moment(int (*read_noref_frame)(float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt, int order);
+int moment(int (*read_noref_frame)(float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, int order);
 
 static void usage(void)
 {
@@ -42,12 +42,13 @@ int run_moment(int order, const char *fmt, const char *video_path, int w, int h)
 {
     int ret = 0;
     struct noref_data *s;
+    enum VmafPixelFormat fmt_enum = get_pix_fmt_from_input_char_ptr(fmt);
     s = (struct noref_data *)malloc(sizeof(struct noref_data));
-    s->format = fmt;
+    s->format = fmt_enum;
     s->width = w;
     s->height = h;
 
-    ret = get_frame_offset(fmt, w, h, &(s->offset));
+    ret = get_frame_offset(fmt_enum, w, h, &(s->offset));
     if (ret)
     {
         goto fail_or_end;
@@ -60,7 +61,7 @@ int run_moment(int order, const char *fmt, const char *video_path, int w, int h)
         goto fail_or_end;
     }
 
-    ret = moment(read_noref_frame, s, w, h, fmt, order);
+    ret = moment(read_noref_frame, s, w, h, order);
 
 fail_or_end:
     if (s->dis_rfile)

--- a/feature/src/ms_ssim_main.c
+++ b/feature/src/ms_ssim_main.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include "common/frame.h"
 
-int ms_ssim(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt);
+int ms_ssim(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt);
 
 static void usage(void)
 {
@@ -35,16 +35,16 @@ static void usage(void)
     );
 }
 
-int run_ms_ssim(const char *fmt, const char *ref_path, const char *dis_path, int w, int h)
+int run_ms_ssim(enum VmafPixelFormat fmt_enum, const char *ref_path, const char *dis_path, int w, int h)
 {
     int ret = 0;
     struct data *s;
     s = (struct data *)malloc(sizeof(struct data));
-    s->format = fmt;
+    s->format = fmt_enum;
     s->width = w;
     s->height = h;
 
-    ret = get_frame_offset(fmt, w, h, &(s->offset));
+    ret = get_frame_offset(fmt_enum, w, h, &(s->offset));
     if (ret)
     {
         goto fail_or_end;
@@ -63,7 +63,7 @@ int run_ms_ssim(const char *fmt, const char *ref_path, const char *dis_path, int
         goto fail_or_end;
     }
 
-    ret = ms_ssim(read_frame, s, w, h, fmt);
+    ret = ms_ssim(read_frame, s, w, h, fmt_enum);
 
 fail_or_end:
     if (s->ref_rfile)
@@ -94,7 +94,7 @@ int main(int argc, const char **argv)
         return 2;
     }
 
-    fmt         = argv[1];
+    fmt      = argv[1];
     ref_path = argv[2];
     dis_path = argv[3];
     w        = atoi(argv[4]);
@@ -105,5 +105,7 @@ int main(int argc, const char **argv)
         return 2;
     }
 
-    return run_ms_ssim(fmt, ref_path, dis_path, w, h);
+    enum VmafPixelFormat fmt_enum = get_pix_fmt_from_input_char_ptr(fmt);
+
+    return run_ms_ssim(fmt_enum, ref_path, dis_path, w, h);
 }

--- a/feature/src/psnr.c
+++ b/feature/src/psnr.c
@@ -61,7 +61,7 @@ int compute_psnr(const float *ref, const float *dis, int w, int h, int ref_strid
     return 0;
 }
 
-int psnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt)
+int psnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt)
 {
     double score = 0;
     float *ref_buf = 0;

--- a/feature/src/psnr_main.c
+++ b/feature/src/psnr_main.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include "common/frame.h"
 
-int psnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt);
+int psnr(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt_enum);
 
 static void usage(void)
 {
@@ -39,12 +39,13 @@ int run_psnr(const char *fmt, const char *ref_path, const char *dis_path, int w,
 {
     int ret = 0;
     struct data *s;
+    enum VmafPixelFormat fmt_enum = get_pix_fmt_from_input_char_ptr(fmt);
     s = (struct data *)malloc(sizeof(struct data));
-    s->format = fmt;
+    s->format = fmt_enum;
     s->width = w;
     s->height = h;
 
-    ret = get_frame_offset(fmt, w, h, &(s->offset));
+    ret = get_frame_offset(fmt_enum, w, h, &(s->offset));
     if (ret)
     {
         goto fail_or_end;
@@ -63,7 +64,7 @@ int run_psnr(const char *fmt, const char *ref_path, const char *dis_path, int w,
         goto fail_or_end;
     }
 
-    ret = psnr(read_frame, s, w, h, fmt);
+    ret = psnr(read_frame, s, w, h, fmt_enum);
 
 fail_or_end:
     if (s->ref_rfile)
@@ -94,7 +95,7 @@ int main(int argc, const char **argv)
         return 2;
     }
 
-    fmt         = argv[1];
+    fmt      = argv[1];
     ref_path = argv[2];
     dis_path = argv[3];
     w        = atoi(argv[4]);

--- a/feature/src/psnr_tools.c
+++ b/feature/src/psnr_tools.c
@@ -23,24 +23,24 @@
 /*
  * For a given format, returns the constants to use in psnr based calculations
  */
-int psnr_constants(const char *fmt, double *peak, double *psnr_max) {
-    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv444p"))
-    {
+int psnr_constants(enum VmafPixelFormat fmt, double *peak, double *psnr_max) {
+
+    switch (fmt) {
         // max psnr 60.0 for 8-bit per Ioannis
-        *peak = 255.0;
-        *psnr_max = 60.0;
-    }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
-    {
+        case VMAF_PIX_FMT_YUV420P:
+        case VMAF_PIX_FMT_YUV422P:
+        case VMAF_PIX_FMT_YUV444P:
+            *peak = 255.0; *psnr_max = 60.0; return 0;
+
         // 10 bit gets normalized to 8 bit, peak is 1023 / 4.0 = 255.75
         // max psnr 72.0 for 10-bit per Ioannis
-        *peak = 255.75;
-        *psnr_max = 72.0;
-    }
-    else
-    {
-        return 1;
+        case VMAF_PIX_FMT_YUV420P10LE:
+        case VMAF_PIX_FMT_YUV422P10LE:
+        case VMAF_PIX_FMT_YUV444P10LE:
+            *peak = 255.75; *psnr_max = 72.0; return 0;
+
+        // other formats error out
+        default: return 1;
     }
 
-    return 0;
 }

--- a/feature/src/psnr_tools.h
+++ b/feature/src/psnr_tools.h
@@ -19,6 +19,8 @@
 #ifndef PSNR_TOOLS_H_
 #define PSNR_TOOLS_H_
 
-int psnr_constants(const char *fmt, double *peak, double *psnr_max);
+#include "libvmaf.h"
+
+int psnr_constants(enum VmafPixelFormat fmt, double *peak, double *psnr_max);
 
 #endif /* PSNR_TOOLS_H_ */

--- a/feature/src/ssim_main.c
+++ b/feature/src/ssim_main.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include "common/frame.h"
 
-int ssim(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, const char *fmt);
+int ssim(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), void *user_data, int w, int h, enum VmafPixelFormat fmt);
 
 static void usage(void)
 {
@@ -39,12 +39,13 @@ int run_ssim(const char *fmt, const char *ref_path, const char *dis_path, int w,
 {
     int ret = 0;
     struct data *s;
+    enum VmafPixelFormat fmt_enum = get_pix_fmt_from_input_char_ptr(fmt);
     s = (struct data *)malloc(sizeof(struct data));
-    s->format = fmt;
+    s->format = fmt_enum;
     s->width = w;
     s->height = h;
 
-    ret = get_frame_offset(fmt, w, h, &(s->offset));
+    ret = get_frame_offset(fmt_enum, w, h, &(s->offset));
     if (ret)
     {
         goto fail_or_end;
@@ -63,7 +64,7 @@ int run_ssim(const char *fmt, const char *ref_path, const char *dis_path, int w,
         goto fail_or_end;
     }
 
-    ret = ssim(read_frame, s, w, h, fmt);
+    ret = ssim(read_frame, s, w, h, fmt_enum);
 
 fail_or_end:
     if (s->ref_rfile)

--- a/python/src/vmaf/__init__.py
+++ b/python/src/vmaf/__init__.py
@@ -164,7 +164,7 @@ class ExternalProgramCaller(object):
     def call_vmafossexec(fmt, w, h, ref_path, dis_path, model, log_file_path, disable_clip_score,
                          enable_transform_score, phone_model, disable_avx, n_thread, n_subsample,
                          psnr, ssim, ms_ssim, ci, exe=None, logger=None, additional_models=None,
-                         use_color=False):
+                         use_chroma=False):
 
         if exe is None:
             exe = required(ExternalProgram.vmafossexec)
@@ -197,8 +197,8 @@ class ExternalProgramCaller(object):
             vmafossexec_cmd += ' --ms-ssim'
         if ci:
             vmafossexec_cmd += ' --ci'
-        if use_color:
-            vmafossexec_cmd += ' --color'
+        if use_chroma:
+            vmafossexec_cmd += ' --chroma'
         if additional_models is not None:
             vmafossexec_cmd += ' --additional-models ' + additional_models
         if logger:

--- a/python/src/vmaf/__init__.py
+++ b/python/src/vmaf/__init__.py
@@ -164,7 +164,7 @@ class ExternalProgramCaller(object):
     def call_vmafossexec(fmt, w, h, ref_path, dis_path, model, log_file_path, disable_clip_score,
                          enable_transform_score, phone_model, disable_avx, n_thread, n_subsample,
                          psnr, ssim, ms_ssim, ci, exe=None, logger=None, additional_models=None,
-                         use_chroma=False):
+                         psnr_chroma=False):
 
         if exe is None:
             exe = required(ExternalProgram.vmafossexec)
@@ -197,8 +197,8 @@ class ExternalProgramCaller(object):
             vmafossexec_cmd += ' --ms-ssim'
         if ci:
             vmafossexec_cmd += ' --ci'
-        if use_chroma:
-            vmafossexec_cmd += ' --chroma'
+        if psnr_chroma:
+            vmafossexec_cmd += ' --psnr-chroma'
         if additional_models is not None:
             vmafossexec_cmd += ' --additional-models ' + additional_models
         if logger:

--- a/python/src/vmaf/__init__.py
+++ b/python/src/vmaf/__init__.py
@@ -163,7 +163,8 @@ class ExternalProgramCaller(object):
     @staticmethod
     def call_vmafossexec(fmt, w, h, ref_path, dis_path, model, log_file_path, disable_clip_score,
                          enable_transform_score, phone_model, disable_avx, n_thread, n_subsample,
-                         psnr, ssim, ms_ssim, ci, exe=None, logger=None):
+                         psnr, ssim, ms_ssim, ci, exe=None, logger=None, additional_models=None,
+                         use_color=False):
 
         if exe is None:
             exe = required(ExternalProgram.vmafossexec)
@@ -182,8 +183,10 @@ class ExternalProgramCaller(object):
             n_subsample=n_subsample)
         if disable_clip_score:
             vmafossexec_cmd += ' --disable-clip'
-        if enable_transform_score or phone_model:
+        if enable_transform_score:
             vmafossexec_cmd += ' --enable-transform'
+        if phone_model:
+            vmafossexec_cmd += ' --phone-model'
         if disable_avx:
             vmafossexec_cmd += ' --disable-avx'
         if psnr:
@@ -194,6 +197,10 @@ class ExternalProgramCaller(object):
             vmafossexec_cmd += ' --ms-ssim'
         if ci:
             vmafossexec_cmd += ' --ci'
+        if use_color:
+            vmafossexec_cmd += ' --color'
+        if additional_models is not None:
+            vmafossexec_cmd += ' --additional-models ' + additional_models
         if logger:
             logger.info(vmafossexec_cmd)
         run_process(vmafossexec_cmd, shell=True)

--- a/python/src/vmaf/core/executor.py
+++ b/python/src/vmaf/core/executor.py
@@ -30,6 +30,9 @@ class Executor(TypeVersionEnabled):
 
     __metaclass__ = ABCMeta
 
+    # if optional dict is too long, executor_id needs to be trimmed
+    MAX_CHARS_EX_ID_OPT_DICT = 10
+
     @abstractmethod
     def _generate_result(self, asset):
         raise NotImplementedError
@@ -80,7 +83,7 @@ class Executor(TypeVersionEnabled):
         if self.optional_dict is not None and len(self.optional_dict) > 0:
             # include optional_dict info in executor_id for result store,
             # as parameters in optional_dict will impact result
-            executor_id_ += '_{}'.format(get_normalized_string_from_dict(self.optional_dict))
+            executor_id_ += '_{}'.format(get_normalized_string_from_dict(self.optional_dict))[0:self.MAX_CHARS_EX_ID_OPT_DICT]
         return executor_id_
 
     def run(self, **kwargs):

--- a/python/src/vmaf/core/quality_runner.py
+++ b/python/src/vmaf/core/quality_runner.py
@@ -675,13 +675,13 @@ class VmafossExecQualityRunner(QualityRunner):
         else:
             ci = False
 
-        if self.optional_dict is not None and 'use_color' in self.optional_dict:
-            use_color = self.optional_dict['use_color']
+        if self.optional_dict is not None and 'use_chroma' in self.optional_dict:
+            use_chroma = self.optional_dict['use_chroma']
         else:
-            use_color = False
+            use_chroma = False
 
         # augment the feature set with color features, if color is enabled
-        if use_color:
+        if use_chroma:
             self.FEATURES += ["psnr_u", "psnr_v"]
 
         additional_models_dict = self.optional_dict['additional_models'] \
@@ -717,7 +717,7 @@ class VmafossExecQualityRunner(QualityRunner):
                                                disable_clip_score, enable_transform_score,
                                                phone_model, disable_avx, n_thread, n_subsample,
                                                psnr, ssim, ms_ssim, ci, exe, logger, additional_models,
-                                               use_color)
+                                               use_chroma)
 
     @staticmethod
     def get_json_additional_model_string(d):

--- a/python/src/vmaf/core/quality_runner.py
+++ b/python/src/vmaf/core/quality_runner.py
@@ -675,13 +675,13 @@ class VmafossExecQualityRunner(QualityRunner):
         else:
             ci = False
 
-        if self.optional_dict is not None and 'use_chroma' in self.optional_dict:
-            use_chroma = self.optional_dict['use_chroma']
+        if self.optional_dict is not None and 'psnr_chroma' in self.optional_dict:
+            psnr_chroma = self.optional_dict['psnr_chroma']
         else:
-            use_chroma = False
+            psnr_chroma = False
 
-        # augment the feature set with color features, if color is enabled
-        if use_chroma:
+        # augment the feature set with color features, if the corresponding features are enabled
+        if psnr_chroma:
             self.FEATURES += ["psnr_u", "psnr_v"]
 
         additional_models_dict = self.optional_dict['additional_models'] \
@@ -717,7 +717,7 @@ class VmafossExecQualityRunner(QualityRunner):
                                                disable_clip_score, enable_transform_score,
                                                phone_model, disable_avx, n_thread, n_subsample,
                                                psnr, ssim, ms_ssim, ci, exe, logger, additional_models,
-                                               use_chroma)
+                                               psnr_chroma)
 
     @staticmethod
     def get_json_additional_model_string(d):

--- a/python/test/lib/libvmaf_libtest.py
+++ b/python/test/lib/libvmaf_libtest.py
@@ -9,6 +9,24 @@ __copyright__ = "Copyright 2016-2018, Netflix, Inc."
 __license__ = "Apache, Version 2.0"
 
 
+def set_default_576_324_videos_for_testing():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324})
+
+    return ref_path, dis_path, asset, asset_original
+
+
 class LibRunner(VmafossExecQualityRunner):
 
     TYPE = "TESTLIB"
@@ -35,13 +53,13 @@ class QualityRunnerTest(unittest.TestCase):
                       workdir_root=VmafConfig.workdir_path(),
                       ref_path=ref_path,
                       dis_path=dis_path,
-                      asset_dict={'width':576, 'height':324})
+                      asset_dict={'width': 576, 'height': 324})
 
         asset_original = Asset(dataset="test", content_id=0, asset_id=1,
                       workdir_root=VmafConfig.workdir_path(),
                       ref_path=ref_path,
                       dis_path=ref_path,
-                      asset_dict={'width':576, 'height':324})
+                      asset_dict={'width': 576, 'height': 324})
 
         self.runner = LibRunner(
             [asset, asset_original],
@@ -64,8 +82,8 @@ class QualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['TESTLIB_ms_ssim_score'], 0.9632498125, places=4)
 
         self.assertAlmostEqual(results[1]['TESTLIB_vif_scale0_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['TESTLIB_vif_scale1_score'],0.999999958333, places=4)
-        self.assertAlmostEqual(results[1]['TESTLIB_vif_scale2_score'],0.999999416667, places=4)
+        self.assertAlmostEqual(results[1]['TESTLIB_vif_scale1_score'], 0.999999958333, places=4)
+        self.assertAlmostEqual(results[1]['TESTLIB_vif_scale2_score'], 0.999999416667, places=4)
         self.assertAlmostEqual(results[1]['TESTLIB_vif_scale3_score'], 0.999999208333, places=4)
         self.assertAlmostEqual(results[1]['TESTLIB_motion2_score'], 3.8953518541666665, places=4)
         self.assertAlmostEqual(results[1]['TESTLIB_adm2_score'], 1.0, places=4)
@@ -74,4 +92,40 @@ class QualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['TESTLIB_ms_ssim_score'], 1.0, places=4)
 
         self.assertAlmostEqual(results[0]['TESTLIB_score'], 76.699271272486044, places=3)
-        self.assertAlmostEqual(results[1]['TESTLIB_score'],99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['TESTLIB_score'], 99.946416604585025, places=4)
+
+    def test_run_testlib_runner_with_thread(self):
+        print('test on running TESTLIB runner with thread...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = LibRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'thread': 3}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['TESTLIB_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[1]['TESTLIB_score'], 99.946416604585025, places=4)
+
+    def test_run_testlib_runner_phone_model(self):
+        print('test on running TESTLIB runner with phone model...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = LibRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'phone_model': True}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['TESTLIB_score'], 92.54239166666667, places=3)
+        self.assertAlmostEqual(results[1]['TESTLIB_score'], 100.0, places=4)

--- a/python/test/vmafossexec_test.py
+++ b/python/test/vmafossexec_test.py
@@ -68,7 +68,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ms_ssim_score'], 1.0, places=4)
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'],99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
 
     def test_run_vmafossexec_runner_with_thread(self):
         print('test on running VMAFOSSEXEC runner with thread...')
@@ -86,7 +86,311 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'],99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+
+    def test_run_vmafossexec_runner_with_061_additional_model(self):
+        print('test on running VMAFOSSEXEC runner with 0.6.1 as additional model...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'additional_models': {"some_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl")}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_some_model_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_some_model_score'], 99.946416604585025, places=4)
+
+    def test_run_vmafossexec_runner_with_061_additional_model_enable_transform(self):
+        print('test on running VMAFOSSEXEC runner with 0.6.1 as additional model + enable_transform...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'additional_models': {"some_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl"),
+                                                                "enable_transform": "1"}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_some_model_score'], 92.54239166666667, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_some_model_score'], 100.0, places=4)
+
+    def test_run_vmafossexec_runner_with_061_additional_models(self):
+        print('test on running VMAFOSSEXEC runner with 0.6.1 as additional models...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'additional_models': {"some_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl")},
+                                                 "other_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl")}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_some_model_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_other_model_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_some_model_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_other_model_score'], 99.946416604585025, places=4)
+
+    def test_run_vmafossexec_runner_with_061_additional_models_one_is_transformed(self):
+        print('test on running VMAFOSSEXEC runner with 0.6.1 as additional models...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'additional_models': {"some_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl")},
+                                                 "other_model": {"model_path": VmafConfig.model_path("vmaf_v0.6.1.pkl"),
+                                                                 "enable_transform": "1"}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_some_model_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_other_model_score'], 92.54239166666667, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_some_model_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_other_model_score'], 100.0, places=4)
+
+    def test_run_vmafossexec_runner_with_4k_additional_model(self):
+        print('test on running VMAFOSSEXEC runner with 4k as additional model...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'additional_models': {"four_k": {"model_path": VmafConfig.model_path("vmaf_4k_v0.6.1.pkl")}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.699271272486044, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_four_k_score'], 84.98462083333332, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.946416604585025, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_four_k_score'], 100.0, places=4)
+
+    def test_run_vmafossexec_runner_default_and_additional_model_use_ci(self):
+        print('test on running VMAFOSSEXEC runner with additional models and ci...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'model_filepath': VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'),
+                           'additional_models': {'vmaf_2': {"model_path": VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'),
+                                                            "enable_conf_interval": "1"}},
+                           'ci': True}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 75.44304862545658, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bagging_score'], 74.96365833333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_stddev_score'], 1.3128927083333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_ci95_low_score'], 72.98503333333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_ci95_high_score'], 77.38652708333333, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_bagging_score'], 74.96365833333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_stddev_score'], 1.3128927083333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_ci95_low_score'], 72.98503333333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_ci95_high_score'], 77.38652708333333, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.95804791666667, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_bagging_score'], 99.93908333333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_stddev_score'], 0.09930395833333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_ci95_low_score'], 91.11520624999999, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_ci95_high_score'], 100.0, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_bagging_score'], 99.93908333333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_stddev_score'], 0.09930395833333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_ci95_low_score'], 91.11520624999999, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_ci95_high_score'], 100.0, places=3)
+
+    def test_run_vmafossexec_runner_only_additional_models_use_ci(self):
+        print('test on running VMAFOSSEXEC runner with additional models and ci...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'model_filepath': VmafConfig.model_path('vmaf_v0.6.1.pkl'),
+                           'additional_models': {'vmaf_2': {"model_path": VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'), "enable_conf_interval": "1"},
+                                                 'vmaf_rb_v0.6.2': {"model_path": VmafConfig.model_path('vmaf_rb_v0.6.2', 'vmaf_rb_v0.6.2.pkl'), "enable_conf_interval": "1"},
+                                                 'vmaf_rb_v0.6.3': {"model_path": VmafConfig.model_path('vmaf_rb_v0.6.3', 'vmaf_rb_v0.6.3.pkl'), "enable_conf_interval": "1"},
+                                                 'vmaf_4k_rb_v0.6.2': {"model_path": VmafConfig.model_path('vmaf_4k_rb_v0.6.2', 'vmaf_4k_rb_v0.6.2.pkl'), "enable_conf_interval": "1"}}}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale0_score'],0.363420458333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale1_score'], 0.766647520833, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale2_score'], 0.862854708333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale3_score'], 0.915971791667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm_scale0_score'], 0.9079192708333332, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm_scale1_score'], 0.8939565625, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm_scale2_score'], 0.9301004166666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm_scale3_score'], 0.9650352708333333, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_motion_score'], 4.0498256249999995, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_motion2_score'], 3.8953518541666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm2_score'], 0.93458777083333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 30.7550666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ssim_score'], 0.86322654166666657, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ms_ssim_score'], 0.9632498125, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.69926875, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_bagging_score'], 74.96365833333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_stddev_score'], 1.3128927083333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_ci95_low_score'], 72.98503333333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_ci95_high_score'], 77.38652708333333, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_bagging_score'], 83.98690625, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_stddev_score'], 0.9290704791666666, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_ci95_low_score'], 82.76451250000001, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_ci95_high_score'], 85.85374791666668, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_bagging_score'], 99.93908333333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_stddev_score'], 0.09930395833333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_ci95_low_score'], 91.11520624999999, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_ci95_high_score'], 100.0, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_bagging_score'], 99.97613958333334, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_stddev_score'], 0.036273541666666666, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_ci95_low_score'], 97.65394583333334, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_4k_rb_v0.6.2_ci95_high_score'], 100.0, places=3)
+
+        self.assertEquals(results[0]['VMAFOSSEXEC_vmaf_rb_v0.6.3_bootstrap_0001_scores'], results[0]['VMAFOSSEXEC_vmaf_rb_v0.6.2_bootstrap_0001_scores'])
+        self.assertEquals(results[0]['VMAFOSSEXEC_vmaf_rb_v0.6.3_bootstrap_0019_scores'], results[0]['VMAFOSSEXEC_vmaf_rb_v0.6.2_bootstrap_0019_scores'])
+        self.assertEquals(results[1]['VMAFOSSEXEC_vmaf_rb_v0.6.3_bootstrap_0019_scores'], results[1]['VMAFOSSEXEC_vmaf_rb_v0.6.2_bootstrap_0019_scores'])
+
+    def test_run_vmafossexec_runner_additional_models_use_ci_et_mix_match(self):
+        print('test on running VMAFOSSEXEC runner with additional models and ci...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'model_filepath': VmafConfig.model_path('vmaf_v0.6.1.pkl'),
+                           'additional_models': {'vmaf_061_wo_ci_wo_et': {'model_path': VmafConfig.model_path('vmaf_v0.6.1.pkl'), 'enable_conf_interval': '0', 'enable_transform': '0'},
+                                                 'vmaf_061_wo_ci_w_et': {'model_path': VmafConfig.model_path('vmaf_v0.6.1.pkl'), 'enable_conf_interval': '0', 'enable_transform': '1'},
+                                                 'vmaf_b063_w_ci_wo_et': {'model_path': VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'), "enable_conf_interval": '1', 'enable_transform': '0'},
+                                                 'vmaf_b063_w_ci_w_et': {'model_path': VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'),"enable_conf_interval": '1', 'enable_transform': '1'}}
+                           }
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.69926875, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_061_wo_ci_wo_et_score'], 76.69926875, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_061_wo_ci_w_et_score'], 92.54239166666667, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_bagging_score'], 74.96365833333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_stddev_score'], 1.3128927083333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_ci95_low_score'], 72.98503333333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_ci95_high_score'], 77.38652708333333, places=3)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_bagging_score'], 91.40493125, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_stddev_score'], 0.8773241874999999, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_ci95_low_score'], 90.05703125000001, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_ci95_high_score'], 92.98213541666667, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_061_wo_ci_wo_et_score'], 99.94641666666666, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_061_wo_ci_w_et_score'], 100.0, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_bagging_score'], 99.93908333333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_stddev_score'], 0.09930395833333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_ci95_low_score'], 91.11520624999999, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_wo_et_ci95_high_score'], 100.0, places=3)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_bagging_score'], 100.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_stddev_score'], 0.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_ci95_low_score'], 99.94739583333332, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_b063_w_ci_w_et_ci95_high_score'], 100.0, places=3)
+
+    def test_run_vmafossexec_runner_with_additional_model_use_ci_et(self):
+        print('test on running VMAFOSSEXEC runner with additional models and ci and enable transform...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'model_filepath': VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'),
+                           'additional_models': {'vmaf_2': {"model_path": VmafConfig.model_path('vmaf_b_v0.6.3', 'vmaf_b_v0.6.3.pkl'),
+                                                            "enable_conf_interval": "1",
+                                                            "enable_transform": "1"}},
+                           'ci': True,
+                           'enable_transform_score': True}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bagging_score'], 91.40493125, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_bagging_score'], 91.40493125, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_ci95_low_score'], 90.05703125000001, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_2_ci95_low_score'], 90.05703125000001, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_bagging_score'], 100.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_2_bagging_score'], 100.0, places=3)
+
+    def test_additional_model_json_string(self):
+        print('test additional model json string creation...')
+        self.assertEquals(VmafossExecQualityRunner
+                          .get_json_additional_model_string({}), "")
+        self.assertEquals(VmafossExecQualityRunner.get_json_additional_model_string({"model A": {"model_path": "/someA/pthA/forA/A.pkl"}}),
+                          '{\\"model A\\"\\:{\\"model_path\\"\\:\\"/someA/pthA/forA/A.pkl\\"}}')
+        self.assertEquals(VmafossExecQualityRunner.get_json_additional_model_string({"model A": {"model_path": "/someA/pthA/forA/A.pkl"}, "model B": {"model_path": "/someB/pthB/forB/B.pkl"}}),
+                          '{\\"model A\\"\\:{\\"model_path\\"\\:\\"/someA/pthA/forA/A.pkl\\"}\\,\\"model B\\"\\:{\\"model_path\\"\\:\\"/someB/pthB/forB/B.pkl\\"}}')
+        self.assertEquals(VmafossExecQualityRunner.get_json_additional_model_string({"model B": {"model_path": "/someB/pthB/forB/B.pkl"}, "model A": {"model_path": "/someA/pthA/forA/A.pkl"}}),
+                          '{\\"model A\\"\\:{\\"model_path\\"\\:\\"/someA/pthA/forA/A.pkl\\"}\\,\\"model B\\"\\:{\\"model_path\\"\\:\\"/someB/pthB/forB/B.pkl\\"}}')
+        self.assertEquals(VmafossExecQualityRunner.get_json_additional_model_string({"model A": {"model_path": "/someA/pthA/forA/A.pkl", "enable_transform": "1"}, "model B": {"model_path": "/someB/pthB/forB/B.pkl"}}),
+                          '{\\"model A\\"\\:{\\"enable_transform\\"\\:\\"1\\"\\,\\"model_path\\"\\:\\"/someA/pthA/forA/A.pkl\\"}\\,\\"model B\\"\\:{\\"model_path\\"\\:\\"/someB/pthB/forB/B.pkl\\"}}')
+        self.assertEquals(VmafossExecQualityRunner.get_json_additional_model_string({"model A": {"model_path": "/someA/pthA/forA/A.pkl", "enable_transform": "1"}, "model B": {"model_path": "/someB/pthB/forB/B.pkl", "disable_clip": "0"}}),
+                          '{\\"model A\\"\\:{\\"enable_transform\\"\\:\\"1\\"\\,\\"model_path\\"\\:\\"/someA/pthA/forA/A.pkl\\"}\\,\\"model B\\"\\:{\\"disable_clip\\"\\:\\"0\\"\\,\\"model_path\\"\\:\\"/someB/pthB/forB/B.pkl\\"}}')
 
     def test_run_vmafossexec_runner_with_subsample(self):
         print('test on running VMAFOSSEXEC runner with subsample...')
@@ -105,6 +409,78 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.954390000000018, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.742800000000003, places=4)
+
+    def test_run_vmafossexec_runner_psnr_color(self):
+        print('test on running VMAFOSSEXEC runner with color ...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'use_color': True}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.69926875, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 30.755066666666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_u_score'], 38.449447916666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_v_score'], 40.9919125, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_u_score'], 60.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
+
+    def test_run_vmafossexec_runner_psnr_color_single_thread(self):
+        print('test on running VMAFOSSEXEC runner with color using one thread ...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'use_color': True, 'thread': 1}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.69926875, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 30.755066666666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_u_score'], 38.449447916666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_v_score'], 40.9919125, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_u_score'], 60.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
+
+    def test_run_vmafossexec_runner_psnr_color_two_threads(self):
+        print('test on running VMAFOSSEXEC runner with color using two threads ...')
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={'use_color': True, 'thread': 2}
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.69926875, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 30.755066666666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_u_score'], 38.449447916666664, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_v_score'], 40.9919125, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_u_score'], 60.0, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
 
     def test_run_vmafossexec_runner_with_phone_score(self):
         print('test on running VMAFOSSEXEC runner with phone score...')
@@ -377,7 +753,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=False,
             delete_workdir=True,
             optional_dict={
-                'phone_model':True,
+                'phone_model': True,
             },
             result_store=self.result_store,
         )
@@ -536,20 +912,20 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 75.443043750000001, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.958047916666672, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_bagging_score'], 73.10273541666668, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_bagging_score'], 99.79000416666668, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_stddev_score'], 1.1991330833333333, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_stddev_score'], 1.3028828125, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ci95_low_score'], 70.82471875, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ci95_low_score'], 94.79667083333334, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ci95_high_score'], 74.85038125, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ci95_high_score'], 99.99736666666666, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bagging_score'], 73.10273541666668, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_bagging_score'], 99.79000416666668, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_stddev_score'], 1.1991330833333333, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_stddev_score'], 1.3028828125, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_ci95_low_score'], 70.82471875, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_ci95_low_score'], 94.79667083333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_ci95_high_score'], 74.85038125, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_ci95_high_score'], 99.99736666666666, places=4)
 
         # per model score checks
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0001_score'], 73.26853333333334, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0002_score'], 70.38517916666667, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0003_score'], 71.59264583333334, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0020_score'], 73.15570625, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0001_score'], 73.26853333333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0002_score'], 70.38517916666667, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0003_score'], 71.59264583333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0020_score'], 73.15570625, places=3)
 
     def test_run_vmafossexec_runner_with_ci_and_custom_model(self):
         print('test on running VMAFOSSEXEC runner with conf interval and custom model...')
@@ -571,10 +947,10 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 75.443043750000001, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.958047916666672, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_bagging_score'], 75.13012623785923, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_bagging_score'], 99.96504855577571, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_stddev_score'], 0.6812993325967104, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_stddev_score'], 0.03947607207290399, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bagging_score'], 75.13012623785923, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_bagging_score'], 99.96504855577571, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_stddev_score'], 0.6812993325967104, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_stddev_score'], 0.03947607207290399, places=4)
 
     def test_run_vmafossexec_runner_with_ci_and_phone_model(self):
         print('test on running VMAFOSSEXEC runner with conf interval and phone model...')
@@ -587,7 +963,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             result_store=None,
             optional_dict={
                 'model_filepath': VmafConfig.model_path("vmaf_rb_v0.6.3", "vmaf_rb_v0.6.3.pkl"),
-                'phone_model':True,
+                'phone_model': True,
                 'ci': True,
             },
         )
@@ -597,16 +973,16 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 91.723012127641823, places=4)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_bagging_score'], 90.13159583333334, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_bagging_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_stddev_score'], 0.8371132083333332, places=3)
-        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_stddev_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bagging_score'], 90.13159583333334, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_bagging_score'], 100.0, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_stddev_score'], 0.8371132083333332, places=3)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vmaf_stddev_score'], 0.0, places=4)
 
         # per model score checks
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0001_score'], 90.25032499999999, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0002_score'], 88.18534583333333, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0003_score'], 89.04952291666666, places=3)
-        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_0020_score'], 90.16633958333334, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0001_score'], 90.25032499999999, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0002_score'], 88.18534583333333, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0003_score'], 89.04952291666666, places=3)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vmaf_bootstrap_0020_score'], 90.16633958333334, places=3)
 
 
 class VmafossexecQualityRunnerSubsamplingTest(unittest.TestCase):

--- a/python/test/vmafossexec_test.py
+++ b/python/test/vmafossexec_test.py
@@ -411,7 +411,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.742800000000003, places=4)
 
     def test_run_vmafossexec_runner_psnr_chroma(self):
-        print('test on running VMAFOSSEXEC runner with chroma ...')
+        print('test on running VMAFOSSEXEC runner with PSNR chroma ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -419,7 +419,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_chroma': True}
+            optional_dict={'psnr_chroma': True}
         )
         self.runner.run()
 
@@ -435,7 +435,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
 
     def test_run_vmafossexec_runner_psnr_chroma_single_thread(self):
-        print('test on running VMAFOSSEXEC runner with chroma using one thread ...')
+        print('test on running VMAFOSSEXEC runner with PSNR chroma using one thread ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -443,7 +443,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_chroma': True, 'thread': 1}
+            optional_dict={'psnr_chroma': True, 'thread': 1}
         )
         self.runner.run()
 
@@ -459,7 +459,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
 
     def test_run_vmafossexec_runner_psnr_chroma_two_threads(self):
-        print('test on running VMAFOSSEXEC runner with chroma using two threads ...')
+        print('test on running VMAFOSSEXEC runner with PSNR chroma using two threads ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -467,7 +467,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_chroma': True, 'thread': 2}
+            optional_dict={'psnr_chroma': True, 'thread': 2}
         )
         self.runner.run()
 

--- a/python/test/vmafossexec_test.py
+++ b/python/test/vmafossexec_test.py
@@ -410,8 +410,8 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.954390000000018, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.742800000000003, places=4)
 
-    def test_run_vmafossexec_runner_psnr_color(self):
-        print('test on running VMAFOSSEXEC runner with color ...')
+    def test_run_vmafossexec_runner_psnr_chroma(self):
+        print('test on running VMAFOSSEXEC runner with chroma ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -419,7 +419,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_color': True}
+            optional_dict={'use_chroma': True}
         )
         self.runner.run()
 
@@ -434,8 +434,8 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_u_score'], 60.0, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
 
-    def test_run_vmafossexec_runner_psnr_color_single_thread(self):
-        print('test on running VMAFOSSEXEC runner with color using one thread ...')
+    def test_run_vmafossexec_runner_psnr_chroma_single_thread(self):
+        print('test on running VMAFOSSEXEC runner with chroma using one thread ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -443,7 +443,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_color': True, 'thread': 1}
+            optional_dict={'use_chroma': True, 'thread': 1}
         )
         self.runner.run()
 
@@ -458,8 +458,8 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_u_score'], 60.0, places=3)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_v_score'], 60.0, places=3)
 
-    def test_run_vmafossexec_runner_psnr_color_two_threads(self):
-        print('test on running VMAFOSSEXEC runner with color using two threads ...')
+    def test_run_vmafossexec_runner_psnr_chroma_two_threads(self):
+        print('test on running VMAFOSSEXEC runner with chroma using two threads ...')
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
@@ -467,7 +467,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
             None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
-            optional_dict={'use_color': True, 'thread': 2}
+            optional_dict={'use_chroma': True, 'thread': 2}
         )
         self.runner.run()
 

--- a/resource/doc/libvmaf.md
+++ b/resource/doc/libvmaf.md
@@ -18,14 +18,11 @@ sudo make install
 This copies the library header `libvmaf.h` under `usr/local/include`, library `libvmaf.a `under `usr/local/lib` and all the model files under `usr/local/share`. You can use the header `libvmaf.h` in your program. It contains an API which can be called from any C/C++ program:
 
 ```
-int compute_vmaf(double* vmaf_score, char* fmt, int width, int height, 
-int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data), 
-void *user_data, char *model_path, char *log_path, char *log_fmt, int disable_clip, 
-int disable_avx, int enable_transform, int phone_model, int do_psnr, int do_ssim, 
-int do_ms_ssim, char *pool_method, int thread, int subsample, int enable_conf_interval);
+int compute_vmaf(double* vmaf_score, int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
+void *user_data, VmafSettings *vmafSettings);
 ```
 
-Here, `read_frame` is a callback function which can be used to pass data from a program to VMAF. `user_data` is a program specific data that can be used by the callback function. For sample usage of `compute_vmaf`, refer to [`wrapper/src/main.cpp`](../../wrapper/src/main.cpp).
+Here, `read_frame` is a callback function which can be used to pass data from a program to VMAF. `user_data` is a program specific data that can be used by the callback function. `VmafSettings is a struct containing relevant parameters for feature extraction and model prediction`. For sample usage of `compute_vmaf`, refer to [`wrapper/src/main.cpp`](../../wrapper/src/main.cpp).
 
 To test the library, run:
 

--- a/resource/doc/libvmaf.md
+++ b/resource/doc/libvmaf.md
@@ -18,7 +18,7 @@ sudo make install
 This copies the library header `libvmaf.h` under `usr/local/include`, library `libvmaf.a `under `usr/local/lib` and all the model files under `usr/local/share`. You can use the header `libvmaf.h` in your program. It contains an API which can be called from any C/C++ program:
 
 ```
-int compute_vmaf(double* vmaf_score, int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
+int compute_vmaf(double* vmaf_score, int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
 void *user_data, VmafSettings *vmafSettings);
 ```
 

--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -11,6 +11,7 @@ PTOOLSDIR = $(TOP)/../ptools
 INSTALL_PREFIX = /usr/local
 INCLUDES += -I$(TOP)/../feature/src
 INCLUDES += -I$(TOP)/../feature/src/common
+LIBVMAF_HEADER = $(TOP)/src
 
 OBJS = \
 	$(OBJDIR)/alloc.o \
@@ -52,6 +53,7 @@ AVX_OBJS := \
 CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic -D MULTI_THREADING
 # CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic -D MULTI_THREADING -D PRINT_PROGRESS
 # CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic
+#CFLAGS_COMMON = -g -O3 -fPIC -w -Wextra -pedantic -D PRINT_PROGRESS
 # CFLAGS_COMMON = -g -O0 -fPIC -Wall -Wextra -pedantic -D PRINT_PROGRESS
 
 CFLAGS   := -std=c99 $(CFLAGS_COMMON) $(CFLAGS)
@@ -68,10 +70,10 @@ $(OBJDIR)/alignment.o: $(FEATURESRCDIR)/common/alignment.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/file_io.o: $(FEATURESRCDIR)/common/file_io.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/frame.o: $(FEATURESRCDIR)/common/frame.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/convolution.o: $(FEATURESRCDIR)/common/convolution.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $(INCLUDES) $<
@@ -83,7 +85,7 @@ $(OBJDIR)/convolution_avx.o: $(FEATURESRCDIR)/common/convolution_avx.c
 	$(CC) -c -o $@ $(EXTRA_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) $<
 
 $(OBJDIR)/psnr_tools.o: $(FEATURESRCDIR)/psnr_tools.c
-	$(CC) -c -o $@ $(EXTRA_CFLAGS) $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(EXTRA_CFLAGS) $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/adm.o: $(FEATURESRCDIR)/adm.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
@@ -92,7 +94,7 @@ $(OBJDIR)/adm_tools.o: $(FEATURESRCDIR)/adm_tools.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/ansnr.o: $(FEATURESRCDIR)/ansnr.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/ansnr_tools.o: $(FEATURESRCDIR)/ansnr_tools.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
@@ -107,7 +109,7 @@ $(OBJDIR)/motion.o: $(FEATURESRCDIR)/motion.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/psnr.o: $(FEATURESRCDIR)/psnr.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/math_utils.o: $(FEATURESRCDIR)/iqa/math_utils.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
@@ -131,7 +133,7 @@ $(OBJDIR)/moment.o: $(FEATURESRCDIR)/moment.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
 
 $(OBJDIR)/all.o: $(FEATURESRCDIR)/all.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/blur_array.o: $(FEATURESRCDIR)/common/blur_array.c
 	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) $<
@@ -147,18 +149,20 @@ $(OBJDIR)/libvmaf.o: $(SRCDIR)/libvmaf.cpp
 	-I $(PTOOLSDIR)/opencontainers_1_8_4/include $<
 
 $(OBJDIR)/main.o: $(SRCDIR)/main.cpp
-	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common $<
+	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) \
+	-DOC_NEW_STYLE_INCLUDES -I $(PTOOLSDIR) \
+	-I $(PTOOLSDIR)/opencontainers_1_8_4/include -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/vmaf.o: $(SRCDIR)/vmaf.cpp
 	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) \
 	-DOC_NEW_STYLE_INCLUDES -I $(PTOOLSDIR) \
-	-I $(PTOOLSDIR)/opencontainers_1_8_4/include -I $(FEATURESRCDIR) $<
+	-I $(PTOOLSDIR)/opencontainers_1_8_4/include -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common $<
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c
-	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(FEATURESRCDIR) $<
+	$(CC) -c -o $@ $(CFLAGS) $(CPPFLAGS) -I $(FEATURESRCDIR) -I $(LIBVMAF_HEADER) $<
 
 $(OBJDIR)/%.o: $(SRCDIR)/pugixml/%.cpp
-	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) $<
+	$(CXX) -c -o $@ $(CXXFLAGS) $(CPPFLAGS) -I $(LIBVMAF_HEADER) $<
 
 $(LIBVMAF): $(OBJS) $(wildcard ../ptools/*.o)
 	ar rcs $@ $^
@@ -185,7 +189,9 @@ uninstall:
 	rm -f $(DESTDIR)$(INSTALL_PREFIX)/lib/pkgconfig/libvmaf.pc
 
 testlib: $(SRCDIR)/main.cpp
-	$(CXX) -s -o $@  $(CXXFLAGS) $^ -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common -I $(DESTDIR)$(INSTALL_PREFIX)/include -L$(DESTDIR)$(INSTALL_PREFIX)/lib -lvmaf -pthread
+	$(CXX) -s -o $@  $(CXXFLAGS) $^ -I $(FEATURESRCDIR) -I $(FEATURESRCDIR)/common \
+	-DOC_NEW_STYLE_INCLUDES -I $(PTOOLSDIR) -I $(PTOOLSDIR)/opencontainers_1_8_4/include \
+	-I $(DESTDIR)$(INSTALL_PREFIX)/include -I $(LIBVMAF_HEADER) -L$(DESTDIR)$(INSTALL_PREFIX)/lib -lvmaf -pthread
 
 .PHONY: clean
 clean:

--- a/wrapper/Makefile
+++ b/wrapper/Makefile
@@ -11,6 +11,8 @@ PTOOLSDIR = $(TOP)/../ptools
 INSTALL_PREFIX = /usr/local
 INCLUDES += -I$(TOP)/../feature/src
 INCLUDES += -I$(TOP)/../feature/src/common
+
+# TODO: improve on the circular dependency introduced with feature/src/common, wrapper and libvmaf.h
 LIBVMAF_HEADER = $(TOP)/src
 
 OBJS = \

--- a/wrapper/libvmaf.pc
+++ b/wrapper/libvmaf.pc
@@ -5,7 +5,7 @@ includedir=/usr/local/include
 
 Name: libvmaf
 Description: Netflix's VMAF library
-Version: 1.3.15
+Version: 1.4.0
 URL: https://github.com/Netflix/vmaf
 Requires:
 Requires.private:

--- a/wrapper/libvmaf.vcxproj
+++ b/wrapper/libvmaf.vcxproj
@@ -47,7 +47,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\feature\src;..\feature\src\common;..\pthreads;..\ptools;..\ptools\opencontainers_1_8_4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wrapper\src;..\feature\src;..\feature\src\common;..\pthreads;..\ptools;..\ptools\opencontainers_1_8_4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -60,7 +60,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\feature\src;..\feature\src\common;..\pthreads;..\ptools;..\ptools\opencontainers_1_8_4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wrapper\src;..\feature\src;..\feature\src\common;..\pthreads;..\ptools;..\ptools\opencontainers_1_8_4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>MULTI_THREADING;PTW32_STATIC_LIB;OC_NEW_STYLE_INCLUDES;NDEBUG;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -75,7 +75,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
     void* user_data = thread_data->user_data;
     enum VmafPixelFormat fmt = thread_data->fmt;
     unsigned int n_subsample = thread_data->n_subsample;
-    bool use_color = thread_data->use_color;
+    bool use_chroma = thread_data->use_chroma;
 
     double score = 0;
     double score2 = 0;
@@ -174,7 +174,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-            if (use_color)
+            if (use_chroma)
             {
                 ref_buf_u = get_free_blur_buf_slot(&thread_data->ref_buf_u_array, frm_idx);
                 dis_buf_u = get_free_blur_buf_slot(&thread_data->dis_buf_u_array, frm_idx);
@@ -195,7 +195,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
             ref_vmaf_pict_ptr->data[0] = ref_buf;
             dis_vmaf_pict_ptr->data[0] = dis_buf;
 
-            if (use_color)
+            if (use_chroma)
             {
                 ref_vmaf_pict_ptr->data[1] = ref_buf_u;
                 dis_vmaf_pict_ptr->data[1] = dis_buf_u;
@@ -228,7 +228,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
             ref_buf = ref_vmaf_pict_ptr->data[0];
             dis_buf = dis_vmaf_pict_ptr->data[0];
 
-            if (use_color) {
+            if (use_chroma) {
                 ref_buf_u = ref_vmaf_pict_ptr->data[1];
                 dis_buf_u = dis_vmaf_pict_ptr->data[1];
                 ref_buf_v = ref_vmaf_pict_ptr->data[2];
@@ -268,7 +268,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 goto fail_or_end;
             }
 
-            if (use_color) {
+            if (use_chroma) {
                 ref_buf_u = get_blur_buf(&thread_data->ref_buf_u_array, frm_idx);
                 dis_buf_u = get_blur_buf(&thread_data->dis_buf_u_array, frm_idx);
                 ref_buf_v = get_blur_buf(&thread_data->ref_buf_v_array, frm_idx);
@@ -302,7 +302,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
             goto fail_or_end;
         }
 
-        if (use_color) {
+        if (use_chroma) {
             next_ref_buf_u = get_free_blur_buf_slot(&thread_data->ref_buf_u_array, frm_idx + 1);
             next_dis_buf_u = get_free_blur_buf_slot(&thread_data->dis_buf_u_array, frm_idx + 1);
             next_ref_buf_v = get_free_blur_buf_slot(&thread_data->ref_buf_v_array, frm_idx + 1);
@@ -321,7 +321,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         ref_vmaf_pict_ptr->data[0] = next_ref_buf;
         dis_vmaf_pict_ptr->data[0] = next_dis_buf;
 
-        if (use_color) {
+        if (use_chroma) {
             ref_vmaf_pict_ptr->data[1] = next_ref_buf_u;
             dis_vmaf_pict_ptr->data[1] = next_dis_buf_u;
             ref_vmaf_pict_ptr->data[2] = next_ref_buf_v;
@@ -354,7 +354,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         next_ref_buf = ref_vmaf_pict_ptr->data[0];
         next_dis_buf = dis_vmaf_pict_ptr->data[0];
 
-        if (use_color) {
+        if (use_chroma) {
             next_ref_buf_u = ref_vmaf_pict_ptr->data[1];
             next_dis_buf_u = dis_vmaf_pict_ptr->data[1];
             next_ref_buf_v = ref_vmaf_pict_ptr->data[2];
@@ -393,7 +393,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         release_blur_buf_reference(&thread_data->ref_buf_array, frm_idx + 1);
         release_blur_buf_reference(&thread_data->dis_buf_array, frm_idx + 1);
 
-        if (use_color) {
+        if (use_chroma) {
             release_blur_buf_reference(&thread_data->ref_buf_u_array, frm_idx + 1);
             release_blur_buf_reference(&thread_data->dis_buf_u_array, frm_idx + 1);
             release_blur_buf_reference(&thread_data->ref_buf_v_array, frm_idx + 1);
@@ -435,7 +435,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
 
             insert_array_at(thread_data->psnr_array, score, frm_idx);
 
-            if (use_color) {
+            if (use_chroma) {
 
                 ret = compute_psnr(ref_buf_u, dis_buf_u,
                     ref_vmaf_pict_ptr->w[1], ref_vmaf_pict_ptr->h[1],
@@ -674,7 +674,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         release_blur_buf_reference(&thread_data->ref_buf_array, frm_idx);
         release_blur_buf_reference(&thread_data->dis_buf_array, frm_idx);
         release_blur_buf_reference(&thread_data->blur_buf_array, frm_idx);
-        if (use_color) {
+        if (use_chroma) {
             release_blur_buf_reference(&thread_data->ref_buf_u_array, frm_idx);
             release_blur_buf_reference(&thread_data->dis_buf_u_array, frm_idx);
             release_blur_buf_reference(&thread_data->ref_buf_v_array, frm_idx);
@@ -694,7 +694,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 release_blur_buf_slot(&thread_data->dis_buf_array, i);
             }
 
-            if (use_color)
+            if (use_chroma)
             {
                 int ref_u_reference_count = get_blur_buf_reference_count(&thread_data->ref_buf_u_array, i);
                 int dis_u_reference_count = get_blur_buf_reference_count(&thread_data->dis_buf_u_array, i);
@@ -741,7 +741,7 @@ void* combo_threadfunc(void* vmaf_thread_data)
         {
             release_blur_buf_slot(&thread_data->ref_buf_array, frm_idx + 1);
             release_blur_buf_slot(&thread_data->dis_buf_array, frm_idx + 1);
-            if (use_color){
+            if (use_chroma){
                 release_blur_buf_slot(&thread_data->ref_buf_u_array, frm_idx + 1);
                 release_blur_buf_slot(&thread_data->dis_buf_u_array, frm_idx + 1);
                 release_blur_buf_slot(&thread_data->ref_buf_v_array, frm_idx + 1);
@@ -807,7 +807,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
         DArray *ms_ssim_array,
         char *errmsg,
         VmafFeatureCalculationSetting vmaf_feature_calculation_setting,
-        bool use_color
+        bool use_chroma
         )
 {
 
@@ -848,7 +848,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
     combo_thread_data.frm_idx = 0;
     combo_thread_data.stop_threads = 0;
     combo_thread_data.n_subsample = vmaf_feature_calculation_setting.n_subsample;
-    combo_thread_data.use_color = use_color;
+    combo_thread_data.use_chroma = use_chroma;
 
     DArray	motion_score_compute_flag_array;
     init_array(&motion_score_compute_flag_array, 1000);
@@ -877,15 +877,15 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
 
     combo_thread_data.data_sz = (size_t)combo_thread_data.stride * h;
 
-    if (use_color) {
+    if (use_chroma) {
 
         size_t w_u = 0, w_v = 0, h_u = 0, h_v = 0;
 
-        int color_resolution_ret = get_color_resolution(fmt, w, h, &w_u, &h_u, &w_v, &h_v);
+        int chroma_resolution_ret = get_chroma_resolution(fmt, w, h, &w_u, &h_u, &w_v, &h_v);
 
-        if (color_resolution_ret)
+        if (chroma_resolution_ret)
         {
-            sprintf(errmsg, "Calculating resolutions for color channels failed A.\n");
+            sprintf(errmsg, "Calculating resolutions for chroma channels failed A.\n");
             return -1;
         }
         combo_thread_data.stride_u = get_stride_byte_from_width(w_u);
@@ -915,7 +915,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
     init_blur_array(&combo_thread_data.dis_buf_array, MIN(combo_thread_data.thread_count + 1, MAX_NUM_THREADS), combo_thread_data.data_sz, MAX_ALIGN);
     init_blur_array(&combo_thread_data.blur_buf_array, MIN(3 * (combo_thread_data.thread_count), MAX_NUM_THREADS), combo_thread_data.data_sz, MAX_ALIGN);
 
-    if (use_color) {
+    if (use_chroma) {
         init_blur_array(&combo_thread_data.ref_buf_u_array, MIN(combo_thread_data.thread_count + 1, MAX_NUM_THREADS), combo_thread_data.data_sz_u, MAX_ALIGN);
         init_blur_array(&combo_thread_data.dis_buf_u_array, MIN(combo_thread_data.thread_count + 1, MAX_NUM_THREADS), combo_thread_data.data_sz_u, MAX_ALIGN);
         init_blur_array(&combo_thread_data.ref_buf_v_array, MIN(combo_thread_data.thread_count + 1, MAX_NUM_THREADS), combo_thread_data.data_sz_v, MAX_ALIGN);
@@ -959,7 +959,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
     free_blur_buf(&combo_thread_data.ref_buf_array);
     free_blur_buf(&combo_thread_data.dis_buf_array);
     free_blur_buf(&combo_thread_data.blur_buf_array);
-    if (use_color) {
+    if (use_chroma) {
         free_blur_buf(&combo_thread_data.ref_buf_u_array);
         free_blur_buf(&combo_thread_data.dis_buf_u_array);
         free_blur_buf(&combo_thread_data.ref_buf_v_array);
@@ -1005,7 +1005,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
         DArray *ms_ssim_array,
         char *errmsg,
         VmafFeatureCalculationSetting vmaf_feature_calculation_setting,
-        bool use_color
+        bool use_chroma
         )
 {
     VMAF_THREAD_STRUCT combo_thread_data;
@@ -1044,7 +1044,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
     combo_thread_data.frm_idx = 0;
     // combo_thread_data.stop_threads = 0;
     combo_thread_data.n_subsample = vmaf_feature_calculation_setting.n_subsample;
-    combo_thread_data.use_color = use_color;
+    combo_thread_data.use_chroma = use_chroma;
 
     // sanity check for width/height
     if (w <= 0 || h <= 0 || (size_t)w > ALIGN_FLOOR(INT_MAX) / sizeof(float))

--- a/wrapper/src/combo.c
+++ b/wrapper/src/combo.c
@@ -777,8 +777,7 @@ fail_or_end:
 
 #ifdef MULTI_THREADING
 
-int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
-        int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
         void *user_data, int w, int h, enum VmafPixelFormat fmt,
         DArray *adm_num_array,
         DArray *adm_den_array,
@@ -814,7 +813,6 @@ int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
 
     // init shared thread data
     VMAF_THREAD_STRUCT combo_thread_data;
-    combo_thread_data.read_frame = read_frame;
     combo_thread_data.read_vmaf_picture = read_vmaf_picture;
     combo_thread_data.user_data = user_data;
     combo_thread_data.w = w;
@@ -977,8 +975,7 @@ int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
 
 #else // #ifdef MULTI_THREADING
 
-int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
-        int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
         void *user_data, int w, int h, enum VmafPixelFormat fmt,
         DArray *adm_num_array,
         DArray *adm_den_array,
@@ -1012,7 +1009,6 @@ int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data,
         )
 {
     VMAF_THREAD_STRUCT combo_thread_data;
-    combo_thread_data.read_frame = read_frame;
     combo_thread_data.read_vmaf_picture = read_vmaf_picture;
     combo_thread_data.user_data = user_data;
     combo_thread_data.w = w;

--- a/wrapper/src/combo.h
+++ b/wrapper/src/combo.h
@@ -35,7 +35,6 @@ extern "C" {
 
 typedef struct
 {
-    int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data);
     int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data);
     void *user_data;
     int w;
@@ -94,8 +93,7 @@ typedef struct
 } VMAF_THREAD_STRUCT;
 void* combo_threadfunc(void* vmaf_thread_data);
 
-int combo(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
-        int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
         void *user_data, int w, int h, enum VmafPixelFormat fmt,
         DArray *adm_num_array,
         DArray *adm_den_array,

--- a/wrapper/src/combo.h
+++ b/wrapper/src/combo.h
@@ -67,8 +67,8 @@ typedef struct
     DArray *ssim_array;
     DArray *ms_ssim_array;
     char *errmsg;
-    int n_subsample;
-    bool use_chroma;
+    VmafFeatureCalculationSetting vmaf_feature_calculation_setting;
+    int vmaf_feature_mode_setting;
 
     int frm_idx;
     int stride, stride_u, stride_v;
@@ -123,7 +123,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
         DArray *ms_ssim_array,
         char *errmsg,
         VmafFeatureCalculationSetting vmaf_feature_calculation_setting,
-        bool use_chroma
+        int vmaf_feature_mode_setting
 );
 
 #ifdef __cplusplus

--- a/wrapper/src/combo.h
+++ b/wrapper/src/combo.h
@@ -68,7 +68,7 @@ typedef struct
     DArray *ms_ssim_array;
     char *errmsg;
     int n_subsample;
-    bool use_color;
+    bool use_chroma;
 
     int frm_idx;
     int stride, stride_u, stride_v;
@@ -123,7 +123,7 @@ int combo(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_
         DArray *ms_ssim_array,
         char *errmsg,
         VmafFeatureCalculationSetting vmaf_feature_calculation_setting,
-        bool use_color
+        bool use_chroma
 );
 
 #ifdef __cplusplus

--- a/wrapper/src/libvmaf.cpp
+++ b/wrapper/src/libvmaf.cpp
@@ -218,7 +218,6 @@ extern "C" {
     enum vmaf_cpu cpu; // global
 
     int compute_vmaf(double* vmaf_score,
-        int(*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride_byte, void *user_data),
         int(*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
         void *user_data, VmafSettings *vmafSettings)
     {
@@ -231,7 +230,7 @@ extern "C" {
         }
 
         try {
-            double score = RunVmaf(read_frame, read_vmaf_picture, user_data, vmafSettings);
+            double score = RunVmaf(read_vmaf_picture, user_data, vmafSettings);
             *vmaf_score = score;
             return 0;
         }

--- a/wrapper/src/libvmaf.cpp
+++ b/wrapper/src/libvmaf.cpp
@@ -251,13 +251,14 @@ extern "C" {
     }
 
     void replace_string_in_place(std::string& subject, const std::string& search,
-                      const std::string& replace) {
-size_t pos = 0;
-while ((pos = subject.find(search, pos)) != std::string::npos) {
-     subject.replace(pos, search.length(), replace);
-     pos += replace.length();
-}
-}
+                      const std::string& replace)
+    {
+        size_t pos = 0;
+        while ((pos = subject.find(search, pos)) != std::string::npos) {
+             subject.replace(pos, search.length(), replace);
+             pos += replace.length();
+        }
+    }
 
     unsigned int get_additional_models(char *additional_model_paths, VmafModel *vmaf_model)
     {

--- a/wrapper/src/libvmaf.cpp
+++ b/wrapper/src/libvmaf.cpp
@@ -217,11 +217,10 @@ extern "C" {
 
     enum vmaf_cpu cpu; // global
 
-    int compute_vmaf(double* vmaf_score,
+    int compute_vmaf(VmafOutput *vmaf_output_ptr,
         int(*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
         void *user_data, VmafSettings *vmafSettings)
     {
-
         cpu = cpu_autodetect();
 
         if (vmafSettings->vmaf_feature_calculation_setting.disable_avx)
@@ -230,8 +229,8 @@ extern "C" {
         }
 
         try {
-            double score = RunVmaf(read_vmaf_picture, user_data, vmafSettings);
-            *vmaf_score = score;
+            Result result = RunVmaf(read_vmaf_picture, user_data, vmafSettings);
+            vmaf_output_ptr->vmaf_score = result.get_score("vmaf");
             return 0;
         }
         catch (VmafException& e)

--- a/wrapper/src/libvmaf.h
+++ b/wrapper/src/libvmaf.h
@@ -19,7 +19,7 @@
 #ifndef LIBVMAF_H_
 #define LIBVMAF_H_
 
-#define MAX_NUM_VMAF_MODELS 5 // there can be MAX_NUM_VMAF_MODELS - 1 additional models at most
+#define MAX_NUM_VMAF_MODELS 21 // there can be MAX_NUM_VMAF_MODELS - 1 additional models at most
 
 #ifndef WINCE
 #define TIME_TEST_ENABLE 		1 // 1: memory leak test enable 0: disable
@@ -35,6 +35,14 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+
+/** Thin wrapper for VMAF outputs (besides the logged features and predictions).
+  * Can be extended to include other fields.
+  **/
+typedef struct VmafOutput
+{
+    double vmaf_score;
+} VmafOutput;
 
 enum VmafLogFmt {
     VMAF_LOG_FMT_XML                                   = 0,
@@ -55,6 +63,10 @@ typedef struct VmafFeatureCalculationSetting
     bool disable_avx;
 } VmafFeatureCalculationSetting;
 
+/** Enum with settings for feature calculation.
+  * If the setting is used, the corresponding feature calculation/operation will occur.
+  * For example, the DO_COLOR setting will instruct read_vmaf_picture to read U and V planes.
+  **/
 enum VmafFeatureModeSetting {
     VMAF_FEATURE_MODE_SETTING_DO_NONE                  = (1 << 0),
     VMAF_FEATURE_MODE_SETTING_DO_PSNR                  = (1 << 1),
@@ -83,6 +95,14 @@ typedef struct VmafPicture
     enum VmafPixelFormat pix_fmt;
 } VmafPicture;
 
+/** Model specific settings.
+  * The "default" model is the one in by model_path and with
+  * additional options, e.g. disable_clip, enable_transform
+  * and enable confidence interval.
+  * To follow the convention this model should be named "vmaf".
+  * Additional models can be named as needed and customized
+  * independently using the desired model setting.
+  */
 enum VmafModelSetting {
     VMAF_MODEL_SETTING_NONE                            = (1 << 0),
     VMAF_MODEL_SETTING_ENABLE_TRANSFORM                = (1 << 1),
@@ -92,7 +112,7 @@ enum VmafModelSetting {
 
 /** Thin VMAF model wrapper.
   * Assumes the existence of the model in a filesystem path.
-  * Includes a model setting for disabling clip, score transformation etc.*/
+  * Includes a model setting for disabling clip, score transformation etc. */
 typedef struct {
     char *name;
     char *path;
@@ -122,7 +142,7 @@ typedef struct {
   * a user-defined struct and a settings struct.
   * A single VMAF value is returned and all calculated
   * features and additional predictions are written into a log file. */
-int compute_vmaf(double* vmaf_score,
+int compute_vmaf(VmafOutput *vmaf_output_ptr,
                  int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
 				 void *user_data, VmafSettings *vmafSettings);
 

--- a/wrapper/src/libvmaf.h
+++ b/wrapper/src/libvmaf.h
@@ -72,7 +72,7 @@ enum VmafFeatureModeSetting {
     VMAF_FEATURE_MODE_SETTING_DO_PSNR                  = (1 << 1),
     VMAF_FEATURE_MODE_SETTING_DO_SSIM                  = (1 << 2),
     VMAF_FEATURE_MODE_SETTING_DO_MS_SSIM               = (1 << 3),
-    VMAF_FEATURE_MODE_SETTING_DO_COLOR                 = (1 << 4),
+    VMAF_FEATURE_MODE_SETTING_DO_CHROMA                = (1 << 4),
 };
 
 /** Definition of pixel formats in the VMAF library.

--- a/wrapper/src/libvmaf.h
+++ b/wrapper/src/libvmaf.h
@@ -69,6 +69,7 @@ typedef struct VmafFeatureCalculationSetting
 /** Enum with settings for feature mode calculation.
   * If the setting is used, the corresponding feature calculation/operation will occur.
   * For example, the DO_PSNR setting will instruct extract PSNR.
+  * The DO_CHROMA_PSNR setting will extract chroma PSNR scores.
   **/
 enum VmafFeatureModeSetting {
     VMAF_FEATURE_MODE_SETTING_DO_NONE                  = (1 << 0),

--- a/wrapper/src/libvmaf.h
+++ b/wrapper/src/libvmaf.h
@@ -56,6 +56,9 @@ enum VmafPoolingMethod {
     VMAF_POOL_HARMONIC_MEAN                            = 2,
 };
 
+/** Enum with settings for feature extraction.
+  * For example, setting read_color to true will instruct read_vmaf_picture to read U and V planes.
+  **/
 typedef struct VmafFeatureCalculationSetting
 {
     unsigned int n_threads;
@@ -63,16 +66,16 @@ typedef struct VmafFeatureCalculationSetting
     bool disable_avx;
 } VmafFeatureCalculationSetting;
 
-/** Enum with settings for feature calculation.
+/** Enum with settings for feature mode calculation.
   * If the setting is used, the corresponding feature calculation/operation will occur.
-  * For example, the DO_COLOR setting will instruct read_vmaf_picture to read U and V planes.
+  * For example, the DO_PSNR setting will instruct extract PSNR.
   **/
 enum VmafFeatureModeSetting {
     VMAF_FEATURE_MODE_SETTING_DO_NONE                  = (1 << 0),
     VMAF_FEATURE_MODE_SETTING_DO_PSNR                  = (1 << 1),
     VMAF_FEATURE_MODE_SETTING_DO_SSIM                  = (1 << 2),
     VMAF_FEATURE_MODE_SETTING_DO_MS_SSIM               = (1 << 3),
-    VMAF_FEATURE_MODE_SETTING_DO_CHROMA                = (1 << 4),
+    VMAF_FEATURE_MODE_SETTING_DO_CHROMA_PSNR           = (1 << 4),
 };
 
 /** Definition of pixel formats in the VMAF library.

--- a/wrapper/src/libvmaf.h
+++ b/wrapper/src/libvmaf.h
@@ -114,7 +114,6 @@ typedef struct {
 } VmafSettings;
 
 int compute_vmaf(double* vmaf_score,
-                 int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride_byte, void *user_data),
                  int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
 				 void *user_data, VmafSettings *vmafSettings);
 

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -115,8 +115,6 @@ int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_p
         int n_thread, int n_subsample, char *model_path, char *additional_model_paths,
         int vmaf_model_setting)
 {
-    double score;
-
     int ret = 0;
     int num_additional_models = 0;
     struct data *s;
@@ -240,8 +238,9 @@ int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_p
     // account for default VMAF model
     vmafSettings->num_models = num_additional_models + 1;
 
+    VmafOutput vmaf_output;
     /* Run VMAF */
-    ret = compute_vmaf(&score, read_vmaf_picture, s, vmafSettings);
+    ret = compute_vmaf(&vmaf_output, read_vmaf_picture, s, vmafSettings);
 
     // free memory relevant to additional models
     for (int i = 0; i < vmafSettings->num_models; i ++)

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -110,7 +110,8 @@ void getMemory(int itr_ctr, int state)
 #endif
 
 int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_path, char *dis_path,
-        char *log_path, enum VmafLogFmt log_fmt, bool disable_avx, int vmaf_feature_mode_setting,
+        char *log_path, enum VmafLogFmt log_fmt, bool disable_avx,
+        int vmaf_feature_mode_setting,
         enum VmafPoolingMethod pool_method,
         int n_thread, int n_subsample, char *model_path, char *additional_model_paths,
         int vmaf_model_setting)
@@ -120,7 +121,6 @@ int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_p
     struct data *s;
     s = (struct data *)malloc(sizeof(struct data));
     s->format = pix_fmt;
-    s->use_chroma = vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
     s->width = width;
     s->height = height;
     s->ref_rfile = NULL;
@@ -467,9 +467,9 @@ int main(int argc, char *argv[])
         vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_MS_SSIM;
     }
 
-    if (cmdOptionExists(argv + 7, argv + argc, "--chroma"))
+    if (cmdOptionExists(argv + 7, argv + argc, "--psnr-chroma"))
     {
-        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_CHROMA_PSNR;
     }
 
     char *pool_method_option = getCmdOption(argv + 7, argv + argc, "--pool");
@@ -495,13 +495,15 @@ int main(int argc, char *argv[])
 		{
 			getMemory(itr_ctr, 1);
 			ret = run_wrapper(pix_fmt, width, height, ref_path, dis_path,
-                log_path, log_fmt, disable_avx, vmaf_feature_mode_setting, pool_method, n_thread,
+                log_path, log_fmt, disable_avx,
+                vmaf_feature_mode_setting, pool_method, n_thread,
                 n_subsample, model_path, additional_model_paths, vmaf_model_setting);
 			getMemory(itr_ctr, 2);
 		}
 #else
         return run_wrapper(pix_fmt, width, height, ref_path, dis_path,
-                log_path, log_fmt, disable_avx, vmaf_feature_mode_setting, pool_method, n_thread,
+                log_path, log_fmt, disable_avx,
+                vmaf_feature_mode_setting, pool_method, n_thread,
                 n_subsample, model_path, additional_model_paths, vmaf_model_setting);
 #endif
     }

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -25,6 +25,8 @@
 #include <cstring>
 #include <cstdint>
 #include <sys/stat.h>
+
+#include "vmaf.h"
 #include "libvmaf.h"
 
 extern "C" {
@@ -51,11 +53,12 @@ bool cmdOptionExists(char** begin, char** end, const std::string& option)
 
 void print_usage(int argc, char *argv[])
 {
-    fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--ssim] [--ms-ssim] [--phone-model] [--ci]\n", argv[0]);
+    fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--ssim] [--ms-ssim] [--phone-model] [--ci] [--color] [--additional-models additional_models]\n", argv[0]);
     fprintf(stderr, "fmt:\n\tyuv420p\n\tyuv422p\n\tyuv444p\n\tyuv420p10le\n\tyuv422p10le\n\tyuv444p10le\n\n");
     fprintf(stderr, "log_fmt:\n\txml (default)\n\tjson\n\tcsv\n\n");
     fprintf(stderr, "n_thread:\n\tmaximum threads to use (default 0 - use all threads)\n\n");
     fprintf(stderr, "n_subsample:\n\tn indicates computing on one of every n frames (default 1)\n\n");
+    fprintf(stderr, "additional_models:\n\tadditional models as an escaped json string, e.g. {\\\"VMAF2\\\"\\\:{\\\"model_path\\\"\\\:\\\"model/vmaf_v0.6.1.pkl\\\"\\\,\\\"enable_transform\\\"\\\:\\\"0\\\"}\\\,\\\"VMAF3\\\"\\\:{\\\"model_path\\\"\\\:\\\"model/vmaf_v0.6.1.pkl\\\"\\\,\\\"enable_transform\\\"\\\:\\\"1\\\"\}}\n\n");
 }
 
 #if MEM_LEAK_TEST_ENABLE
@@ -106,22 +109,26 @@ void getMemory(int itr_ctr, int state)
 }
 #endif
 
-int run_wrapper(char *fmt, int width, int height, char *ref_path, char *dis_path, char *model_path,
-        char *log_path, char *log_fmt, bool disable_clip, bool disable_avx, bool enable_transform, bool phone_model,
-        bool do_psnr, bool do_ssim, bool do_ms_ssim, char *pool_method, int n_thread, int n_subsample, bool enable_conf_interval)
+int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_path, char *dis_path,
+        char *log_path, enum VmafLogFmt log_fmt, bool disable_avx, int vmaf_feature_mode_setting,
+        enum VmafPoolingMethod pool_method,
+        int n_thread, int n_subsample, char *model_path, char *additional_model_paths,
+        int vmaf_model_setting)
 {
     double score;
 
     int ret = 0;
+    int num_additional_models = 0;
     struct data *s;
     s = (struct data *)malloc(sizeof(struct data));
-    s->format = fmt;
+    s->format = pix_fmt;
+    s->use_color = vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_COLOR;
     s->width = width;
     s->height = height;
     s->ref_rfile = NULL;
     s->dis_rfile = NULL;
 
-    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv420p10le"))
+    if (pix_fmt == VMAF_PIX_FMT_YUV420P || pix_fmt == VMAF_PIX_FMT_YUV420P10LE)
     {
         if ((width * height) % 2 != 0)
         {
@@ -131,17 +138,17 @@ int run_wrapper(char *fmt, int width, int height, char *ref_path, char *dis_path
         }
         s->offset = width * height / 2;
     }
-    else if (!strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv422p10le"))
+    else if (pix_fmt == VMAF_PIX_FMT_YUV422P || pix_fmt == VMAF_PIX_FMT_YUV422P10LE)
     {
         s->offset = width * height;
     }
-    else if (!strcmp(fmt, "yuv444p") || !strcmp(fmt, "yuv444p10le"))
+    else if (pix_fmt == VMAF_PIX_FMT_YUV444P || pix_fmt == VMAF_PIX_FMT_YUV444P10LE)
     {
         s->offset = width * height * 2;
     }
     else
     {
-        fprintf(stderr, "unknown format %s.\n", fmt);
+        fprintf(stderr, "Unknown format.\n");
         ret = 1;
         goto fail_or_end;
     }
@@ -152,7 +159,6 @@ int run_wrapper(char *fmt, int width, int height, char *ref_path, char *dis_path
         ret = 1;
         goto fail_or_end;
     }
-
 
     if (!(s->dis_rfile = fopen(dis_path, "rb")))
     {
@@ -172,7 +178,7 @@ int run_wrapper(char *fmt, int width, int height, char *ref_path, char *dis_path
 #endif
         {
             size_t frame_size = width * height + s->offset;
-            if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+            if (pix_fmt == VMAF_PIX_FMT_YUV420P10LE || pix_fmt == VMAF_PIX_FMT_YUV422P10LE || pix_fmt == VMAF_PIX_FMT_YUV444P10LE)
             {
                 frame_size *= 2;
             }
@@ -189,10 +195,65 @@ int run_wrapper(char *fmt, int width, int height, char *ref_path, char *dis_path
         s->num_frames = -1;
     }
 
+    // initialize settings
+    VmafSettings *vmafSettings;
+    vmafSettings = (VmafSettings *)malloc(sizeof(VmafSettings));
+
+    if (!vmafSettings)
+    {
+        fprintf(stderr, "Malloc for VMAF settings failed.\n");
+        return 1;
+        goto fail_or_end;
+    }
+
+    // fill settings with data
+    vmafSettings->pix_fmt = pix_fmt;
+    vmafSettings->width = width;
+    vmafSettings->height = height;
+
+    vmafSettings->log_path = log_path;
+
+    vmafSettings->log_fmt = log_fmt;
+    vmafSettings->vmaf_feature_mode_setting = vmaf_feature_mode_setting;
+    vmafSettings->pool_method = pool_method;
+
+    vmafSettings->vmaf_feature_calculation_setting.n_subsample = n_subsample;
+    vmafSettings->vmaf_feature_calculation_setting.n_threads = n_thread;
+    vmafSettings->vmaf_feature_calculation_setting.disable_avx = disable_avx;
+
+    // set the first model as the default VMAF model
+    vmafSettings->default_model_ind = 0;
+
+    vmafSettings->vmaf_model[0].name = "vmaf";
+    vmafSettings->vmaf_model[0].path = model_path;
+    vmafSettings->vmaf_model[0].vmaf_model_setting = vmaf_model_setting;
+
+    num_additional_models = get_additional_models(additional_model_paths, vmafSettings->vmaf_model);
+
+    if (num_additional_models == -1)
+    {
+        fprintf(stderr, "Error: problem with additional model loading.\n");
+        return 1;
+        goto fail_or_end;
+    }
+
+    // account for default VMAF model
+    vmafSettings->num_models = num_additional_models + 1;
+
     /* Run VMAF */
-    ret = compute_vmaf(&score, fmt, width, height, read_frame, s, model_path, log_path, log_fmt,
-                       disable_clip, disable_avx, enable_transform, phone_model, do_psnr, do_ssim,
-                       do_ms_ssim, pool_method, n_thread, n_subsample, enable_conf_interval);
+    ret = compute_vmaf(&score, read_frame, read_vmaf_picture, s, vmafSettings);
+
+    // free memory relevant to additional models
+    for (int i = 0; i < vmafSettings->num_models; i ++)
+    {
+        if (i != vmafSettings->default_model_ind) {
+            free((char*)vmafSettings->vmaf_model[i].name);
+            free((char*)vmafSettings->vmaf_model[i].path);
+        }
+    }
+
+    // free VMAF settings
+    free(vmafSettings);
 
 fail_or_end:
     if (s->ref_rfile)
@@ -212,25 +273,24 @@ fail_or_end:
 
 int main(int argc, char *argv[])
 {
-    char* fmt;
     int width;
     int height;
     char* ref_path;
     char* dis_path;
     char *model_path;
+    char *additional_model_paths;
     char *log_path = NULL;
-    char *log_fmt = NULL;
-    bool disable_clip = false;
-    bool disable_avx = false;
-    bool enable_transform = false;
-    bool phone_model = false;
-    bool do_psnr = false;
-    bool do_ssim = false;
-    bool do_ms_ssim = false;
-    char *pool_method = NULL;
+
+    int vmaf_feature_mode_setting = VMAF_FEATURE_MODE_SETTING_DO_NONE;
+    int vmaf_model_setting = VMAF_MODEL_SETTING_NONE;
+
+    enum VmafPixelFormat pix_fmt = VMAF_PIX_FMT_UNKNOWN;
+    enum VmafLogFmt log_fmt = VMAF_LOG_FMT_XML;
+    enum VmafPoolingMethod pool_method = VMAF_POOL_MEAN;
+
     int n_thread = 0;
     int n_subsample = 1;
-    bool enable_conf_interval = false;
+
     char *temp;
 #if MEM_LEAK_TEST_ENABLE	
 	int itr_ctr;
@@ -244,7 +304,38 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    fmt = argv[1];
+    char *pix_fmt_option = argv[1];
+
+    if (!strcmp(pix_fmt_option, "yuv420p"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV420P;
+    }
+    else if (!strcmp(pix_fmt_option, "yuv422p"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV422P;
+    }
+        else if (!strcmp(pix_fmt_option, "yuv444p"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV444P;
+    }
+        else if (!strcmp(pix_fmt_option, "yuv420p10le"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV420P10LE;
+    }
+        else if (!strcmp(pix_fmt_option, "yuv422p10le"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV422P10LE;
+    }
+        else if (!strcmp(pix_fmt_option, "yuv444p10le"))
+    {
+        pix_fmt = VMAF_PIX_FMT_YUV444P10LE;
+    }
+    else
+    {
+        fprintf(stderr, "Unknown format %s.\n", pix_fmt_option);
+        print_usage(argc, argv);
+        return 1;
+    }
 
     try
     {
@@ -271,11 +362,20 @@ int main(int argc, char *argv[])
 
     log_path = getCmdOption(argv + 7, argv + argc, "--log");
 
-    log_fmt = getCmdOption(argv + 7, argv + argc, "--log-fmt");
-    if (log_fmt != NULL && !(strcmp(log_fmt, "xml")==0 || strcmp(log_fmt, "json")==0 || strcmp(log_fmt, "csv") == 0))
+    char *log_fmt_option = getCmdOption(argv + 7, argv + argc, "--log-fmt");
+    if (log_fmt_option != NULL && !(strcmp(log_fmt_option, "xml") == 0 || strcmp(log_fmt_option, "json") == 0 || strcmp(log_fmt_option, "csv") == 0))
     {
-        fprintf(stderr, "Error: log_fmt must be xml, json or csv, but is %s\n", log_fmt);
+        fprintf(stderr, "Error: log_fmt must be xml, json or csv, but is %s\n", log_fmt_option);
         return -1;
+    }
+
+    if ((log_fmt_option != NULL) && (strcmp(log_fmt_option, "json") == 0))
+    {
+        log_fmt = VMAF_LOG_FMT_JSON;
+    }
+    else if ((log_fmt_option != NULL) && (strcmp(log_fmt_option, "csv") == 0))
+    {
+        log_fmt = VMAF_LOG_FMT_CSV;
     }
 
     temp = getCmdOption(argv + 7, argv + argc, "--thread");
@@ -320,68 +420,90 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    if (cmdOptionExists(argv + 7, argv + argc, "--disable-clip"))
-    {
-        disable_clip = true;
-    }
-
+    bool disable_avx = false;
     if (cmdOptionExists(argv + 7, argv + argc, "--disable-avx"))
     {
         disable_avx = true;
     }
 
+    // populate VmafModelSetting (use passed in model settings for the default VMAF model)
+
+    if (cmdOptionExists(argv + 7, argv + argc, "--disable-clip"))
+    {
+        vmaf_model_setting |= VMAF_MODEL_SETTING_DISABLE_CLIP;
+    }
+
     if (cmdOptionExists(argv + 7, argv + argc, "--enable-transform"))
     {
-        enable_transform = true;
-    }
-
-    if (cmdOptionExists(argv + 7, argv + argc, "--phone-model"))
-    {
-        phone_model = true;
-    }
-
-    if (cmdOptionExists(argv + 7, argv + argc, "--psnr"))
-    {
-        do_psnr = true;
-    }
-
-    if (cmdOptionExists(argv + 7, argv + argc, "--ssim"))
-    {
-        do_ssim = true;
-    }
-
-    if (cmdOptionExists(argv + 7, argv + argc, "--ms-ssim"))
-    {
-        do_ms_ssim = true;
-    }
-
-    pool_method = getCmdOption(argv + 7, argv + argc, "--pool");
-    if (pool_method != NULL && !(strcmp(pool_method, "min")==0 || strcmp(pool_method, "harmonic_mean")==0 || strcmp(pool_method, "mean")==0))
-    {
-        fprintf(stderr, "Error: pool_method must be min, harmonic_mean or mean, but is %s\n", pool_method);
-        return -1;
+        vmaf_model_setting |= VMAF_MODEL_SETTING_ENABLE_TRANSFORM;
     }
 
     if (cmdOptionExists(argv + 7, argv + argc, "--ci"))
     {
-        enable_conf_interval = true;
+        vmaf_model_setting |= VMAF_MODEL_SETTING_ENABLE_CONF_INTERVAL;
+    }
+
+    // allow for phone_model option, but internally use enable_transform
+    if (cmdOptionExists(argv + 7, argv + argc, "--phone-model"))
+    {
+        vmaf_model_setting |= VMAF_MODEL_SETTING_ENABLE_TRANSFORM;
+    }
+
+    additional_model_paths = getCmdOption(argv + 7, argv + argc, "--additional-models");
+
+    // populate VmafFeatureModeSetting
+
+    if (cmdOptionExists(argv + 7, argv + argc, "--psnr"))
+    {
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_PSNR;
+    }
+
+    if (cmdOptionExists(argv + 7, argv + argc, "--ssim"))
+    {
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_SSIM;
+    }
+
+    if (cmdOptionExists(argv + 7, argv + argc, "--ms-ssim"))
+    {
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_MS_SSIM;
+    }
+
+    if (cmdOptionExists(argv + 7, argv + argc, "--color"))
+    {
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_COLOR;
+    }
+
+    char *pool_method_option = getCmdOption(argv + 7, argv + argc, "--pool");
+    if (pool_method_option != NULL && !(strcmp(pool_method_option, "min") == 0 || strcmp(pool_method_option, "harmonic_mean") == 0 || strcmp(pool_method_option, "mean") == 0))
+    {
+        fprintf(stderr, "Error: pool_method must be min, harmonic_mean or mean, but is %s\n", pool_method_option);
+        return -1;
+    }
+
+    if ((pool_method_option != NULL) && (strcmp(pool_method_option, "min") == 0))
+    {
+        pool_method = VMAF_POOL_MIN;
+    }
+    else if ((pool_method_option != NULL) && (strcmp(pool_method_option, "harmonic_mean") == 0))
+    {
+        pool_method = VMAF_POOL_HARMONIC_MEAN;
     }
 
     try
     {
 #if MEM_LEAK_TEST_ENABLE
-		for(itr_ctr=0;itr_ctr<1000;itr_ctr++)
+		for(itr_ctr = 0; itr_ctr < 1000; itr_ctr ++)
 		{
-			getMemory(itr_ctr,1);
-			ret = run_wrapper(fmt, width, height, ref_path, dis_path, model_path,
-                log_path, log_fmt, disable_clip, disable_avx, enable_transform, phone_model,
-                do_psnr, do_ssim, do_ms_ssim, pool_method, n_thread, n_subsample, enable_conf_interval);
-			getMemory(itr_ctr,2);
+			getMemory(itr_ctr, 1);
+			ret = run_wrapper(pix_fmt, width, height, ref_path, dis_path,
+                log_path, log_fmt, disable_avx, vmaf_feature_mode_setting, pool_method, n_thread,
+                n_subsample, model_path, additional_model_paths, vmaf_model_setting);
+			getMemory(itr_ctr, 2);
 		}
 #else
-        return run_wrapper(fmt, width, height, ref_path, dis_path, model_path,
-                log_path, log_fmt, disable_clip, disable_avx, enable_transform, phone_model,
-                do_psnr, do_ssim, do_ms_ssim, pool_method, n_thread, n_subsample, enable_conf_interval);
+        return run_wrapper(pix_fmt, width, height, ref_path, dis_path,
+                log_path, log_fmt, disable_avx, vmaf_feature_mode_setting, pool_method, n_thread,
+                n_subsample, model_path, additional_model_paths, vmaf_model_setting);
 #endif
     }
     catch (const std::exception &e)

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -120,7 +120,7 @@ int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_p
     struct data *s;
     s = (struct data *)malloc(sizeof(struct data));
     s->format = pix_fmt;
-    s->use_color = vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_COLOR;
+    s->use_chroma = vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
     s->width = width;
     s->height = height;
     s->ref_rfile = NULL;
@@ -467,9 +467,9 @@ int main(int argc, char *argv[])
         vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_MS_SSIM;
     }
 
-    if (cmdOptionExists(argv + 7, argv + argc, "--color"))
+    if (cmdOptionExists(argv + 7, argv + argc, "--chroma"))
     {
-        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_COLOR;
+        vmaf_feature_mode_setting |= VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
     }
 
     char *pool_method_option = getCmdOption(argv + 7, argv + argc, "--pool");

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -241,7 +241,7 @@ int run_wrapper(enum VmafPixelFormat pix_fmt, int width, int height, char *ref_p
     vmafSettings->num_models = num_additional_models + 1;
 
     /* Run VMAF */
-    ret = compute_vmaf(&score, read_frame, read_vmaf_picture, s, vmafSettings);
+    ret = compute_vmaf(&score, read_vmaf_picture, s, vmafSettings);
 
     // free memory relevant to additional models
     for (int i = 0; i < vmafSettings->num_models; i ++)

--- a/wrapper/src/main.cpp
+++ b/wrapper/src/main.cpp
@@ -53,7 +53,7 @@ bool cmdOptionExists(char** begin, char** end, const std::string& option)
 
 void print_usage(int argc, char *argv[])
 {
-    fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--ssim] [--ms-ssim] [--phone-model] [--ci] [--color] [--additional-models additional_models]\n", argv[0]);
+    fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--psnr-chroma] [--ssim] [--ms-ssim] [--phone-model] [--ci] [--color] [--additional-models additional_models]\n", argv[0]);
     fprintf(stderr, "fmt:\n\tyuv420p\n\tyuv422p\n\tyuv444p\n\tyuv420p10le\n\tyuv422p10le\n\tyuv444p10le\n\n");
     fprintf(stderr, "log_fmt:\n\txml (default)\n\tjson\n\tcsv\n\n");
     fprintf(stderr, "n_thread:\n\tmaximum threads to use (default 0 - use all threads)\n\n");

--- a/wrapper/src/vmaf.cpp
+++ b/wrapper/src/vmaf.cpp
@@ -601,7 +601,6 @@ void VmafQualityRunner::_set_prediction_result(
 }
 
 void VmafQualityRunner::feature_extract(Result &result,
-                        int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
                         int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
                         void *user_data, VmafSettings *vmafSettings)
 {
@@ -679,7 +678,7 @@ void VmafQualityRunner::feature_extract(Result &result,
     }
 
     dbg_printf("Extract atom features...\n");
-    int ret = combo(read_frame, read_vmaf_picture, user_data, w, h, fmt, &adm_num_array,
+    int ret = combo(read_vmaf_picture, user_data, w, h, fmt, &adm_num_array,
             &adm_den_array, &adm_num_scale0_array, &adm_den_scale0_array,
             &adm_num_scale1_array, &adm_den_scale1_array, &adm_num_scale2_array,
             &adm_den_scale2_array, &adm_num_scale3_array, &adm_den_scale3_array,
@@ -1035,8 +1034,7 @@ void BootstrapVmafQualityRunner::_set_prediction_result(
 
 }
 
-double RunVmaf(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
-               int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+double RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
                void *user_data, VmafSettings *vmafSettings)
 {
     printf("Start calculating VMAF score...\n");
@@ -1063,7 +1061,7 @@ double RunVmaf(int (*read_frame)(float *ref_data, float *main_data, float *temp_
     Result result;
 
     // feature extraction
-    VmafQualityRunner::feature_extract(result, read_frame, read_vmaf_picture, user_data, vmafSettings);
+    VmafQualityRunner::feature_extract(result, read_vmaf_picture, user_data, vmafSettings);
 
     unsigned int num_models = vmafSettings->num_models;
     for (int i = 0; i < num_models; i ++)

--- a/wrapper/src/vmaf.cpp
+++ b/wrapper/src/vmaf.cpp
@@ -1034,7 +1034,7 @@ void BootstrapVmafQualityRunner::_set_prediction_result(
 
 }
 
-double RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+Result RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
                void *user_data, VmafSettings *vmafSettings)
 {
     printf("Start calculating VMAF score...\n");
@@ -1301,5 +1301,5 @@ double RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture 
         xml.save_file(vmafSettings->log_path);
     }
 
-    return aggregate_vmaf;
+    return result;
 }

--- a/wrapper/src/vmaf.cpp
+++ b/wrapper/src/vmaf.cpp
@@ -667,9 +667,7 @@ void VmafQualityRunner::feature_extract(Result &result,
         ms_ssim_array_ptr = NULL;
     }
 
-    bool use_chroma = vmafSettings->vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
-
-    if (use_chroma) {
+    if (vmafSettings->vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_CHROMA_PSNR) {
         psnr_u_array_ptr = &psnr_u_array;
         psnr_v_array_ptr = &psnr_v_array;
     } else {
@@ -687,8 +685,9 @@ void VmafQualityRunner::feature_extract(Result &result,
             &vif_num_scale2_array, &vif_den_scale2_array, &vif_num_scale3_array,
             &vif_den_scale3_array, &vif_array,
             psnr_array_ptr, psnr_u_array_ptr, psnr_v_array_ptr, ssim_array_ptr,
-            ms_ssim_array_ptr, errmsg, vmafSettings->vmaf_feature_calculation_setting,
-            use_chroma);
+            ms_ssim_array_ptr, errmsg,
+            vmafSettings->vmaf_feature_calculation_setting,
+            vmafSettings->vmaf_feature_mode_setting);
     if (ret) {
         throw VmafException(errmsg);
     }

--- a/wrapper/src/vmaf.cpp
+++ b/wrapper/src/vmaf.cpp
@@ -667,9 +667,9 @@ void VmafQualityRunner::feature_extract(Result &result,
         ms_ssim_array_ptr = NULL;
     }
 
-    bool use_color = vmafSettings->vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_COLOR;
+    bool use_chroma = vmafSettings->vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_CHROMA;
 
-    if (vmafSettings->vmaf_feature_mode_setting & VMAF_FEATURE_MODE_SETTING_DO_COLOR) {
+    if (use_chroma) {
         psnr_u_array_ptr = &psnr_u_array;
         psnr_v_array_ptr = &psnr_v_array;
     } else {
@@ -688,7 +688,7 @@ void VmafQualityRunner::feature_extract(Result &result,
             &vif_den_scale3_array, &vif_array,
             psnr_array_ptr, psnr_u_array_ptr, psnr_v_array_ptr, ssim_array_ptr,
             ms_ssim_array_ptr, errmsg, vmafSettings->vmaf_feature_calculation_setting,
-            use_color);
+            use_chroma);
     if (ret) {
         throw VmafException(errmsg);
     }

--- a/wrapper/src/vmaf.h
+++ b/wrapper/src/vmaf.h
@@ -40,8 +40,7 @@
 static const char VMAFOSS_DOC_VERSION[] = "1.4.0";
 static const std::string BOOSTRAP_VMAF_MODEL_KEY = "_bootstrap_";
 
-double RunVmaf(int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
-               int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+double RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
                void *user_data, VmafSettings *vmafSettings);
 
 class VmafException: public std::exception
@@ -178,7 +177,6 @@ class VmafQualityRunner : public IVmafQualityRunner
 public:
     VmafQualityRunner(const char *model_path): model_path(model_path) {}
     static void feature_extract(Result &result,
-                int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride, void *user_data),
                 int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
                 void *user_data, VmafSettings *vmafSettings);
     virtual void predict(Result &result, VmafModel *vmaf_model_ptr);

--- a/wrapper/src/vmaf.h
+++ b/wrapper/src/vmaf.h
@@ -40,22 +40,6 @@
 static const char VMAFOSS_DOC_VERSION[] = "1.4.0";
 static const std::string BOOSTRAP_VMAF_MODEL_KEY = "_bootstrap_";
 
-double RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
-               void *user_data, VmafSettings *vmafSettings);
-
-class VmafException: public std::exception
-{
-public:
-    explicit VmafException(const char *msg): msg(msg) {}
-    virtual const char* what() const throw () { return msg.c_str(); }
-private:
-    std::string msg;
-};
-
-struct SvmDelete {
-    void operator()(void *svm);
-};
-
 enum VmafPredictionReturnType
 {
     SCORE,
@@ -111,6 +95,22 @@ private:
     std::map<std::string, StatVector> d;
     ScoreAggregateMethod score_aggregate_method;
     unsigned int num_frms;
+};
+
+Result RunVmaf(int (*read_vmaf_picture)(VmafPicture *ref_vmaf_pict, VmafPicture *dis_vmaf_pict, float *temp_data, void *user_data),
+               void *user_data, VmafSettings *vmafSettings);
+
+class VmafException: public std::exception
+{
+public:
+    explicit VmafException(const char *msg): msg(msg) {}
+    virtual const char* what() const throw () { return msg.c_str(); }
+private:
+    std::string msg;
+};
+
+struct SvmDelete {
+    void operator()(void *svm);
 };
 
 struct VmafPredictionStruct

--- a/wrapper/vmafossexec.vcxproj
+++ b/wrapper/vmafossexec.vcxproj
@@ -47,10 +47,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\feature\src;..\feature\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wrapper\src;..\ptools;..\pthreads;..\ptools\opencontainers_1_8_4\include;..\feature\src;..\feature\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>MULTI_THREADING;_DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MULTI_THREADING;_DEBUG;OC_NEW_STYLE_INCLUDES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -63,9 +63,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\feature\src;..\feature\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\wrapper\src;..\ptools;..\pthreads;..\ptools\opencontainers_1_8_4\include;..\feature\src;..\feature\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>MULTI_THREADING;NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>MULTI_THREADING;NDEBUG;OC_NEW_STYLE_INCLUDES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>


### PR DESCRIPTION
This PR has a number of important changes:

1. Libvmaf interface change
2. Support for multiple prediction models, each additional model has the flexibility to use different enable_transform, disable_clip and ci than other models
3. Decouple feature extraction and model prediction
4. As part of the API change, we should also change read_frame and extend it to read all three color channels. To do so, we introduce a VmafPicture struct as a helper.