### PR TITLE
Travis CI: Update to Ubuntu 18.04, use Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
+dist: bionic
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
 - Updates build environment to Ubuntu 18.04
 - Uses Python 3.7 instead of 3.6