### PR TITLE
libvmaf: implement vmaf_fex_float_motion

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -51,7 +51,7 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name)
 }
 
 typedef struct VmafFeatureExtractorContext {
-    bool is_initialized;
+    bool is_initialized, is_closed;
     VmafFeatureExtractor *fex;
 } VmafFeatureExtractorContext;
 
@@ -125,11 +125,13 @@ int vmaf_feature_extractor_context_close(VmafFeatureExtractorContext *fex_ctx)
 {
     if (!fex_ctx) return -EINVAL;
     if (!fex_ctx->is_initialized) return -EINVAL;
+    if (fex_ctx->is_closed) return 0;
 
     int err = 0;
     if (fex_ctx->fex->close) {
         err = fex_ctx->fex->close(fex_ctx->fex);
     }
+    fex_ctx->is_closed = true;
     return err;
 }
 

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -10,6 +10,7 @@ extern VmafFeatureExtractor vmaf_fex_psnr;
 extern VmafFeatureExtractor vmaf_fex_float_psnr;
 extern VmafFeatureExtractor vmaf_fex_float_adm;
 extern VmafFeatureExtractor vmaf_fex_float_vif;
+extern VmafFeatureExtractor vmaf_fex_float_motion;
 
 static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_ssim,
@@ -18,6 +19,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_float_psnr,
     &vmaf_fex_float_adm,
     &vmaf_fex_float_vif,
+    &vmaf_fex_float_motion,
     NULL
 };
 

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -1,0 +1,104 @@
+#include <errno.h>
+#include <math.h>
+#include <string.h>
+
+#include "common/convolution.h"
+#include "feature_collector.h"
+#include "feature_extractor.h"
+#include "motion.h"
+#include "motion_tools.h"
+
+#include "picture_copy.h"
+
+typedef struct MotionState {
+    size_t float_stride;
+    float *ref;
+    float *tmp;
+    float *blur[3];
+    VmafFeatureCollector *feature_collector;
+    unsigned index;
+    double score;
+} MotionState;
+
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
+{
+    MotionState *s = fex->priv;
+
+    s->float_stride = sizeof(float) * w;
+    s->ref = malloc(s->float_stride * h);
+    s->tmp = malloc(s->float_stride * h);
+    s->blur[0] = malloc(s->float_stride * h);
+    s->blur[1] = malloc(s->float_stride * h);
+    s->blur[2] = malloc(s->float_stride * h);
+    s->score = 0;
+
+    return 0;
+}
+
+static int extract(VmafFeatureExtractor *fex,
+                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   unsigned index, VmafFeatureCollector *feature_collector)
+{
+    MotionState *s = fex->priv;
+    int err = 0;
+
+    s->index = index;
+    unsigned blur_idx_0 = (index + 0) % 3;
+    unsigned blur_idx_1 = (index + 1) % 3;
+    unsigned blur_idx_2 = (index + 2) % 3;
+    s->feature_collector = feature_collector; //FIXME
+
+    picture_copy(s->ref, ref_pic);
+    convolution_f32_c_s(FILTER_5_s, 5, s->ref, s->blur[blur_idx_0], s->tmp,
+                        ref_pic->w[0], ref_pic->h[0],
+                        s->float_stride / sizeof(float),
+                        s->float_stride / sizeof(float));
+
+    if (index == 0)
+        return vmaf_feature_collector_append(feature_collector, "float_motion2",
+                                             0., index);
+
+    double score;
+    err = compute_motion(s->blur[blur_idx_2], s->blur[blur_idx_0],
+                         ref_pic->w[0], ref_pic->h[0],
+                         s->float_stride, s->float_stride, &score);
+    if (err) return err;
+
+    if (index == 1) return 0;
+    double score2;
+    err = compute_motion(s->blur[blur_idx_2], s->blur[blur_idx_1],
+                         ref_pic->w[0], ref_pic->h[0],
+                         s->float_stride, s->float_stride, &score2);
+    if (err) return err;
+    score2 = score2 < score ? score2 : score;
+    err = vmaf_feature_collector_append(feature_collector, "float_motion2",
+                                        score2, index - 1);
+
+    s->score = score;
+
+    if (err) return err;
+    return 0;
+}
+
+static int close(VmafFeatureExtractor *fex)
+{
+    MotionState *s = fex->priv;
+
+    if (s->ref) free(s->ref);
+    if (s->blur[0]) free(s->blur[0]);
+    if (s->blur[1]) free(s->blur[1]);
+    if (s->blur[2]) free(s->blur[2]);
+    if (s->tmp) free(s->tmp);
+
+    return vmaf_feature_collector_append(s->feature_collector, "float_motion2",
+                                         s->score, s->index);
+}
+
+VmafFeatureExtractor vmaf_fex_float_motion = {
+    .name = "float_motion",
+    .init = init,
+    .extract = extract,
+    .close = close,
+    .priv_size = sizeof(MotionState),
+};

