### PR TITLE
fdtools: de-capitalize winsock2.h

### DIFF
--- a/libvmaf/src/third_party/ptools/fdtools.h
+++ b/libvmaf/src/third_party/ptools/fdtools.h
@@ -4,7 +4,7 @@
 extern "C" {
 #if defined(_MSC_VER) || defined(__MINGW32__)
     #include <io.h>
-    #include <Winsock2.h>
+    #include <winsock2.h>
     #include <string.h>
 #else
     #include <unistd.h>


### PR DESCRIPTION
Breaks mingw-w64 builds on case sensitive systems