### PR TITLE
travis: use most recent clang package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
       gcc-8) sudo apt-get install -qq gcc-8 g++-8 ;;
       gcc-9) sudo apt-get install -qq gcc-9 g++-9 ;;
       clang-6.0) sudo apt-get install -qq clang-6.0 ;;
-      clang-10) sudo apt-get install -qq clang-10 ;;
+      clang) sudo apt-get install -qq clang ;;
       esac
     fi
   - export CC="ccache $CC" CXX="ccache $CXX"
@@ -56,8 +56,8 @@ matrix:
     - name: libvmaf GCC-9
       env: CC=gcc-9 CXX=g++-9
       script: *base-gcc-script
-    - name: libvmaf Clang-10
-      env: CC=clang-10 CXX=clang++-10
+    - name: libvmaf Clang
+      env: CC=clang CXX=clang++
       script: *base-gcc-script
     - name: libvmaf AppleClang
       os: osx


### PR DESCRIPTION
Since `clang-10` doesn't seem to be an installable package any more, let's just use the most recent `clang` package.