--- a/libvmaf/src/feature/motion.h
+++ b/libvmaf/src/feature/motion.h
@@ -1,0 +1,1 @@
+int compute_motion(const float *ref, const float *dis, int w, int h, int ref_stride, int dis_stride, double *score);

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -213,16 +213,14 @@ const char *vmaf_version(void)
 int vmaf_write_output(VmafContext *vmaf, FILE *outfile,
                       enum VmafOutputFormat fmt)
 {
-    int err = 0;
+    RegisteredFeatureExtractors rfe = vmaf->registered_feature_extractors;
+    for (unsigned i = 0; i < rfe.cnt; i++)
+        vmaf_feature_extractor_context_close(rfe.fex_ctx[i]);
 
     switch (fmt) {
-    case VMAF_OUTPUT_FORMAT_NONE:
     case VMAF_OUTPUT_FORMAT_XML:
-        err = vmaf_write_output_xml(vmaf->feature_collector, outfile);
-        break;
+        return vmaf_write_output_xml(vmaf->feature_collector, outfile);
     default:
-        break;
+        return 0;
     }
-
-    return err;
 }

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -136,6 +136,9 @@ libvmaf_rc_sources = [
     src_dir + 'model.c',
     src_dir + 'unpickle.cpp',
     src_dir + 'svm.cpp',
+    feature_src_dir + 'common/cpu.c',
+    feature_src_dir + 'offset.c',
+    feature_src_dir + 'common/alignment.c',
     src_dir + 'picture.c',
     src_dir + 'mem.c',
     src_dir + 'picture.c',
@@ -162,6 +165,9 @@ libvmaf_rc_sources = [
     feature_src_dir + 'integer_psnr.c',
     feature_src_dir + 'float_psnr.c',
     feature_src_dir + 'psnr.c',
+    feature_src_dir + 'float_motion.c',
+    feature_src_dir + 'motion.c',
+    feature_src_dir + 'common/convolution.c',
 ]
 
 libvmaf_rc_include = include_directories(

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -40,7 +40,7 @@ int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile)
                 continue;
             if (!fc->feature_vector[j]->score[i].written)
                 continue;
-            fprintf(outfile, "%s=\"%.6f\" ",
+            fprintf(outfile, "%s=\"%.5f\" ",
                 fc->feature_vector[j]->name,
                 fc->feature_vector[j]->score[i].value
             );

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -48,6 +48,9 @@ test_feature_extractor = executable('test_feature_extractor',
      '../src/feature/float_vif.c',
      '../src/feature/vif.c',
      '../src/feature/vif_tools.c',
+     '../src/feature/float_motion.c',
+     '../src/feature/motion.c',
+     '../src/feature/common/convolution.c',
      '../src/feature/float_ssim.c',
      '../src/feature/iqa/math_utils.c',
      '../src/feature/iqa/convolve.c',
@@ -56,12 +59,12 @@ test_feature_extractor = executable('test_feature_extractor',
      '../src/feature/ssim.c',
      '../src/feature/integer_psnr.c',
      '../src/feature/float_psnr.c',
-     '../src/feature/psnr.c'],
+     '../src/feature/psnr.c',],
     include_directories : [libvmaf_inc, test_inc, '../src/'],
     dependencies : math_lib,
     objects : [
-        convolution_and_psnr_avx_static_lib.extract_all_objects(),
-    ],
+      convolution_and_psnr_avx_static_lib.extract_all_objects(),
+    ]
 )
 
 test('test_picture', test_picture)

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -133,6 +133,8 @@ void cli_parse(const int argc, char *const *const argv,
         }
     }
 
+    if (!settings->output_fmt)
+        settings->output_fmt = VMAF_OUTPUT_FORMAT_XML;
     if (!settings->y4m_path_ref)
         usage(argv[0], "Reference .y4m (-r/--reference) is required");
     if (!settings->y4m_path_ref)


### PR DESCRIPTION
Implements `float_motion` feature extractor, wrapping the existing float implementation.