### PR TITLE
libvmaf: implement VmafThreadPool api

### DIFF
--- a/libvmaf/src/fex_ctx_vector.c
+++ b/libvmaf/src/fex_ctx_vector.c
@@ -1,0 +1,52 @@
+#include <errno.h>
+
+#include "feature/feature_extractor.h"
+#include "fex_ctx_vector.h"
+
+int feature_extractor_vector_init(RegisteredFeatureExtractors *rfe)
+{
+    rfe->cnt = 0;
+    rfe->capacity = 8;
+    size_t sz = sizeof(*(rfe->fex_ctx)) * rfe->capacity;
+    rfe->fex_ctx = malloc(sz);
+    if (!rfe->fex_ctx) return -ENOMEM;
+    memset(rfe->fex_ctx, 0, sz);
+    return 0;
+}
+
+int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
+                                    VmafFeatureExtractorContext *fex_ctx)
+{
+    if (!rfe) return -EINVAL;
+    if (!fex_ctx) return -EINVAL;
+
+    for (unsigned i = 0; i < rfe->cnt; i++) {
+        if (!strcmp(rfe->fex_ctx[i]->fex->name, fex_ctx->fex->name))
+            return vmaf_feature_extractor_context_destroy(fex_ctx);
+    }
+
+    if (rfe->cnt >= rfe->capacity) {
+        size_t capacity = rfe->capacity * 2;
+        VmafFeatureExtractorContext **fex_ctx =
+            realloc(rfe->fex_ctx, sizeof(*(rfe->fex_ctx)) * capacity);
+        if (!fex_ctx) return -ENOMEM;
+        rfe->fex_ctx = fex_ctx;
+        rfe->capacity = capacity;
+        for (unsigned i = rfe->cnt; i < rfe->capacity; i++)
+            rfe->fex_ctx[i] = NULL;
+    }
+
+    rfe->fex_ctx[rfe->cnt++] = fex_ctx;
+    return 0;
+}
+
+void feature_extractor_vector_destroy(RegisteredFeatureExtractors *rfe)
+{
+    if (!rfe) return;
+    for (unsigned i = 0; i < rfe->cnt; i++) {
+        vmaf_feature_extractor_context_close(rfe->fex_ctx[i]);
+        vmaf_feature_extractor_context_destroy(rfe->fex_ctx[i]);
+    }
+    free(rfe->fex_ctx);
+    return;
+}

--- a/libvmaf/src/fex_ctx_vector.h
+++ b/libvmaf/src/fex_ctx_vector.h
@@ -1,0 +1,18 @@
+#ifndef __VMAF_SRC_FEX_CTX_VECTOR_H__
+#define __VMAF_SRC_FEX_CTX_VECTOR_H__
+
+#include "feature/feature_extractor.h"
+
+typedef struct {
+    VmafFeatureExtractorContext **fex_ctx;
+    unsigned cnt, capacity;
+} RegisteredFeatureExtractors;
+
+int feature_extractor_vector_init(RegisteredFeatureExtractors *rfe);
+
+int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
+                                    VmafFeatureExtractorContext *fex_ctx);
+
+void feature_extractor_vector_destroy(RegisteredFeatureExtractors *rfe);
+
+#endif /* __VMAF_SRC_FEX_CTX_VECTOR_H__ */

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -8,69 +8,17 @@
 #include "feature/common/cpu.h"
 #include "feature/feature_extractor.h"
 #include "feature/feature_collector.h"
+#include "fex_ctx_vector.h"
 #include "model.h"
 #include "output.h"
 #include "picture.h"
 #include "predict.h"
-
-typedef struct {
-    VmafFeatureExtractorContext **fex_ctx;
-    unsigned cnt, capacity;
-} RegisteredFeatureExtractors;
 
 typedef struct VmafContext {
     VmafConfiguration cfg;
     VmafFeatureCollector *feature_collector;
     RegisteredFeatureExtractors registered_feature_extractors;
 } VmafContext;
