### PR TITLE
libvmaf: update VmafFeatureExtractor init

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -77,14 +77,17 @@ free_f:
     return -ENOMEM;
 }
 
-int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx)
+int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
+                                        enum VmafPixelFormat pix_fmt,
+                                        unsigned bpc, unsigned w, unsigned h)
 {
     if (!fex_ctx) return -EINVAL;
     if (fex_ctx->is_initialized) return -EINVAL;
+    if (!pix_fmt) return -EINVAL;
 
     int err = 0;
     if (!fex_ctx->is_initialized) {
-        int err = fex_ctx->fex->init(fex_ctx->fex);
+        int err = fex_ctx->fex->init(fex_ctx->fex, pix_fmt, bpc, w, h);
         if (err) return err;
     }
 
@@ -105,7 +108,9 @@ int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
     if (!fex_ctx->fex->extract) return -EINVAL;
 
     if (!fex_ctx->is_initialized) {
-        int err = vmaf_feature_extractor_context_init(fex_ctx);
+        int err =
+            vmaf_feature_extractor_context_init(fex_ctx, ref->pix_fmt, ref->bpc,
+                                                ref->w[0], ref->h[0]);
         if (err) return err;
     }
 

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -14,7 +14,8 @@ enum VmafFeatureExtractorFlags {
 
 typedef struct VmafFeatureExtractor {
     const char *name;
-    int (*init)(struct VmafFeatureExtractor *fex);
+    int (*init)(struct VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h);
     int (*extract)(struct VmafFeatureExtractor *fex,
                    VmafPicture *ref_pic, VmafPicture *dist_pic,
                    unsigned index, VmafFeatureCollector *feature_collector);
@@ -33,7 +34,9 @@ typedef struct VmafFeatureExtractorContext VmafFeatureExtractorContext;
 int vmaf_feature_extractor_context_create(VmafFeatureExtractorContext **fex_ctx,
                                           VmafFeatureExtractor *fex);
 
-int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx);
+int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
+                                        enum VmafPixelFormat pix_fmt,
+                                        unsigned bpc, unsigned w, unsigned h);
 
 int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
                                            VmafPicture *ref, VmafPicture *dist,

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -1,46 +1,63 @@
+#include <errno.h>
 #include <math.h>
 #include <string.h>
 
 #include "feature_collector.h"
 #include "feature_extractor.h"
+
 #include "psnr.h"
 #include "picture_copy.h"
 
-static int init(VmafFeatureExtractor *fex)
+typedef struct PsnrState {
+    size_t float_stride;
+    float *ref;
+    float *dist;
+} PsnrState;
+
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
 {
+    PsnrState *s = fex->priv;
+    s->float_stride = sizeof(float) * w;
+    s->ref = malloc(s->float_stride * h);
+    if (!s->ref) goto fail;
+    s->dist = malloc(s->float_stride * h);
+    if (!s->dist) goto free_ref;
+
     return 0;
+
+free_ref:
+    free(s->ref);
+fail:
+    return -ENOMEM;
 }
 
 static int extract(VmafFeatureExtractor *fex,
                    VmafPicture *ref_pic, VmafPicture *dist_pic,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
+    PsnrState *s = fex->priv;
     int err = 0;
 
-    size_t stride = sizeof(float) * ref_pic->w[0];
-    float *ref = malloc(ref_pic->h[0] * stride);
-    float *dist = malloc(dist_pic->h[0] * stride);
-
-    picture_copy(ref, ref_pic);
-    picture_copy(dist, dist_pic);
+    picture_copy(s->ref, ref_pic);
+    picture_copy(s->dist, dist_pic);
 
     double score;
-    err = compute_psnr(ref, dist, ref_pic->w[0], ref_pic->h[0], stride, stride,
-                       &score, 255., 60.);
+    err = compute_psnr(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,
+                       s->float_stride, &score, 255., 60.);
 
     if (err) return err;
-
-    err = vmaf_feature_collector_append(feature_collector, "float_psnr", score,
-                                        index);
+    err = vmaf_feature_collector_append(feature_collector, "float_psnr",
+                                        score, index);
     if (err) return err;
-
-    free(ref);
-    free(dist);
     return 0;
 }
 
 static int close(VmafFeatureExtractor *fex)
 {
+    PsnrState *s = fex->priv;
+    if (s->ref) free(s->ref);
+    if (s->dist) free(s->dist);
     return 0;
 }
 
@@ -49,4 +66,5 @@ VmafFeatureExtractor vmaf_fex_float_psnr = {
     .init = init,
     .extract = extract,
     .close = close,
+    .priv_size = sizeof(PsnrState),
 };

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -1,43 +1,60 @@
+#include <errno.h>
+
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
 #include "ssim.h"
 #include "picture_copy.h"
 
-static int init(VmafFeatureExtractor *fex)
+typedef struct SsimState {
+    size_t float_stride;
+    float *ref;
+    float *dist;
+} SsimState;
+
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
 {
+    SsimState *s = fex->priv;
+    s->float_stride = sizeof(float) * w;
+    s->ref = malloc(s->float_stride * h);
+    if (!s->ref) goto fail;
+    s->dist = malloc(s->float_stride * h);
+    if (!s->dist) goto free_ref;
+
     return 0;
+
+free_ref:
+    free(s->ref);
+fail:
+    return -ENOMEM;
 }
 
 static int extract(VmafFeatureExtractor *fex,
                    VmafPicture *ref_pic, VmafPicture *dist_pic,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
+    SsimState *s = fex->priv;
     int err = 0;
 
-    size_t stride = sizeof(float) * ref_pic->w[0];
-    float *ref = malloc(ref_pic->h[0] * stride);
-    float *dist = malloc(dist_pic->h[0] * stride);
-
-    picture_copy(ref, ref_pic);
-    picture_copy(dist, dist_pic);
+    picture_copy(s->ref, ref_pic);
+    picture_copy(s->dist, dist_pic);
 
     double score, l_score, c_score, s_score;
-    err = compute_ssim(ref, dist, ref_pic->w[0], ref_pic->h[0], stride, stride,
-                       &score, &l_score, &c_score, &s_score);
+    err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,
+                       s->float_stride, &score, &l_score, &c_score, &s_score);
     if (err) return err;
-
-    err = vmaf_feature_collector_append(feature_collector, "float_ssim", score,
-                                        index);
+    err = vmaf_feature_collector_append(feature_collector, "float_ssim",
+                                        score, index);
     if (err) return err;
-
-    free(ref);
-    free(dist);
     return 0;
 }
 
 static int close(VmafFeatureExtractor *fex)
 {
+    SsimState *s = fex->priv;
+    if (s->ref) free(s->ref);
+    if (s->dist) free(s->dist);
     return 0;
 }
 
@@ -46,4 +63,5 @@ VmafFeatureExtractor vmaf_fex_float_ssim = {
     .init = init,
     .extract = extract,
     .close = close,
+    .priv_size = sizeof(SsimState),
 };

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -4,7 +4,8 @@
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
-static int init(VmafFeatureExtractor *fex)
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
 {
     return 0;
 }

--- a/libvmaf/src/feature/integer_ssim.c
+++ b/libvmaf/src/feature/integer_ssim.c
@@ -196,7 +196,8 @@ static double calc_ssim(const unsigned char *_src,int _systride,
   return ssim/ssimw;
 }
 
-static int init(VmafFeatureExtractor *fex)
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
 {
     return 0;
 }


### PR DESCRIPTION
Updated callback signature for VmafFeatureExtractor `init()`. Also updated are feature extractors `float_ssim` and `float_psnr` to take advantage of the updated callback. Each feature extractor now only allocates its float buffers just once.