### PR TITLE
libvmaf/vmaf_rc: add support for high bitdepth input

### DIFF
--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -41,8 +41,8 @@ static int extract(VmafFeatureExtractor *fex,
     AdmState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128);
-    picture_copy(s->dist, dist_pic, -128);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -53,7 +53,7 @@ static int extract(VmafFeatureExtractor *fex,
     unsigned blur_idx_2 = (index + 2) % 3;
     s->feature_collector = feature_collector; //FIXME
 
-    picture_copy(s->ref, ref_pic, -128);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
     convolution_f32_c_s(FILTER_5_s, 5, s->ref, s->blur[blur_idx_0], s->tmp,
                         ref_pic->w[0], ref_pic->h[0],
                         s->float_stride / sizeof(float),

--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -38,8 +38,8 @@ static int extract(VmafFeatureExtractor *fex,
     MsSsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0);
-    picture_copy(s->dist, dist_pic, 0);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
 
     double score, l_scores[5], c_scores[5], s_scores[5];
     err = compute_ms_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -40,8 +40,8 @@ static int extract(VmafFeatureExtractor *fex,
     PsnrState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0);
-    picture_copy(s->dist, dist_pic, 0);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
 
     double score;
     err = compute_psnr(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -38,8 +38,8 @@ static int extract(VmafFeatureExtractor *fex,
     SsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0);
-    picture_copy(s->dist, dist_pic, 0);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
 
     double score, l_score, c_score, s_score;
     err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -41,8 +41,8 @@ static int extract(VmafFeatureExtractor *fex,
     VifState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128);
-    picture_copy(s->dist, dist_pic, -128);
+    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/picture_copy.c
+++ b/libvmaf/src/feature/picture_copy.c
@@ -2,8 +2,26 @@
 
 #include <libvmaf/picture.h>
 
-void picture_copy(float *dst, VmafPicture *src, int offset)
+void picture_copy_hbd(float *dst, VmafPicture *src, int offset)
 {
+    float *float_data = dst;
+    uint16_t *data = src->data[0];
+
+    for (unsigned i = 0; i < src->h[0]; i++) {
+        for (unsigned j = 0; j < src->w[0]; j++) {
+            float_data[j] = (float) data[j] / 4.0 + offset;
+        }
+        float_data += src->w[0];
+        data += src->stride[0] / 2;
+    }
+    return;
+}
+
+void picture_copy(float *dst, VmafPicture *src, int offset, unsigned bpc)
+{
+    if (bpc > 8)
+        return picture_copy_hbd(dst, src, offset);
+
     float *float_data = dst;
     uint8_t *data = src->data[0];
 

--- a/libvmaf/src/feature/picture_copy.h
+++ b/libvmaf/src/feature/picture_copy.h
@@ -1,1 +1,1 @@
-void picture_copy(float *dst, VmafPicture *src, int offset);
+void picture_copy(float *dst, VmafPicture *src, int offset, unsigned bpc);

--- a/libvmaf/tools/yuv_input.c
+++ b/libvmaf/tools/yuv_input.c
@@ -42,22 +42,23 @@ static yuv_input *yuv_input_open(FILE *_fin,
     yuv->height = height;
     yuv->pix_fmt = pix_fmt;
     yuv->bitdepth = bitdepth;
+    bool hbd = yuv->bitdepth > 8;
 
     switch (yuv->pix_fmt) {
     case VMAF_PIX_FMT_YUV420P:
         yuv->src_c_dec_h=yuv->dst_c_dec_h=yuv->src_c_dec_v=yuv->dst_c_dec_v=2;
-        yuv->dst_buf_sz=yuv->width*yuv->height
-         +2*((yuv->width+1)/2)*((yuv->height+1)/2);
+        yuv->dst_buf_sz = (yuv->width*yuv->height
+         +2*((yuv->width+1)/2)*((yuv->height+1)/2)) << hbd;
         break;
     case VMAF_PIX_FMT_YUV422P:
         yuv->src_c_dec_h=yuv->dst_c_dec_h=2;
         yuv->src_c_dec_v=yuv->dst_c_dec_v=1;
-        yuv->dst_buf_sz = yuv->width*yuv->height +
-            2*(((yuv->width+1)/2) * yuv->height);
+        yuv->dst_buf_sz = (yuv->width*yuv->height +
+            2*(((yuv->width+1)/2) * yuv->height)) << hbd;
         break;
     case VMAF_PIX_FMT_YUV444P:
         yuv->src_c_dec_h=yuv->dst_c_dec_h=yuv->src_c_dec_v=yuv->dst_c_dec_v=1;
-        yuv->dst_buf_sz=yuv->width*yuv->height*3;
+        yuv->dst_buf_sz = (yuv->width*yuv->height*3) << hbd;
         break;
     default:
         goto fail; 


### PR DESCRIPTION
This PR adds support for high bitdepth inputs.