### PR TITLE
libvmaf: implement vmaf_predict_score_at_index

### DIFF
--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -1,0 +1,124 @@
+#include <errno.h>
+#include <stdlib.h>
+
+#include "feature/feature_collector.h"
+#include "model.h"
+#include "svm.h"
+
+static int normalize(VmafModel *model, double slope, double intercept,
+                     double *feature_score)
+{
+    switch (model->norm_type) {
+    case(VMAF_MODEL_NORMALIZATION_TYPE_NONE):
+        break;
+    case(VMAF_MODEL_NORMALIZATION_TYPE_LINEAR_RESCALE):
+        *feature_score = slope * (*feature_score) + intercept;
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int denormalize(VmafModel *model, double *prediction)
+{
+    switch (model->norm_type) {
+    case(VMAF_MODEL_NORMALIZATION_TYPE_NONE):
+        break;
+    case(VMAF_MODEL_NORMALIZATION_TYPE_LINEAR_RESCALE):
+        *prediction -=
+            (model->feature[0].intercept / model->feature[0].slope);
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+
+static int transform(VmafModel *model, double *prediction)
+{
+    if (!model->score_transform.enabled)
+        return 0;
+
+    double value = 0.;
+    double p = *prediction;
+
+    if (model->score_transform.p0.enabled)
+        value += model->score_transform.p0.value;
+    if (model->score_transform.p1.enabled)
+        value += model->score_transform.p1.value * p;
+    if (model->score_transform.p2.enabled)
+        value += model->score_transform.p2.value * p * p;
+    if (model->score_transform.out_lte_in)
+        value = (value > p) ? p : value;
+    if (model->score_transform.out_gte_in)
+        value = (value < p) ? p : value;
+
+    *prediction = value;
+    return 0;
+}
+
+static int clip(VmafModel *model, double *prediction)
+{
+    if (!model->score_clip.enabled)
+        return 0;
+
+    *prediction = (*prediction < model->score_clip.min) ?
+        model->score_clip.min : *prediction;
+    *prediction = (*prediction > model->score_clip.max) ?
+        model->score_clip.max : *prediction;
+
+    return 0;
+}
+
+int vmaf_predict_score_at_index(VmafModel *model,
+                                VmafFeatureCollector *feature_collector,
+                                unsigned index, double *vmaf_score)
+{
+    if (!model) return -EINVAL;
+    if (!feature_collector) return -EINVAL;
+    if (!vmaf_score) return -EINVAL;
+
+    int err = 0;
+
+    struct svm_node *node = malloc(sizeof(*node) * (model->n_features + 1));
+    if (!node) return -ENOMEM;
+
+    for (unsigned i = 0; i < model->n_features; i++) {
+        double feature_score;
+
+        err = vmaf_feature_collector_get_score(feature_collector,
+                                               model->feature[i].name,
+                                               &feature_score, index);
+        if (err) goto free_node;
+        err = normalize(model, model->feature[i].slope,
+                        model->feature[i].intercept, &feature_score);
+        if (err) goto free_node;
+
+        node[i].index = i + 1;
+        node[i].value = feature_score;
+    }
+    node[model->n_features].index = -1;
+
+    double prediction = svm_predict(model->svm, node);
+
+    err = denormalize(model, &prediction);
+    if (err) goto free_node;
+    err = transform(model, &prediction);
+    if (err) goto free_node;
+    err = clip(model, &prediction);
+    if (err) goto free_node;
+
+    err = vmaf_feature_collector_append(feature_collector, model->path,
+                                        prediction, index);
+    if (err) goto free_node;
+
+    *vmaf_score = prediction;
+
+free_node:
+    free(node);
+    return err;
+}

--- a/libvmaf/src/predict.h
+++ b/libvmaf/src/predict.h
@@ -1,0 +1,11 @@
+#ifndef __VMAF_PREDICT_H__
+#define __VMAF_PREDICT_H__
+
+#include "feature/feature_collector.h"
+#include "model.h"
+
+int vmaf_predict_score_at_index(VmafModel *model,
+                                VmafFeatureCollector *feature_collector,
+                                unsigned index, double *vmaf_score);
+
+#endif /* __VMAF_PREDICT_H__ */

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -20,6 +20,19 @@ test_model = executable('test_model',
     dependencies : thread_lib,
 )
 
+test_predict = executable('test_predict',
+    ['test.c', 'test_predict.c', '../src/predict.c',
+     '../src/feature/feature_collector.c', '../src/model.c', '../src/svm.cpp',
+     '../src/unpickle.cpp'],
+    include_directories : [libvmaf_inc, test_inc, opencontainers_include,
+                           '../src/third_party/ptools/', '../src'],
+    c_args : vmaf_cflags_common,
+    cpp_args : vmaf_cflags_common,
+    objects : libptools.extract_all_objects(),
+    dependencies : thread_lib,
+)
+
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
 test('test_model', test_model)
+test('test_predict', test_predict)

--- a/libvmaf/test/test_predict.c
+++ b/libvmaf/test/test_predict.c
@@ -1,0 +1,37 @@
+#include <stdint.h>
+
+#include "test.h"
+#include "predict.h"
+
+static char *test_predict_score_at_index()
+{
+    int err;
+
+    VmafFeatureCollector *feature_collector;
+    err = vmaf_feature_collector_init(&feature_collector);
+    mu_assert("problem during vmaf_feature_collector_init", !err);
+
+    VmafModel *model;
+    err = vmaf_model_load_from_path(&model, "../../model/vmaf_v0.6.1.pkl");
+    mu_assert("problem during vmaf_model_load_from_path", !err);
+
+    for (unsigned i = 0; i < model->n_features; i++) {
+        err = vmaf_feature_collector_append(feature_collector,
+                                            model->feature[i].name, 60., 0);
+        mu_assert("problem during vmaf_feature_collector_append", !err);
+    }
+
+    double vmaf_score = 0.;
+    err = vmaf_predict_score_at_index(model, feature_collector, 0, &vmaf_score);
+    mu_assert("problem during vmaf_predict_score_at_index", !err);
+
+    vmaf_model_destroy(model);
+    vmaf_feature_collector_destroy(feature_collector);
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_predict_score_at_index);
+    return NULL;
+}


### PR DESCRIPTION
Here is the initial implementation for `vmaf_predict_score_at_index()`. Given a `VmafModel` and a `VmafFeatureCollector` this function computes the vmaf score at a particular index. The value of `vmaf_score` is both returned in a pointer and also added to the `VmafFeatureCollector`. 

See `test_predict_score_at_index()` for usage.