### PR TITLE
[WIP] libvmaf: add VmafFeatureCollector

### DIFF
--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -1,0 +1,202 @@
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "feature_collector.h"
+
+typedef struct {
+    char *name;
+    struct {
+        bool written;
+        double value;
+    } *score;
+    unsigned capacity;
+} FeatureVector;
+
+typedef struct VmafFeatureCollector {
+    FeatureVector **feature_vector;
+    unsigned cnt, capacity;
+    pthread_mutex_t lock;
+} VmafFeatureCollector;
+
+static int feature_vector_init(FeatureVector **const feature_vector,
+                               const char *name)
+{
+    if (!feature_vector) return -EINVAL;
+    if (!name) return -EINVAL;
+
+    FeatureVector *const fv = *feature_vector = malloc(sizeof(*fv));
+    if (!fv) goto fail;
+    memset(fv, 0, sizeof(*fv));
+    fv->name = malloc(strlen(name) + 1);
+    if (!fv->name) goto free_fv;
+    strcpy(fv->name, name);
+    fv->capacity = 8;
+    fv->score = malloc(sizeof(fv->score[0]) * fv->capacity);
+    if (!fv->score) goto free_name;
+    memset(fv->score, 0, sizeof(fv->score[0]) * fv->capacity);
+    return 0;
+
+free_name:
+    free(fv->name);
+free_fv:
+    free(fv);
+fail:
+    return -ENOMEM;
+}
+
+static void feature_vector_destroy(FeatureVector *feature_vector)
+{
+    if (!feature_vector) return;
+    free(feature_vector->name);
+    free(feature_vector->score);
+    free(feature_vector);
+}
+
+static int feature_vector_append(FeatureVector *feature_vector,
+                                 unsigned index, double score)
+{
+    if (!feature_vector) return -EINVAL;
+
+    while (index >= feature_vector->capacity) {
+        size_t initial_size =
+            sizeof(feature_vector->score[0]) * feature_vector->capacity;
+        void *score = realloc(feature_vector->score, initial_size * 2);
+        if (!score) return -ENOMEM;
+        memset(score + initial_size, 0, initial_size);
+        feature_vector->score = score;
+        feature_vector->capacity *= 2;
+    }
+
+    if (feature_vector->score[index].written)
+        return -EINVAL;
+
+    feature_vector->score[index].written = true;
+    feature_vector->score[index].value = score;
+
+    return 0;
+}
+
+int vmaf_feature_collector_init(VmafFeatureCollector **const feature_collector)
+{
+    if (!feature_collector) return -EINVAL;
+
+    VmafFeatureCollector *const fc = *feature_collector = malloc(sizeof(*fc));
+    if (!fc) goto fail;
+    memset(fc, 0, sizeof(*fc));
+    fc->capacity = 8;
+    fc->feature_vector = malloc(sizeof(*(fc->feature_vector)) * fc->capacity);
+    if (!fc->feature_vector) goto free_fc;
+    memset(fc->feature_vector, 0, sizeof(*(fc->feature_vector)) * fc->capacity);
+    int err = pthread_mutex_init(&(fc->lock), NULL);
+    if (err) goto free_feature_vector;
+    return 0;
+
+free_feature_vector:
+    free(fc->feature_vector);
+free_fc:
+    free(fc);
+fail:
+    return -ENOMEM;
+}
+
+static FeatureVector *find_feature_vector(VmafFeatureCollector *fc,
+                                          char *feature_name)
+{
+    FeatureVector *feature_vector = NULL;
+    for (unsigned i = 0; i < fc->cnt; i++) {
+        FeatureVector *fv = fc->feature_vector[i];
+        if (!strcmp(fv->name, feature_name)) {
+            feature_vector = fv;
+            break;
+        }
+    }
+    return feature_vector;
+}
+
+int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
+                                  char *feature_name, double score,
+                                  unsigned picture_index)
+{
+    if (!feature_collector) return -EINVAL;
+    if (!feature_name) return -EINVAL;
+
+    pthread_mutex_lock(&(feature_collector->lock));
+    int err = 0;
+
+    FeatureVector *feature_vector =
+        find_feature_vector(feature_collector, feature_name);
+
+    if (!feature_vector) {
+        err = feature_vector_init(&feature_vector, feature_name);
+        if (err) goto unlock;
+        if (feature_collector->cnt + 1 > feature_collector->capacity) {
+            size_t initial_size = sizeof(feature_collector->feature_vector[0]) *
+                feature_vector->capacity;
+            FeatureVector **fv =
+                realloc(feature_collector->feature_vector,
+                sizeof(*(feature_collector->feature_vector)) *
+                initial_size * 2);
+            if (!fv) {
+                err = -ENOMEM;
+                goto unlock;
+            }
+            memset(fv + feature_collector->capacity, 0, initial_size);
+            feature_collector->feature_vector = fv;
+            feature_collector->capacity *= 2;
+        }
+        feature_collector->feature_vector[feature_collector->cnt++]
+            = feature_vector;
+    }
+
+    err = feature_vector_append(feature_vector, picture_index, score);
+
+unlock:
+    pthread_mutex_unlock(&(feature_collector->lock));
+    return err;
+}
+
+int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
+                                     char *feature_name, double *score,
+                                     unsigned index)
+{
+    if (!feature_collector) return -EINVAL;
+    if (!feature_name) return -EINVAL;
+    if (!score) return -EINVAL;
+
+    pthread_mutex_lock(&(feature_collector->lock));
+    int err = 0;
+
+    FeatureVector *feature_vector =
+        find_feature_vector(feature_collector, feature_name);
+
+    if (!feature_vector || index >= feature_vector->capacity) {
+        err = -EINVAL;
+        goto unlock;
+    }
+
+    if (!feature_vector->score[index].written) {
+        err = -EINVAL;
+        goto unlock;
+    }
+
+    *score = feature_vector->score[index].value;
+
+unlock:
+    pthread_mutex_unlock(&(feature_collector->lock));
+    return err;
+}
+
+void vmaf_feature_collector_destroy(VmafFeatureCollector *feature_collector)
+{
+    if (!feature_collector) return;
+
+    pthread_mutex_lock(&(feature_collector->lock));
+    for (unsigned i = 0; i < feature_collector->cnt; i++)
+        feature_vector_destroy(feature_collector->feature_vector[i]);
+    free(feature_collector->feature_vector);
+    pthread_mutex_destroy(&(feature_collector->lock));
+    free(feature_collector);
+}

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -1,0 +1,18 @@
+#ifndef __VMAF_FEATURE_COLLECTOR_H__
+#define __VMAF_FEATURE_COLLECTOR_H__
+
+typedef struct VmafFeatureCollector VmafFeatureCollector;
+
+int vmaf_feature_collector_init(VmafFeatureCollector **const feature_collector);
+
+int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
+                                  char *feature_name, double score,
+                                  unsigned index);
+
+int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
+                                     char *feature_name, double *score,
+                                     unsigned index);
+
+void vmaf_feature_collector_destroy(VmafFeatureCollector *feature_collector);
+
+#endif /* __VMAF_FEATURE_COLLECTOR_H__ */

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -5,4 +5,10 @@ test_picture = executable('test_picture',
     include_directories : [libvmaf_inc, test_inc, '../src/'],
 )
 
