### PR TITLE
update to python3

### DIFF
--- a/python/script/ffmpeg2vmaf.py
+++ b/python/script/ffmpeg2vmaf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import matplotlib
 matplotlib.use('Agg')

--- a/python/script/run_cleaning_cache.py
+++ b/python/script/run_cleaning_cache.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 from vmaf.core.quality_runner import QualityRunner

--- a/python/script/run_psnr.py
+++ b/python/script/run_psnr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/python/script/run_result_assembly.py
+++ b/python/script/run_result_assembly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/python/script/run_testing.py
+++ b/python/script/run_testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import matplotlib
 matplotlib.use('Agg')

--- a/python/script/run_vmaf.py
+++ b/python/script/run_vmaf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import matplotlib
 matplotlib.use('Agg')

--- a/python/script/run_vmaf_in_batch.py
+++ b/python/script/run_vmaf_in_batch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/python/script/run_vmaf_training.py
+++ b/python/script/run_vmaf_training.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import matplotlib
 matplotlib.use('Agg')

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 VMAF - Video Multimethod Assessment Fusion

--- a/resource/doc/VMAF_Python_library.md
+++ b/resource/doc/VMAF_Python_library.md
@@ -5,7 +5,7 @@ The VMAF Python library offers full functionalities from running basic VMAF comm
 
 ## Prerequisites
 
-The VMAF Python library has its core feature extraction library written in C, and the rest scripting code written in Python. To build the C code, it requires `gcc` and `g++` (>=4.8). To run scripts and tests, it requires Python2 (>= 2.7) installed.
+The VMAF Python library has its core feature extraction library written in C, and the rest scripting code written in Python. To build the C code, it requires `gcc` and `g++` (>=4.8). To run scripts and tests, it requires Python 3.
 
 It also requires a number of Python packages:
 
@@ -30,19 +30,23 @@ Install the dependencies:
 sudo apt-get update -qq && \
 sudo apt-get install -y \
   pkg-config gfortran libhdf5-dev libfreetype6-dev liblapack-dev \
-  python python-setuptools python-dev python-pip python-tk
+  python3 \
+  python3-dev \
+  python3-pip \
+  python3-setuptools \
+  python3-tk
 ```
 
 Upgrade `pip` to the newest version:
 
 ```
-sudo -H pip install --upgrade pip
+sudo -H pip3 install --upgrade pip
 ```
 
 Then install the required Python packages:
 
 ```
-pip install --user numpy scipy matplotlib pandas scikit-learn scikit-image h5py sureal
+pip3 install --user numpy scipy matplotlib pandas scikit-learn scikit-image h5py sureal
 ```
 
 Make sure your user install executable directory is on your PATH. Add this to the end of `~/.bashrc` and restart your shell:
@@ -74,20 +78,20 @@ pip3 install meson
 You can verify if these packages are properly installed and its version/location by:
 
 ```
-python -c 'import numpy as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import scipy as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import matplotlib as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import pandas as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import sklearn as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import skimage as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import h5py as pkg; print(pkg.__version__); print(pkg.__file__)'
-python -c 'import sureal as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import numpy as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import scipy as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import matplotlib as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import pandas as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import sklearn as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import skimage as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import h5py as pkg; print(pkg.__version__); print(pkg.__file__)'
+python3 -c 'import sureal as pkg; print(pkg.__version__); print(pkg.__file__)'
 ```
 
 If you see that the printed version number is older than the ones aforementioned, it could suggest that a previously installed package with the same name but older version at a different location may have overshadowed the new one. Make sure that the new one's path appears early in the path list, which can be printed by:
 
 ```
-python -c 'import sys; print(sys.path)'
+python3 -c 'import sys; print(sys.path)'
 ```
 
 (Or simply delete the older one).
@@ -315,13 +319,13 @@ When creating a dataset file, one may make errors (for example, having a typo in
 If the problem persists, one may need to run the script:
 
 ```
-python python/script/run_cleaning_cache.py quality_type test_dataset_file
+python3 python/script/run_cleaning_cache.py quality_type test_dataset_file
 ```
 
 to clean up corrupted results in the store before retrying. For example:
 
 ```
-python python/script/run_cleaning_cache.py VMAF \
+python3 python/script/run_cleaning_cache.py VMAF \
   resource/example/example_dataset.py
 ```
 

--- a/third_party/libsvm/python/svm.py
+++ b/third_party/libsvm/python/svm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from ctypes import *
 from ctypes.util import find_library

--- a/third_party/libsvm/python/svmutil.py
+++ b/third_party/libsvm/python/svmutil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys
 sys.path = [os.path.dirname(os.path.abspath(__file__))] + sys.path 

--- a/third_party/libsvm/tools/checkdata.py
+++ b/third_party/libsvm/tools/checkdata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # A format checker for LIBSVM

--- a/third_party/libsvm/tools/easy.py
+++ b/third_party/libsvm/tools/easy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/third_party/libsvm/tools/grid.py
+++ b/third_party/libsvm/tools/grid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 __all__ = ['find_parameters']
 
 import os, sys, traceback, getpass, time, re

--- a/third_party/libsvm/tools/subset.py
+++ b/third_party/libsvm/tools/subset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys, math, random
 from collections import defaultdict

--- a/unittest
+++ b/unittest
@@ -5,5 +5,5 @@
 
 #echo "Run tests in python/test..."
 cd python
-PYTHONPATH=src python -m unittest discover -t . -s test -p '*_test.py'
+PYTHONPATH=src python3 -m unittest discover -t . -s test -p '*_test.py'
 cd ..


### PR DESCRIPTION
This removes all references to python and instead uses python3, which is
to be used according to https://www.python.org/dev/peps/pep-0394/.

Particularly, distributors may choose not to provide python as a standalone
command.