### PR TITLE
libvmaf: implement VmafModel

### DIFF
--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -1,0 +1,9 @@
+#ifndef __VMAF_MODEL_H__
+#define __VMAF_MODEL_H__
+
+typedef struct VmafModel VmafModel;
+
+int vmaf_model_load_from_path(VmafModel **model, const char *path);
+void vmaf_model_destroy(VmafModel *model);
+
+#endif /* __VMAF_MODEL_H__ */

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -1,0 +1,55 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "model.h"
+#include "svm.h"
+#include "unpickle.h"
+
+int vmaf_model_load_from_path(VmafModel **model, const char *path)
+{
+    VmafModel *const m = *model = malloc(sizeof(*m));
+    if (!m) goto fail;
+    memset(m, 0, sizeof(*m));
+    m->path = malloc(strlen(path) + 1);
+    if (!m->path) goto free_m;
+    strcpy(m->path, path);
+
+    // ugly, this shouldn't be implict (but it is)
+    char *svm_path_suffix = ".model";
+    size_t svm_path_sz =
+        strlen(m->path) + strlen(svm_path_suffix) + 1 * sizeof(char);
+    char *svm_path = malloc(svm_path_sz);
+    if (!svm_path) goto free_path;
+    memset(svm_path, 0, svm_path_sz);
+    strncat(svm_path, m->path, strlen(m->path));
+    strncat(svm_path, svm_path_suffix, strlen(svm_path_suffix));
+
+    m->svm = svm_load_model(svm_path);
+    free(svm_path);
+    if (!m->svm) goto free_path;
+    int err = vmaf_unpickle_model(m, m->path);
+    if (err) goto free_svm;
+
+    return 0;
+
+free_svm:
+    svm_free_and_destroy_model(&(m->svm));
+free_path:
+    free(m->path);
+free_m:
+    free(m);
+fail:
+    return -ENOMEM;
+}
+
+void vmaf_model_destroy(VmafModel *model)
+{
+    if (!model) return;
+    free(model->path);
+    svm_free_and_destroy_model(&(model->svm));
+    for (unsigned i = 0; i < model->n_features; i++)
+        free(model->feature[i].name);
+    free(model->feature);
+    free(model);
+}

--- a/libvmaf/src/model.h
+++ b/libvmaf/src/model.h
@@ -1,0 +1,45 @@
+#ifndef __VMAF_SRC_MODEL_H__
+#define __VMAF_SRC_MODEL_H__
+
+#include <stdbool.h>
+
+enum VmafModelType {
+    VMAF_MODEL_TYPE_UNKNOWN = 0,
+    VMAF_MODEL_TYPE_SVM_NUSVR,
+    VMAF_MODEL_BOOTSTRAP_SVM_NUSVR,
+    VMAF_MODEL_RESIDUE_BOOTSTRAP_SVM_NUSVR,
+};
+
+enum VmafModelNormalizationType {
+    VMAF_MODEL_NORMALIZATION_TYPE_UNKNOWN = 0,
+    VMAF_MODEL_NORMALIZATION_TYPE_NONE,
+    VMAF_MODEL_NORMALIZATION_TYPE_LINEAR_RESCALE,
+};
+
+typedef struct {
+    char *name;
+    double slope, intercept;
+} VmafModelFeature;
+
+typedef struct {
+    char *path;
+    enum VmafModelType type;
+    VmafModelFeature *feature;
+    unsigned n_features;
+    struct {
+        bool enabled;
+        double min, max;
+    } score_clip;
+    enum VmafModelNormalizationType norm_type;
+    struct {
+        bool enabled;
+        struct {
+            bool enabled;
+            double value;
+        } p0, p1, p2;
+        bool out_lte_in, out_gte_in;
+    } score_transform;
+    struct svm_model *svm;
+} VmafModel;
+
+#endif /* __VMAF_SRC_MODEL_H__ */

--- a/libvmaf/src/svm.cpp
+++ b/libvmaf/src/svm.cpp
@@ -602,7 +602,7 @@ void svm_free_model_content(svm_model* model_ptr)
     model_ptr->nSV = NULL;
 }
 
