### PR TITLE
libvmaf: implement vmaf_write_output()

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -10,6 +10,11 @@ enum VmafLogLevel {
     VMAF_LOG_LEVEL_NONE,
 };
 
+enum VmafOutputFormat {
+    VMAF_OUTPUT_FORMAT_NONE,
+    VMAF_OUTPUT_FORMAT_XML,
+};
+
 typedef struct {
     enum VmafLogLevel log_level;
     unsigned n_threads;
@@ -29,7 +34,6 @@ typedef struct {
 typedef struct VmafContext VmafContext;
 
 void vmaf_default_configuration(VmafConfiguration *cfg);
-void vmaf_write_log(VmafContext *vmaf, FILE *log);
 
 /**
  * Get libvmaf version.
@@ -164,5 +168,8 @@ int vmaf_score_pooled(VmafContext *vmaf, VmafModel model,
  * @param vmaf The VMAF instance to close.
  */
 int vmaf_close(VmafContext *vmaf);
+
+int vmaf_write_output(VmafContext *vmaf, FILE *logfile,
+                      enum VmafOutputFormat fmt);
 
 #endif /* __VMAF_H__ */

--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -6,21 +6,6 @@
 
 #include "feature_collector.h"
 
-typedef struct {
-    char *name;
-    struct {
-        bool written;
-        double value;
-    } *score;
-    unsigned capacity;
-} FeatureVector;
-
-typedef struct VmafFeatureCollector {
-    FeatureVector **feature_vector;
-    unsigned cnt, capacity;
-    pthread_mutex_t lock;
-} VmafFeatureCollector;
-
 static int feature_vector_init(FeatureVector **const feature_vector,
                                const char *name)
 {

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -1,7 +1,23 @@
 #ifndef __VMAF_FEATURE_COLLECTOR_H__
 #define __VMAF_FEATURE_COLLECTOR_H__
 
-typedef struct VmafFeatureCollector VmafFeatureCollector;
+#include <pthread.h>
+#include <stdbool.h>
+
+typedef struct {
+    char *name;
+    struct {
+        bool written;
+        double value;
+    } *score;
+    unsigned capacity;
+} FeatureVector;
+
+typedef struct VmafFeatureCollector {
+    FeatureVector **feature_vector;
+    unsigned cnt, capacity;
+    pthread_mutex_t lock;
+} VmafFeatureCollector;
 
 int vmaf_feature_collector_init(VmafFeatureCollector **const feature_collector);
 

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -7,6 +7,7 @@
 #include "feature/feature_collector.h"
 #include "libvmaf/libvmaf.rc.h"
 #include "model.h"
+#include "output.h"
 #include "picture.h"
 
 typedef struct {
@@ -201,7 +202,19 @@ const char *vmaf_version(void)
     return "RELEASE_CANDIDATE";
 }
 
-void vmaf_write_log(VmafContext *vmaf, FILE *logfile)
+int vmaf_write_output(VmafContext *vmaf, FILE *outfile,
+                      enum VmafOutputFormat fmt)
 {
-    return;
+    int err = 0;
+
+    switch (fmt) {
+    case VMAF_OUTPUT_FORMAT_NONE:
+    case VMAF_OUTPUT_FORMAT_XML:
+        err = vmaf_write_output_xml(vmaf->feature_collector, outfile);
+        break;
+    default:
+        break;
+    }
+
+    return err;
 }

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -138,6 +138,7 @@ libvmaf_rc_sources = [
     src_dir + 'picture.c',
     src_dir + 'mem.c',
     src_dir + 'picture.c',
+    src_dir + 'output.c',
     feature_src_dir + 'feature_collector.c',
     feature_src_dir + 'feature_extractor.c',
 ]

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -1,0 +1,55 @@
+#include <errno.h>
+#include <stdio.h>
+
+#include "feature/feature_collector.h"
+#include <libvmaf/libvmaf.rc.h>
+
+static unsigned max_capacity(VmafFeatureCollector *fc)
+{
+    unsigned capacity = 0;
+
+    for (unsigned j = 0; j < fc->cnt; j++) {
+        if (fc->feature_vector[j]->capacity > capacity)
+            capacity = fc->feature_vector[j]->capacity;
+    }
+
+    return capacity;
+}
+
+int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile)
+{
+    if (!fc) return -EINVAL;
+    if (!outfile) return -EINVAL;
+
+    fprintf(outfile, "<VMAF version=\"%s\">\n", vmaf_version());
+    fprintf(outfile, "  <frames>\n");
+
+    for (unsigned i = 0 ; i < max_capacity(fc); i++) {
+        unsigned cnt = 0;
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (fc->feature_vector[j]->score[i].written)
+                cnt++;
+        }
+        if (!cnt) continue;
+
+        fprintf(outfile, "    <frame frameNum=\"%d\" ", i);
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (!fc->feature_vector[j]->score[i].written)
+                continue;
+            fprintf(outfile, "%s=\"%.6f\" ",
+                fc->feature_vector[j]->name,
+                fc->feature_vector[j]->score[i].value
+            );
+        }
+        fprintf(outfile, "    />\n");
+    }
+
+    fprintf(outfile, "  </frames>\n");
+    fprintf(outfile, "</VMAF>\n");
+
+    return 0;
+}