+test_feature_collector = executable('test_feature_collector',
+    ['test.c', 'test_feature_collector.c',],
+    include_directories : [libvmaf_inc, test_inc, '../src/feature/'],
+)
+
 test('test_picture', test_picture)
+test('test_feature_collector', test_feature_collector)

--- a/libvmaf/test/test_feature_collector.c
+++ b/libvmaf/test/test_feature_collector.c
@@ -1,0 +1,76 @@
+#include "test.h"
+#include "feature_collector.c"
+
+static char *test_feature_vector_init_append_and_destroy()
+{
+    int err;
+
+    FeatureVector *feature_vector;
+    err = feature_vector_init(&feature_vector, "psnr_y");
+    mu_assert("problem during feature_vector_init", !err);
+
+    unsigned initial_capacity = feature_vector->capacity;
+    for (int j = initial_capacity - 1; j >= 0; j--) {
+        err = feature_vector_append(feature_vector, j, 60.);
+        mu_assert("problem during feature_vector_append", !err);
+    }
+    mu_assert("feature_vector->capacity should not have changed",
+              feature_vector->capacity == initial_capacity);
+    err = feature_vector_append(feature_vector, initial_capacity, 60.);
+    mu_assert("problem during feature_vector_append", !err);
+    mu_assert("feature_vector->capacity did not double its allocation",
+              feature_vector->capacity == initial_capacity * 2);
+    err = feature_vector_append(feature_vector, initial_capacity, 60.);
+    mu_assert("feature_vector_append should not overwrite", err);
+
+    feature_vector_destroy(feature_vector);
+    return NULL;
+}
+
+static char *test_feature_collector_init_append_get_and_destroy()
+{
+    int err;
+
+    VmafFeatureCollector *feature_collector;
+    err = vmaf_feature_collector_init(&feature_collector);
+    mu_assert("problem during vmaf_feature_collector_init", !err);
+    unsigned initial_capacity = feature_collector->capacity;
+    mu_assert("this test assumes an initial capacity of 8",
+              initial_capacity == 8);
+    err  = vmaf_feature_collector_append(feature_collector, "feature0", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature1", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature2", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature3", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature4", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature5", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature6", 60., 1);
+    err |= vmaf_feature_collector_append(feature_collector, "feature7", 60., 1);
+    mu_assert("problem during vmaf_feature_collector_append", !err);
+    mu_assert("feature_collector->capacity should not have changed",
+              feature_collector->capacity == initial_capacity);
+    err = vmaf_feature_collector_append(feature_collector, "feature8", 60., 1);
+    mu_assert("problem during vmaf_feature_collector_append", !err);
+    mu_assert("feature_collector->capacity did not double its allocation",
+              feature_collector->capacity == initial_capacity * 2);
+
+    double score;
+    err = vmaf_feature_collector_get_score(feature_collector, "feature5",
+                                           &score, 1);
+    mu_assert("problem during vmaf_feature_collector_get_score", !err);
+    mu_assert("vmaf_feature_collector_get_score did not get the expected score",
+              score == 60.);
+    err = vmaf_feature_collector_get_score(feature_collector, "feature5",
+                                           &score, 2);
+    mu_assert("vmaf_feature_collector_get_score did not fail with bad index",
+              err);
+
+    vmaf_feature_collector_destroy(feature_collector);
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_feature_vector_init_append_and_destroy);
+    mu_run_test(test_feature_collector_init_append_get_and_destroy);
+    return NULL;
+}


### PR DESCRIPTION
This adds a new internal struct `VmafFeatureCollector`, as well as an API for interacting with it. The  purpose of this is to collect extracted features on a per frame basis. See `feature_collector.h` and `test_feature_collector_init_append_and_destroy` for usage.

`VmafFeatureCollector` has the following attributes:
- Hold scores for an extracted feature with any `feature_name`
- Thread safe
- OOO insertion, for feature extraction parallelism on a frame level
- Avoid this mess: https://github.com/Netflix/vmaf/blob/master/libvmaf/src/combo.h#L40-L63
- Add a new feature extractor to `libvmaf` with no internal changes.

I've marked this as **WIP** for now, since I don't exactly know when the best time to integrate it is. Also there still needs to be an API to get scores out from the `VmafFeatureCollector`. Depending on how this gets used, it may be necessary to adjust the internal data structure.