-void svm_free_and_destroy_model(svm_model** model_ptr_ptr)
+void svm_free_and_destroy_model(struct svm_model** model_ptr_ptr)
 {
 	if(model_ptr_ptr != NULL && *model_ptr_ptr != NULL)
 	{

--- a/libvmaf/src/svm.h
+++ b/libvmaf/src/svm.h
@@ -77,7 +77,7 @@ double svm_predict_values(const struct svm_model *model, const struct svm_node *
 double svm_predict(const struct svm_model *model, const struct svm_node *x);
 
 void svm_free_model_content(struct svm_model *model_ptr);
-void svm_free_and_destroy_model(svm_model** model_ptr_ptr);
+void svm_free_and_destroy_model(struct svm_model** model_ptr_ptr);
 
 #ifdef __cplusplus
 }

--- a/libvmaf/src/unpickle.cpp
+++ b/libvmaf/src/unpickle.cpp
@@ -1,0 +1,118 @@
+#include <errno.h>
+
+#include "chooseser.h"
+#include "model.h"
+
+#define VAL_EQUAL_STR(V,S) (Stringize((V)).compare((S))==0)
+#define VAL_IS_LIST(V) ((V).tag=='n') /* check ocval.cc */
+#define VAL_IS_NONE(V) ((V).tag=='Z') /* check ocval.cc */
+#define VAL_IS_DICT(V) ((V).tag=='t') /* check ocval.cc */
+
+static int unpickle(VmafModel *model, const char *pickle_path)
+{
+    Val pickle_model;
+    LoadValFromFile(pickle_path, pickle_model, SERIALIZE_P0);
+    Val model_type = pickle_model["model_dict"]["model_type"];
+    Val feature_names = pickle_model["model_dict"]["feature_names"];
+    Val norm_type = pickle_model["model_dict"]["norm_type"];
+    Val slopes = pickle_model["model_dict"]["slopes"];
+    Val intercepts = pickle_model["model_dict"]["intercepts"];
+    Val score_clip = pickle_model["model_dict"]["score_clip"];
+    Val score_transform = pickle_model["model_dict"]["score_transform"];
+
+    if (!((VAL_IS_NONE(score_clip)) || VAL_IS_LIST(score_clip)))
+        return -EINVAL;
+    model->score_clip.enabled = !(VAL_IS_NONE(score_clip));
+    if (model->score_clip.enabled) {
+        model->score_clip.min = score_clip[0];
+        model->score_clip.max = score_clip[1];
+    }
+
+    if (VAL_EQUAL_STR(model_type, "'RESIDUEBOOTSTRAP_LIBSVMNUSVR'"))
+        model->type = VMAF_MODEL_RESIDUE_BOOTSTRAP_SVM_NUSVR;
+    else if (VAL_EQUAL_STR(model_type, "BOOTSTRAP_LIBSVMNUSVR"))
+        model->type = VMAF_MODEL_BOOTSTRAP_SVM_NUSVR;
+    else if (VAL_EQUAL_STR(model_type, "'LIBSVMNUSVR'"))
+        model->type = VMAF_MODEL_TYPE_SVM_NUSVR;
+    else
+        return -EINVAL;
+
+    if (VAL_EQUAL_STR(norm_type, "'linear_rescale'"))
+        model->norm_type = VMAF_MODEL_NORMALIZATION_TYPE_LINEAR_RESCALE;
+    else if (VAL_EQUAL_STR(norm_type, "'none'"))
+        model->norm_type = VMAF_MODEL_NORMALIZATION_TYPE_NONE;
+    else
+        return -EINVAL;
+
+    if (!(VAL_IS_NONE(score_transform) || VAL_IS_DICT(score_transform)))
+        return -EINVAL;
+    if (VAL_IS_NONE(score_transform)) {
+        model->score_transform.enabled = false;
+    } else {
+        model->score_transform.enabled = true;
+
+        if (VAL_IS_NONE(score_transform["p0"])) {
+            model->score_transform.p0.enabled = false;
+        } else {
+            model->score_transform.p0.enabled = true;
+            model->score_transform.p0.value = score_transform["p0"];
+        }
+        if (VAL_IS_NONE(score_transform["p1"])) {
+            model->score_transform.p1.enabled = false;
+        } else {
+            model->score_transform.p1.enabled = true;
+            model->score_transform.p1.value = score_transform["p1"];
+        }
+        if (VAL_IS_NONE(score_transform["p2"])) {
+            model->score_transform.p2.enabled = false;
+        } else {
+            model->score_transform.p2.enabled = true;
+            model->score_transform.p2.value = score_transform["p2"];
+        }
+        if (!VAL_IS_NONE(score_transform["out_lte_in"]) &&
+            VAL_EQUAL_STR(score_transform["out_lte_in"], "'true'"))
+        {
+            model->score_transform.out_lte_in = true;
+        }
+        if (!VAL_IS_NONE(score_transform["out_gte_in"]) &&
+            VAL_EQUAL_STR(score_transform["out_gte_in"], "'true'"))
+        {
+            model->score_transform.out_gte_in = true;
+        }
+    }
+
+    if (!VAL_IS_LIST(feature_names))
+        return -EINVAL;
+    model->n_features = feature_names.length();
+    model->feature = (VmafModelFeature *)
+        malloc(sizeof(*(model->feature)) * model->n_features);
+    if (!model->feature) goto fail;
+    memset(model->feature, 0, sizeof(*(model->feature)) * model->n_features);
+    for (unsigned i = 0; i < model->n_features; i++) {
+       model->feature[i].name = strdup(Stringize(feature_names[i]).c_str());
+       if (!model->feature[i].name) goto free_name;
+       model->feature[i].slope = slopes[i];
+       model->feature[i].intercept = intercepts[i];
+    }
+
+    return 0;
+
+free_name:
+    for (unsigned i = 0; i < model->n_features; i++) {
+        if (model->feature[i].name)
+            free(model->feature[i].name);
+    }
+free_feature:
+    free(model->feature);
+fail:
+    return -ENOMEM;
+}
+
+extern "C" {
+
+int vmaf_unpickle_model(VmafModel *model, const char *pickle_path)
+{
+    return unpickle(model, pickle_path);
+}
+
+}

--- a/libvmaf/src/unpickle.h
+++ b/libvmaf/src/unpickle.h
@@ -1,0 +1,3 @@
+#include "model.h"
+
+int vmaf_unpickle_model(VmafModel *model, const char *pickle_path);

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -10,5 +10,16 @@ test_feature_collector = executable('test_feature_collector',
     include_directories : [libvmaf_inc, test_inc, '../src/feature/'],
 )
 
+test_model = executable('test_model',
+    ['test.c', 'test_model.c', '../src/svm.cpp', '../src/unpickle.cpp'],
+    include_directories : [libvmaf_inc, test_inc, opencontainers_include,
+                           '../src/third_party/ptools/', '../src'],
+    c_args : vmaf_cflags_common,
+    cpp_args : vmaf_cflags_common,
+    objects : libptools.extract_all_objects(),
+    dependencies : thread_lib,
+)
+
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
+test('test_model', test_model)

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+#include "test.h"
+#include "model.c"
+
+static char *test_model_load_and_destroy()
+{
+    int err;
+
+    VmafModel *model;
+    err = vmaf_model_load_from_path(&model, "../../model/vmaf_v0.6.1.pkl");
+    mu_assert("problem during vmaf_model_load_from_path", !err);
+
+    /*
+    for (unsigned i = 0; i < model->n_features; i++)
+        fprintf(stderr, "feature name: %s slope: %f intercept: %f\n",
+                model->feature[i].name,
+                model->feature[i].slope,
+                model->feature[i].intercept
+        );
+    */
+
+    vmaf_model_destroy(model);
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_model_load_and_destroy);
+    return NULL;
+}


### PR DESCRIPTION
Initial implementation of `VmafModel` as well as the unpickler for reading from the `.pkl` model files.  Holds everything `LibsvmNusvrTrainTestModel` and `BootstrapLibsvmNusvrTrainTestModel` do, but there's no reliance on ptools specific types, which allows us to make a distinction between model data and the model file format. I'm still holding out for #360.

```
(VmafModel) *m = {
  path = 0x00000001004002a0 "../../model/vmaf_v0.6.1.pkl"
  type = VMAF_MODEL_TYPE_SVM_NUSVR
  feature = 0x0000000100401460
  n_features = 6
  score_clip = (enabled = true, min = 0, max = 100)
  norm_type = VMAF_MODEL_NORMALIZATION_TYPE_LINEAR_RESCALE
  score_transform = {
    enabled = true
    p0 = (enabled = true, value = 1.7067469200000001)
    p1 = (enabled = true, value = 1.7264384399999999)
    p2 = (enabled = true, value = -0.0070530499999999999)
    out_lte_in = false
    out_gte_in = true
  }
  svm = 0x0000000100400400
}
```

Still to be ported are the prediction methods from the aforementioned classes. Also worth noting, `VmafModel` will be used in the new public API, but only as an opaque type.