### PR TITLE
libvmaf/Makefile: Add one more .. to model

### DIFF
--- a/src/libvmaf/Makefile
+++ b/src/libvmaf/Makefile
@@ -209,7 +209,7 @@ install: libvmaf.pc
 	mkdir -p $(DESTDIR)$(INSTALL_PREFIX)/lib/pkgconfig
 	cp $(LIBVMAF) $(DESTDIR)$(INSTALL_PREFIX)/lib/$(LIBVMAF)
 	cp src/libvmaf.h $(DESTDIR)$(INSTALL_PREFIX)/include/
-	cp -r ../model $(DESTDIR)$(INSTALL_PREFIX)/share/
+	cp -r ../../model $(DESTDIR)$(INSTALL_PREFIX)/share/
 	cp libvmaf.pc $(DESTDIR)$(INSTALL_PREFIX)/lib/pkgconfig/
 
 .PHONY: uninstall


### PR DESCRIPTION
make install was failing since make couldn't find `../model` since it was two levels up. The travis-ci was not reporting the `sudo make install` as failing

Fixes m-ab-s/media-autobuild_suite#1418