--- a/libvmaf/src/output.h
+++ b/libvmaf/src/output.h
@@ -1,0 +1,1 @@
+int vmaf_write_log_xml(VmafFeatureCollector *fc, FILE *logfile);

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -9,13 +9,14 @@
 
 #include <libvmaf/libvmaf.rc.h>
 
-static const char short_opts[] = "r:d:m:l:t:f:i:v:";
+static const char short_opts[] = "r:d:m:o:x:t:f:i:n:v:";
 
 static const struct option long_opts[] = {
     { "reference",        1, NULL, 'r' },
     { "distorted",        1, NULL, 'd' },
     { "model",            1, NULL, 'm' },
-    { "log",              1, NULL, 'l' },
+    { "output",           1, NULL, 'o' },
+    { "xml",              0, NULL, 'x' },
     { "threads",          1, NULL, 't' },
     { "feature",          1, NULL, 'f' },
     { "import",           1, NULL, 'i' },
@@ -37,7 +38,8 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --reference/-r $path:      path to reference .y4m\n"
             " --distorted/-d $path:      path to distorted .y4m\n"
             " --model/-m $path:          path to model file\n"
-            " --log/-l $path:            path to output log file\n"
+            " --output/-o $path:         path to output file\n"
+            " --xml/-x:                  write output file as XML (default)\n"
             " --threads/-t $unsigned:    number of threads to use\n"
             " --feature/-f $string:      additional feature\n"
             " --import/-i $path:         path to precomputed feature log\n"
@@ -90,8 +92,11 @@ void cli_parse(const int argc, char *const *const argv,
         case 'd':
             settings->y4m_path_dist = optarg;
             break;
-        case 'l':
-            settings->log_path = optarg;
+        case 'o':
+            settings->output_path = optarg;
+            break;
+        case 'x':
+            settings->output_fmt = VMAF_OUTPUT_FORMAT_XML;
             break;
         case 'm':
             if (settings->model_cnt == CLI_SETTINGS_STATIC_ARRAY_LEN) {

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -9,7 +9,8 @@
 
 typedef struct {
     char *y4m_path_ref, *y4m_path_dist;
-    char *log_path;
+    char *output_path;
+    enum VmafOutputFormat output_fmt;
     char *model_path[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned model_cnt;
     char *feature[CLI_SETTINGS_STATIC_ARRAY_LEN];

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -213,14 +213,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (c.log_path) {
-        FILE *logfile = fopen(c.log_path, "w");
-        if (!logfile) {
-            fprintf(stderr, "could not open file: %s\n", c.y4m_path_dist);
+    if (c.output_path) {
+        FILE *outfile = fopen(c.output_path, "w");
+        if (!outfile) {
+            fprintf(stderr, "could not open file: %s\n", c.output_path);
             return -1;
         }
-        vmaf_write_log(vmaf, logfile);
-        fclose(logfile);
+        vmaf_write_output(vmaf, outfile, c.output_fmt);
+        fclose(outfile);
     }
 
     for (unsigned i = 0; i < c.model_cnt; i++)


### PR DESCRIPTION
Implements `vmaf_write_output()`, a `libvmaf` library function for writing an output stats file.