### PR TITLE
Travis: Test multiple compilers and FFmpeg integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,5 +89,17 @@ matrix:
       script:
         - git clone https://github.com/FFmpeg/FFmpeg --branch master --depth=1 ffmpeg && cd ffmpeg
         - "sudo chown -R travis: $HOME/.ccache"
-        - ./configure --enable-libvmaf --enable-version3 || less ffbuild/config.log
+        - CFLAGS="-static" ./configure --enable-libvmaf --enable-version3 || less ffbuild/config.log
         - make --quiet -j $(nproc) && sudo make install
+        - curl https://gist.githubusercontent.com/1480c1/0c4575da638ef6e8203feffd0597de16/raw/akiyo_cif.tar.xz.base64 | base64 -d | tar xJ
+        - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/x86_64-linux-gnu
+        - vmaf_score=$(ffmpeg -hide_banner -nostats -i encoded.mkv -i orig.mkv -filter_complex libvmaf -f null - 2>&1 | grep 'VMAF score' | tr ' ' '\n' | tail -n1)
+        - echo "$vmaf_score"
+        - |
+          if [[ $vmaf_score != "93.665821" ]]; then
+            echo "vmaf Score doesn't match 93.665821"
+            return 1
+          else
+            echo "vmaf score matches"
+            return 0
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,93 @@
-language: python
+os: linux
 dist: bionic
-python:
-  - "2.7"
-  - "3.7"
+language: c++
+cache: ccache
 
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq g++-9
-  - export CXX="g++-9" CC="gcc-9"
-  - sudo apt-get install git
-  - sudo apt-get install ninja-build python3-pip python3-setuptools
+addons:
+  apt:
+    update: true
+    sources:
+      - sourceline: "ppa:ubuntu-toolchain-r/test"
+      - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main"
+        key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+    packages:
+      - python3-pip
+      - ninja-build
+      - python3-setuptools
+      - ccache
+      - yasm
+  homebrew:
+    packages:
+      - ninja
+      - ccache
+      - yasm
+
+before_install: "sudo chown -R travis: $HOME/.ccache"
 
 install:
-  - pip install tox-travis
+  - ccache -s
   - pip3 install meson
+  - |
+    if type apt-get; then
+      case "$CC" in
+      gcc-7) sudo apt-get install -qq gcc-7 g++-7 ;;
+      gcc-8) sudo apt-get install -qq gcc-8 g++-8 ;;
+      gcc-9) sudo apt-get install -qq gcc-9 g++-9 ;;
+      clang-6.0) sudo apt-get install -qq clang-6.0 ;;
+      clang-10) sudo apt-get install -qq clang-10 ;;
+      esac
+    fi
+  - export CC="ccache $CC" CXX="ccache $CXX"
 
-script:
-  - >
-    cd third_party/libsvm &&
-    make lib &&
-    cd -
-  - >
-    cd libvmaf &&
-    mkdir build && cd build &&
-    meson .. --buildtype release &&
-    ninja -vC . test &&
-    DESTDIR=$(pwd)/install ninja -vC . install &&
-    cd ../..
-  - tox -c python/ -- -v -p no:warnings -m 'main or lib' --doctest-modules
+after_script:
+  - ccache -s
+
+matrix:
+  fast_finish: true
+  include:
+    - name: libvmaf GCC-7
+      env: CC=gcc-7 CXX=g++-7
+      script: &base-gcc-script
+        - mkdir libvmaf/build && cd libvmaf/build
+        - meson .. --buildtype release
+        - sudo ninja -v install
+        - sudo ninja -v test
+        - cd $TRAVIS_BUILD_DIR
+    - name: libvmaf GCC-9
+      env: CC=gcc-9 CXX=g++-9
+      script: *base-gcc-script
+    - name: libvmaf Clang-10
+      env: CC=clang-10 CXX=clang++-10
+      script: *base-gcc-script
+    - name: libvmaf AppleClang
+      os: osx
+      osx_image: xcode11.2
+      compiler: clang
+      script: *base-gcc-script
+    - name: Python3 Tox
+      language: python
+      python: "3.7"
+      env: CC=gcc-7 CXX=g++-7
+      cache: &python-cache
+        pip: true
+        directories:
+          - $HOME/.ccache
+      before_script: *base-gcc-script
+      script: &python-tox
+        - pip3 install tox-travis
+        - make -C third_party/libsvm -j lib
+        - tox -c python/ -- -v -p no:warnings -m 'main or lib' --doctest-modules
+    - name: Python2 Tox
+      language: python
+      python: "2.7"
+      env: CC=gcc-7 CXX=g++-7
+      cache: *python-cache
+      before_script: *base-gcc-script
+      script: *python-tox
+    - name: libvmaf FFmpeg
+      before_script: *base-gcc-script
+      script:
+        - git clone https://github.com/FFmpeg/FFmpeg --branch master --depth=1 ffmpeg && cd ffmpeg
+        - "sudo chown -R travis: $HOME/.ccache"
+        - ./configure --enable-libvmaf --enable-version3 || less ffbuild/config.log
+        - make --quiet -j $(nproc) && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,6 @@ matrix:
         - pip3 install tox-travis
         - make -C third_party/libsvm -j lib
         - tox -c python/ -- -v -p no:warnings -m 'main or lib' --doctest-modules
-    - name: Python2 Tox
-      language: python
-      python: "2.7"
-      env: CC=gcc-7 CXX=g++-7
-      cache: *python-cache
-      before_script: *base-gcc-script
-      script: *python-tox
     - name: libvmaf FFmpeg
       before_script: *base-gcc-script
       script:


### PR DESCRIPTION
Add GCC-7,8,9 and Clang-10 compile tests along with keeping the python tests and add a ffmpeg compile test.

@kylophone, is vmaf targeting a minimum compiler version? I don't particularly see any mention of anything like that.

Questions:
- Should I add a macOS build job?
- Should I test if running vmaf through ffmpeg works?
- Should I remove the python2 tox job? https://pythonclock.org/
- Would you prefer these to be in Travis-CI or in Github Actions?

Anything else you think I should add?