### PR TITLE
libvmaf/feature: use aligned_malloc for float buffers

### DIFF
--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -7,6 +7,7 @@
 
 #include "adm.h"
 #include "adm_options.h"
+#include "mem.h"
 #include "picture_copy.h"
 
 typedef struct AdmState {
@@ -20,9 +21,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 {
     AdmState *s = fex->priv;
     s->float_stride = sizeof(float) * w;
-    s->ref = malloc(s->float_stride * h);
+    s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
-    s->dist = malloc(s->float_stride * h);
+    s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
     return 0;
@@ -60,8 +61,8 @@ static int extract(VmafFeatureExtractor *fex,
 static int close(VmafFeatureExtractor *fex)
 {
     AdmState *s = fex->priv;
-    if (s->ref) free(s->ref);
-    if (s->dist) free(s->dist);
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
     return 0;
 }
 

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -5,6 +5,7 @@
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
+#include "mem.h"
 #include "psnr.h"
 #include "picture_copy.h"
 
@@ -19,9 +20,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 {
     PsnrState *s = fex->priv;
     s->float_stride = sizeof(float) * w;
-    s->ref = malloc(s->float_stride * h);
+    s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
-    s->dist = malloc(s->float_stride * h);
+    s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
     return 0;
@@ -56,8 +57,8 @@ static int extract(VmafFeatureExtractor *fex,
 static int close(VmafFeatureExtractor *fex)
 {
     PsnrState *s = fex->priv;
-    if (s->ref) free(s->ref);
-    if (s->dist) free(s->dist);
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
     return 0;
 }
 

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -3,6 +3,7 @@
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
+#include "mem.h"
 #include "ssim.h"
 #include "picture_copy.h"
 
@@ -17,9 +18,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 {
     SsimState *s = fex->priv;
     s->float_stride = sizeof(float) * w;
-    s->ref = malloc(s->float_stride * h);
+    s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
-    s->dist = malloc(s->float_stride * h);
+    s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
     return 0;
@@ -53,8 +54,8 @@ static int extract(VmafFeatureExtractor *fex,
 static int close(VmafFeatureExtractor *fex)
 {
     SsimState *s = fex->priv;
-    if (s->ref) free(s->ref);
-    if (s->dist) free(s->dist);
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
     return 0;
 }
 

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -4,6 +4,7 @@
 
 #include "feature_collector.h"
 #include "feature_extractor.h"
+#include "mem.h"
 
 #include "vif.h"
 #include "vif_options.h"
@@ -20,9 +21,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 {
     VifState *s = fex->priv;
     s->float_stride = sizeof(float) * w;
-    s->ref = malloc(s->float_stride * h);
+    s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
-    s->dist = malloc(s->float_stride * h);
+    s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
     return 0;
@@ -73,8 +74,8 @@ static int extract(VmafFeatureExtractor *fex,
 static int close(VmafFeatureExtractor *fex)
 {
     VifState *s = fex->priv;
-    if (s->ref) free(s->ref);
-    if (s->dist) free(s->dist);
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
     return 0;
 }
 


### PR DESCRIPTION
AVX2 requires aligned buffers.  Happened to work fine on some platforms, but only because of UB.