### PR TITLE
libvmaf: implement vmaf_use_features_from_model

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -41,21 +41,15 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name)
 
     VmafFeatureExtractor *fex = NULL;
     for (unsigned i = 0; (fex = feature_extractor_list[i]); i++) {
-        /*
+        if (!fex->provided_features) continue;
         const char *fname = NULL;
-        for (unsigned j = 0; (fname = fex->feature[j]); j++) {
-            if (!strcmp(feature_name, fname))
+        for (unsigned j = 0; (fname = fex->provided_features[j]); j++) {
+            if (!strcmp(name, fname))
                 return fex;
         }
-        */
     }
     return NULL;
 }
-
-typedef struct VmafFeatureExtractorContext {
-    bool is_initialized, is_closed;
-    VmafFeatureExtractor *fex;
-} VmafFeatureExtractorContext;
 
 int vmaf_feature_extractor_context_create(VmafFeatureExtractorContext **fex_ctx,
                                           VmafFeatureExtractor *fex)

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -23,13 +23,16 @@ typedef struct VmafFeatureExtractor {
     void *priv;
     size_t priv_size;
     uint64_t flags;
-    const char *feature[];
+    const char **provided_features;
 } VmafFeatureExtractor;
 
 VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(char *name);
 VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name);
 
-typedef struct VmafFeatureExtractorContext VmafFeatureExtractorContext;
+typedef struct VmafFeatureExtractorContext {
+    bool is_initialized, is_closed;
+    VmafFeatureExtractor *fex;
+} VmafFeatureExtractorContext;
 
 int vmaf_feature_extractor_context_create(VmafFeatureExtractorContext **fex_ctx,
                                           VmafFeatureExtractor *fex);

--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -65,10 +65,16 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "'VMAF_feature_adm2_score'",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_float_adm = {
     .name = "float_adm",
     .init = init,
     .extract = extract,
     .close = close,
     .priv_size = sizeof(AdmState),
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -98,10 +98,16 @@ static int close(VmafFeatureExtractor *fex)
                                          s->score, s->index);
 }
 
+static const char *provided_features[] = {
+    "'VMAF_feature_motion2_score'",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_float_motion = {
     .name = "float_motion",
     .init = init,
     .extract = extract,
     .close = close,
     .priv_size = sizeof(MotionState),
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -61,10 +61,16 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "float_psnr",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_float_psnr = {
     .name = "float_psnr",
     .init = init,
     .extract = extract,
     .close = close,
     .priv_size = sizeof(PsnrState),
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -58,10 +58,16 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "float_ssim",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_float_ssim = {
     .name = "float_ssim",
     .init = init,
     .extract = extract,
     .close = close,
     .priv_size = sizeof(SsimState),
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -78,10 +78,17 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "'VMAF_feature_vif_scale0_score'", "'VMAF_feature_vif_scale1_score'",
+    "'VMAF_feature_vif_scale2_score'", "'VMAF_feature_vif_scale3_score'",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_float_vif = {
     .name = "float_vif",
     .init = init,
     .extract = extract,
     .close = close,
     .priv_size = sizeof(VifState),
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -53,9 +53,15 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "psnr_y", "psnr_cb", "psnr_cr",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_psnr = {
     .name = "psnr",
     .init = init,
     .extract = extract,
     .close = close,
+    .provided_features = provided_features,
 };

--- a/libvmaf/src/feature/integer_ssim.c
+++ b/libvmaf/src/feature/integer_ssim.c
@@ -221,9 +221,15 @@ static int close(VmafFeatureExtractor *fex)
     return 0;
 }
 
+static const char *provided_features[] = {
+    "ssim",
+    NULL
+};
+
 VmafFeatureExtractor vmaf_fex_ssim = {
     .name = "ssim",
     .init = init,
     .extract = extract,
     .close = close,
+    .provided_features = provided_features,
 };

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -15,11 +15,17 @@ static char *test_get_feature_extractor_by_name_and_feature_name()
 {
     cpu = cpu_autodetect(); //FIXME, see above
 
-    VmafFeatureExtractor *fex = NULL;
+    VmafFeatureExtractor *fex;
     fex = vmaf_get_feature_extractor_by_name("");
-    mu_assert("problem during vmaf_picture_unref", !fex);
-    fex = vmaf_get_feature_extractor_by_feature_name("");
-    mu_assert("problem during vmaf_picture_unref", !fex);
+    mu_assert("problem during vmaf_get_feature_extractor_by_name", !fex);
+    fex = vmaf_get_feature_extractor_by_name("float_vif");
+    mu_assert("problem vmaf_get_feature_extractor_by_name",
+              !strcmp(fex->name, "float_vif"));
+
+    fex =
+        vmaf_get_feature_extractor_by_feature_name("'VMAF_feature_adm2_score'");
+    mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
+              fex && !strcmp(fex->name, "float_adm"));
 
     return NULL;
 }


### PR DESCRIPTION
Implements `vmaf_use_features_from_model()`. Function call used for registering all feature extractors required by a specific model.