### PR TITLE
pkg-config: Add libvmaf as a subdir to actually point to the correct includedir

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -134,5 +134,6 @@ pkg_mod.generate(libraries: libvmaf,
     version: meson.project_version(),
     name: 'libvmaf',
     filebase: 'libvmaf',
-    description: 'VMAF, Video Multimethod Assessment Fusion'
+    description: 'VMAF, Video Multimethod Assessment Fusion',
+    subdirs: 'libvmaf'
 )


### PR DESCRIPTION
FFmpeg configuration on current master branches fails since pkg-config isn't giving `${prefix}/include/libvmaf` to find libvmaf.h

Changes Cflags line in libvmaf.pc file from
`Cflags: -I${includedir}`
to
`Cflags: -I${includedir}/libvmaf`