-
-static int feature_extractor_vector_init(RegisteredFeatureExtractors *rfe)
-{
-    rfe->cnt = 0;
-    rfe->capacity = 8;
-    size_t sz = sizeof(*(rfe->fex_ctx)) * rfe->capacity;
-    rfe->fex_ctx = malloc(sz);
-    if (!rfe->fex_ctx) return -ENOMEM;
-    memset(rfe->fex_ctx, 0, sz);
-    return 0;
-}
-
-static int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
-                                           VmafFeatureExtractorContext *fex_ctx)
-{
-    if (!rfe) return -EINVAL;
-    if (!fex_ctx) return -EINVAL;
-
-    for (unsigned i = 0; i < rfe->cnt; i++) {
-        if (!strcmp(rfe->fex_ctx[i]->fex->name, fex_ctx->fex->name))
-            return vmaf_feature_extractor_context_destroy(fex_ctx);
-    }
-
-    if (rfe->cnt >= rfe->capacity) {
-        size_t capacity = rfe->capacity * 2;
-        VmafFeatureExtractorContext **fex_ctx =
-            realloc(rfe->fex_ctx, sizeof(*(rfe->fex_ctx)) * capacity);
-        if (!fex_ctx) return -ENOMEM;
-        rfe->fex_ctx = fex_ctx;
-        rfe->capacity = capacity;
-        for (unsigned i = rfe->cnt; i < rfe->capacity; i++)
-            rfe->fex_ctx[i] = NULL;
-    }
-
-    rfe->fex_ctx[rfe->cnt++] = fex_ctx;
-    return 0;
-}
-
-static void feature_extractor_vector_destroy(RegisteredFeatureExtractors *rfe)
-{
-    if (!rfe) return;
-    for (unsigned i = 0; i < rfe->cnt; i++) {
-        vmaf_feature_extractor_context_close(rfe->fex_ctx[i]);
-        vmaf_feature_extractor_context_destroy(rfe->fex_ctx[i]);
-    }
-    free(rfe->fex_ctx);
-    return;
-}
 
 enum vmaf_cpu cpu;
 // ^ FIXME, this is a global in the old libvmaf

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -182,6 +182,7 @@ libvmaf_rc_sources = [
     src_dir + 'picture.c',
     src_dir + 'output.c',
     src_dir + 'fex_ctx_vector.c',
+    src_dir + 'thread_pool.c',
 ]
 
 libvmaf_rc = both_libraries(

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -181,6 +181,7 @@ libvmaf_rc_sources = [
     src_dir + 'mem.c',
     src_dir + 'picture.c',
     src_dir + 'output.c',
+    src_dir + 'fex_ctx_vector.c',
 ]
 
 libvmaf_rc = both_libraries(

--- a/libvmaf/src/thread_pool.c
+++ b/libvmaf/src/thread_pool.c
@@ -1,0 +1,180 @@
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct VmafThreadPoolJob {
+    void (*func)(void *data);
+    void *data;
+    struct VmafThreadPoolJob *next;
+} VmafThreadPoolJob;
+
+typedef struct VmafTreadPool {
+    struct {
+        pthread_mutex_t lock;
+        pthread_cond_t empty;
+        VmafThreadPoolJob *head, *tail;
+    } queue;
+    pthread_cond_t working;
+    unsigned n_threads;
+    unsigned n_working;
+    bool stop;
+} VmafThreadPool;
+
+static VmafThreadPoolJob *vmaf_thread_pool_fetch_job(VmafThreadPool *pool)
+{
+    if (!pool) return NULL;
+    if (!pool->queue.head) return NULL;
+
+    VmafThreadPoolJob *job = pool->queue.head;
+    if (!job->next) {
+        pool->queue.head = NULL;
+        pool->queue.tail = NULL;
+    } else {
+        pool->queue.head = job->next;
+    }
+    return job;
+}
+
+static void vmaf_thread_pool_job_destroy(VmafThreadPoolJob *job)
+{
+    if (!job) return;
+    if (job->data) free(job->data);
+    free(job);
+}
+
+static void *vmaf_thread_pool_runner(void *p)
+{
+    VmafThreadPool *pool = p;
+
+    for (;;) {
+        pthread_mutex_lock(&(pool->queue.lock));
+        if (!pool->queue.head && !pool->stop)
+            pthread_cond_wait(&(pool->queue.empty), &(pool->queue.lock));
+        if (pool->stop) break;
+        VmafThreadPoolJob *job = vmaf_thread_pool_fetch_job(pool);
+        pool->n_working++;
+        pthread_mutex_unlock(&(pool->queue.lock));
+        if (job) {
+            job->func(job->data);
+            vmaf_thread_pool_job_destroy(job);
+        }
+        pthread_mutex_lock(&(pool->queue.lock));
+        pool->n_working--;
+        if (!pool->stop && pool->n_working == 0 && !pool->queue.head)
+            pthread_cond_signal(&(pool->working));
+        pthread_mutex_unlock(&(pool->queue.lock));
+    }
+
+    if (--(pool->n_threads) == 0)
+        pthread_cond_signal(&(pool->working));
+
+    pthread_mutex_unlock(&(pool->queue.lock));
+    return NULL;
+}
+
+int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
+{
+    if (!pool) return -EINVAL;
+    if (!n_threads) return -EINVAL;
+
+    VmafThreadPool *const p = *pool = malloc(sizeof(*p));
+    if (!p) return -ENOMEM;
+    memset(p, 0, sizeof(*p));
+    p->n_threads = n_threads;
+
+    pthread_mutex_init(&(p->queue.lock), NULL);
+    pthread_cond_init(&(p->queue.empty), NULL);
+    pthread_cond_init(&(p->working), NULL);
+
+    for (unsigned i = 0; i < n_threads; i++) {
+        pthread_t thread;
+        pthread_create(&thread, NULL, vmaf_thread_pool_runner, p);
+        pthread_detach(thread);
+    }
+
+    return 0;
+}
+
+int vmaf_thread_pool_enqueue(VmafThreadPool *pool, void (*func)(void *data),
+                             void *data, size_t data_sz)
+{
+    if (!pool) return -EINVAL;
+    if (!func) return -EINVAL;
+
+    VmafThreadPoolJob *job = malloc(sizeof(*job));
+    if (!job) return -ENOMEM;
+    memset(job, 0, sizeof(*job));
+    job->func = func;
+    if (data) {
+        job->data = malloc(data_sz);
+        if (!job->data) goto free_job;
+        memcpy(job->data, data, data_sz);
+    }
+
+    pthread_mutex_lock(&(pool->queue.lock));
+
+    if (!pool->queue.head) {
+        pool->queue.head = job;
+        pool->queue.tail = pool->queue.head;
+    } else {
+        pool->queue.tail->next = job;
+        pool->queue.tail = job;
+    }
+
+    pthread_cond_broadcast(&(pool->queue.empty));
+    pthread_mutex_unlock(&(pool->queue.lock));
+
+    return 0;
+
+free_job:
+    free(job);
+    return -ENOMEM;
+}
+
+int vmaf_thread_pool_wait(VmafThreadPool *pool)
+{
+    if (!pool) return -EINVAL;
+
+    pthread_mutex_lock(&(pool->queue.lock));
+
+    for (;;) {
+        if ((!pool->stop && pool->n_working != 0) ||
+            (pool->stop && pool->n_threads != 0))
+        {
+            pthread_cond_wait(&(pool->working), &(pool->queue.lock));
+        } else {
+            break;
+        }
+    }
+
+    pthread_mutex_unlock(&(pool->queue.lock));
+
+    return 0;
+}
+int vmaf_thread_pool_destroy(VmafThreadPool *pool)
+{
+    if (!pool) return -EINVAL;
+    pthread_mutex_lock(&(pool->queue.lock));
+
+    VmafThreadPoolJob *job = pool->queue.head;
+    while (job) {
+        VmafThreadPoolJob *next_job = job->next;
+        vmaf_thread_pool_job_destroy(job);
+        job = next_job;
+    }
+
+    pool->stop = true;
+    pthread_cond_broadcast(&(pool->queue.empty));
+    pthread_mutex_unlock(&(pool->queue.lock));
+
+    vmaf_thread_pool_wait(pool);
+
+    pthread_mutex_destroy(&(pool->queue.lock));
+    pthread_cond_destroy(&(pool->queue.empty));
+    pthread_cond_destroy(&(pool->working));
+
+    free(pool);
+    return 0;
+}

--- a/libvmaf/src/thread_pool.h
+++ b/libvmaf/src/thread_pool.h
@@ -1,0 +1,17 @@
+#ifndef __VMAF_THREAD_POOL_H__
+#define __VMAF_THREAD_POOL_H__
+
+#include <pthread.h>
+
+typedef struct VmafThreadPool VmafThreadPool;
+
+int vmaf_thread_pool_create(VmafThreadPool **tpool, unsigned n_threads);
+
+int vmaf_thread_pool_enqueue(VmafThreadPool *pool, void (*func)(void *data),
+                             void *data, size_t data_sz);
+
+int vmaf_thread_pool_wait(VmafThreadPool *pool);
+
+int vmaf_thread_pool_destroy(VmafThreadPool *tpool);
+
+#endif /* __VMAF_THREAD_POOL_H__ */

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -10,6 +10,12 @@ test_feature_collector = executable('test_feature_collector',
     include_directories : [libvmaf_inc, test_inc, '../src/feature/'],
 )
 
+test_thread_pool = executable('test_thread_pool',
+    ['test.c', 'test_thread_pool.c', '../src/thread_pool.c'],
+    include_directories : [libvmaf_inc, test_inc, '../src/'],
+    dependencies : thread_lib,
+)
+
 test_model = executable('test_model',
     ['test.c', 'test_model.c', '../src/svm.cpp', '../src/unpickle.cpp'],
     include_directories : [libvmaf_inc, test_inc, opencontainers_include,
@@ -45,6 +51,7 @@ test_feature_extractor = executable('test_feature_extractor',
 
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
+test('test_thread_pool', test_thread_pool)
 test('test_model', test_model)
 test('test_predict', test_predict)
 test('test_feature_extractor', test_feature_extractor)

--- a/libvmaf/test/test_thread_pool.c
+++ b/libvmaf/test/test_thread_pool.c
@@ -1,0 +1,67 @@
+#include <stdint.h>
+
+#include "feature/common/cpu.h"
+#include "test.h"
+#include "thread_pool.h"
+
+static void fn_a(void *data)
+{
+    (void) data;
+    printf("thread ");
+}
+
+static void fn_b(void *data)
+{
+    (void) data;
+    printf("pool ");
+}
+
+static void fn_c(void *data)
+{
+    (void) data;
+    printf("test ");
+}
+
+typedef struct Fps {
+    unsigned num, den;
+} Fps;
+
+static void fn_d(void *data)
+{
+    Fps *fps = data;
+    printf("FPS: %d/%d ", fps->num, fps->den);
+}
+
+static char *test_thread_pool_create_enqueue_wait_and_destroy()
+{
+    int err;
+
+    VmafThreadPool *pool;
+    unsigned n_threads = 8;
+
+    err = vmaf_thread_pool_create(&pool, n_threads);
+    mu_assert("problem during vmaf_thread_pool_init", !err);
+    err = vmaf_thread_pool_enqueue(pool, fn_a, NULL, 0);
+    mu_assert("problem during vmaf_thread_pool_enqueue", !err);
+    err = vmaf_thread_pool_enqueue(pool, fn_b, NULL, 0);
+    mu_assert("problem during vmaf_thread_pool_enqueue", !err);
+    err = vmaf_thread_pool_enqueue(pool, fn_c, NULL, 0);
+    mu_assert("problem during vmaf_thread_pool_enqueue", !err);
+    Fps fps = { 24, 1 };
+    err = vmaf_thread_pool_enqueue(pool, fn_d, &fps, sizeof(fps));
+    mu_assert("problem during vmaf_thread_pool_enqueue with data", !err);
+    err = vmaf_thread_pool_wait(pool);
+    mu_assert("problem during vmaf_thread_pool_wait", !err);
+    err = vmaf_thread_pool_destroy(pool);
+    mu_assert("problem during vmaf_thread_pool_destroy", !err);
+
+    printf("\n");
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_thread_pool_create_enqueue_wait_and_destroy);
+    return NULL;
+}


### PR DESCRIPTION
Implements the `VmafThreadPool` api, and also a second commit which opens the `fex_ctx_vector` api. One more commit is coming, which will tie these two things together and give frame parallelism and multithreaded feature extraction.