### PR TITLE
fix libvmaf_rc regression

### DIFF
--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -38,8 +38,8 @@ static int extract(VmafFeatureExtractor *fex,
     MsSsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
+    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
 
     double score, l_scores[5], c_scores[5], s_scores[5];
     err = compute_ms_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -38,8 +38,8 @@ static int extract(VmafFeatureExtractor *fex,
     SsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
+    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
 
     double score, l_score, c_score, s_score;
     err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/python/test/vmafrc_test.py
+++ b/python/test/vmafrc_test.py
@@ -48,8 +48,8 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 3.895352291666667, places=8)
         self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9345877291666667, places=8)
         self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 30.7550666667, places=8)
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.86322654166666657, places=8)  # FIXME: this is a regression from previous comment
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9632406874999999, places=8)  # FIXME: this is a regression from previous comment
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.86322654166666657, places=8)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9632406874999999, places=8)
 
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'],0.9999998541666666, places=8)
@@ -255,9 +255,9 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFRC_vif_scale3_score'], 0.9159719583333334, places=8)
         self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 3.895352291666667, places=8)
         self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9345877291666667, places=8)
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 30.780577083333331, places=8)  # FIXME
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.86322654166666657, places=8)  # FIXME
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9632406874999999, places=8)  # FIXME
+        self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 30.780577083333331, places=8)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.86322654166666657, places=8)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9632406874999999, places=8)
 
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999998541666666, places=8)
@@ -265,7 +265,7 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale3_score'], 0.9999991458333334, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_motion2_score'], 3.895352291666667, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_adm2_score'], 1.0, places=8)
-        # self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 72.0, places=8)  # FIXME
+        self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 72.0, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=8)
 
@@ -311,9 +311,9 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFRC_vif_scale3_score'], 0.9993221999999999, places=8)
         # self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 0.7523685999999999, places=8)  # FIXME
         self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9981770000000001, places=8)
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 48.81622, places=8)  # FIXME
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.99566, places=8)  # FIXME
-        # self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9993778000000001, places=8)  # FIXME
+        self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 48.81622, places=8)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.99566, places=8)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9993778000000001, places=8)
 
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=8)
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999990000000001, places=8)
@@ -321,11 +321,11 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale3_score'], 0.9999990000000001, places=8)
         # self.assertAlmostEqual(results[1]['VMAFRC_motion2_score'], 0.7523685999999999, places=8)  # FIXME
         self.assertAlmostEqual(results[1]['VMAFRC_adm2_score'], 1.0, places=8)
-        # self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 72.0, places=8)  # FIXME
-        # self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=8)  # FIXME
-        # self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=8)  # FIXME
+        self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 72.0, places=8)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=8)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=8)
 
-        # self.assertAlmostEqual(results[0]['VMAFRC_score'], 97.90585999999999, places=8)  # FIXME
+        # self.assertAlmostEqual(results[0]['VMAFRC_score'], 97.90585999999999, places=8) # FIXME
         self.assertAlmostEqual(results[1]['VMAFRC_score'], 98.47138, places=8)
 
 


### PR DESCRIPTION
Fixes the regression introduced when 10-bit input was implemented. PSNR, SSIM, MS-SSIM feature extractors do not use a pixel value offset.