### PR TITLE
Motion comparison for all frames

### DIFF
--- a/libvmaf/tools/read_frame.c
+++ b/libvmaf/tools/read_frame.c
@@ -59,7 +59,6 @@ fail_or_end:
  */
 static int read_image_b(FILE * rfile, float *buf, float off, int width, int height, int stride)
 {
-	// printf("buf: %p -> %f\n", buf, *buf);
     char *byte_ptr = (char *)buf;
 	unsigned char *tmp_buf = 0;
 	int i, j;
@@ -91,7 +90,6 @@ static int read_image_b(FILE * rfile, float *buf, float off, int width, int heig
 
 		byte_ptr += stride;
 	}
-    //printf("Advanced %zu bytes\n", height * width);
 	ret = 0;
 
 fail_or_end:
@@ -263,20 +261,18 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     int h = user_data->height;
     int ret;
     
-    if (offset > 0){
+    // if we have given a valid (non-negative) offset value, seek to that frame. This if statement
+    // should only be entered from the second pass in motion.c for comparing motion between all frames.
+    if (offset >= 0){
         fseek(user_data->dis_rfile, offset, SEEK_SET);
-    } else if (offset == -1){
-        fseek(user_data->dis_rfile, 0, SEEK_SET);
     }
     // read dis y
     if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv444p"))
     {
-        //printf("no ref read_image_b entered\n");
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
     else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
     {
-        //printf("no ref read_image_w entered\n");
         ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
     else
@@ -286,19 +282,12 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     }
     if (ret)
     {
-        // printf("ret exit pre fread call\n");
         if (feof(user_data->dis_rfile))
         {
             ret = 2; // OK if end of file
         }
         return ret;
     }
-
-    // if (offset > 0){
-    //     fseek(user_data->dis_rfile, offset, SEEK_SET);
-    // } else if (offset == -1){
-    //     fseek(user_data->dis_rfile, 0, SEEK_SET);
-    // }
     // dis skip u and v
     if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv444p"))
     {
@@ -307,7 +296,6 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
             fprintf(stderr, "dis fread u and v failed.\n");
             goto fail_or_end;
         }
-        //printf("read %zu bytes\n", (size_t)user_data->offset);
         
     }
     else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))

--- a/libvmaf/tools/read_frame.h
+++ b/libvmaf/tools/read_frame.h
@@ -41,7 +41,7 @@ struct noref_data
 
 int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_byte, void *s);
 
-int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s);
+int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s, int offset);
 
 int get_frame_offset(const char *fmt, int w, int h, size_t *offset);
 


### PR DESCRIPTION
Changes within this pull request:

- Modified _motion.c_ to extend from only comparing adjacent frames to comparing all frames motion-wise
- Modified the _read_noref_frame_ function within _read_frame.c_ to accommodate the necessary file seeking for the N^2 comparison
- Modified _read_frame.h_ to comply with the necessary function stub declaration (i.e. the additional _int motion_ parameter is included in the '.h' definition