### PR TITLE
libvmaf: add pixel offset for float feature extractors

### DIFF
--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -40,8 +40,8 @@ static int extract(VmafFeatureExtractor *fex,
     AdmState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic);
-    picture_copy(s->dist, dist_pic);
+    picture_copy(s->ref, ref_pic, -128);
+    picture_copy(s->dist, dist_pic, -128);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -49,7 +49,7 @@ static int extract(VmafFeatureExtractor *fex,
     unsigned blur_idx_2 = (index + 2) % 3;
     s->feature_collector = feature_collector; //FIXME
 
-    picture_copy(s->ref, ref_pic);
+    picture_copy(s->ref, ref_pic, -128);
     convolution_f32_c_s(FILTER_5_s, 5, s->ref, s->blur[blur_idx_0], s->tmp,
                         ref_pic->w[0], ref_pic->h[0],
                         s->float_stride / sizeof(float),

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -39,8 +39,8 @@ static int extract(VmafFeatureExtractor *fex,
     PsnrState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic);
-    picture_copy(s->dist, dist_pic);
+    picture_copy(s->ref, ref_pic, 0);
+    picture_copy(s->dist, dist_pic, 0);
 
     double score;
     err = compute_psnr(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -37,8 +37,8 @@ static int extract(VmafFeatureExtractor *fex,
     SsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic);
-    picture_copy(s->dist, dist_pic);
+    picture_copy(s->ref, ref_pic, 0);
+    picture_copy(s->dist, dist_pic, 0);
 
     double score, l_score, c_score, s_score;
     err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -40,8 +40,8 @@ static int extract(VmafFeatureExtractor *fex,
     VifState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic);
-    picture_copy(s->dist, dist_pic);
+    picture_copy(s->ref, ref_pic, -128);
+    picture_copy(s->dist, dist_pic, -128);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/picture_copy.c
+++ b/libvmaf/src/feature/picture_copy.c
@@ -2,14 +2,14 @@
 
 #include <libvmaf/picture.h>
 
-void picture_copy(float *dst, VmafPicture *src)
+void picture_copy(float *dst, VmafPicture *src, int offset)
 {
     float *float_data = dst;
     uint8_t *data = src->data[0];
 
     for (unsigned i = 0; i < src->h[0]; i++) {
         for (unsigned j = 0; j < src->w[0]; j++) {
-            float_data[j] = (float) data[j];
+            float_data[j] = (float) data[j] + offset;
         }
         float_data += src->w[0];
         data += src->stride[0];

--- a/libvmaf/src/feature/picture_copy.h
+++ b/libvmaf/src/feature/picture_copy.h
@@ -1,1 +1,1 @@
-void picture_copy(float *dst, VmafPicture *src);
+void picture_copy(float *dst, VmafPicture *src, int offset);


### PR DESCRIPTION
A few `libvmaf` feature extractors require an offset of -128, this PR implements that in `libvmaf_rc` for the wrapped `VmafFeatureExtractor`s.