### PR TITLE
AppVeyor: Re-add artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
   - set "CXXFLAGS=-static %CXXFLAGS%"
   - cd libvmaf
   - meson setup --backend=ninja --default-library=static --buildtype=release --prefix="%CD%/install" build
-  - ninja -vC build instal
+  - ninja -vC build install
 
 test_script:
   - ninja -vC build test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ os: Visual Studio 2019
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  LDFLAGS: -static-libgcc -static-libstdc++
   matrix:
     #- arch: x86
     #  compiler: msvc2015
@@ -43,14 +44,17 @@ install:
 
 build_script:
   - echo Building on %arch% with %compiler%
+  - set "CFLAGS=-static %CFLAGS%"
+  - set "CXXFLAGS=-static %CXXFLAGS%"
   - cd libvmaf
-  - meson --backend=ninja build
-  - ninja -vC build
+  - meson setup --backend=ninja --default-library=static --buildtype=release --prefix="%CD%/install" build
+  - ninja -vC build instal
 
 test_script:
   - ninja -vC build test
 
-after_build: 7z a vmaf-win-%arch%.zip build\**\*.*
+after_build:
+  - 7z a vmaf-win-%arch%.zip install\**\*.*
 
 artifacts:
   - path: libvmaf\**\*.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,12 +50,13 @@ build_script:
 test_script:
   - ninja -vC build test
 
-after_build: 7z a vmaf-win-%arch%.zip build\*.*
+after_build: 7z a vmaf-win-%arch%.zip build\**\*.*
 
 artifacts:
-  - path: libvmaf\build\*.zip
+  - path: libvmaf\**\*.zip
   - path: libvmaf\build\src\libvmaf*.*
   - path: libvmaf\build\tools\*vmaf*.exe
+  - path: libvmaf\build\meson-logs\*.txt
 
 cache:
   - 'C:\msys64\home\appveyor\.ccache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
 test_script:
   - ninja -vC build test
 
-after_build: 7z a vmaf-win-%arch%.zip libvmaf\build\*.*
+after_build: 7z a vmaf-win-%arch%.zip build\*.*
 
 artifacts:
   - path: libvmaf\build\*.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,9 +50,12 @@ build_script:
 test_script:
   - ninja -vC build test
 
+after_build: 7z a vmaf-win-$(arch).zip libvmaf\build\*.*
+
 artifacts:
-    - path: libvmaf\build\src\libvmaf*.*
-    - path: libvmaf\build\tools\*vmaf*.exe
+  - path: libvmaf\build\*.zip
+  - path: libvmaf\build\src\libvmaf*.*
+  - path: libvmaf\build\tools\*vmaf*.exe
 
 cache:
   - 'C:\msys64\home\appveyor\.ccache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,9 @@ build_script:
 test_script:
   - ninja -vC build test
 
+artifacts:
+    - path: libvmaf\**\*vmaf*.*
+
 cache:
   - 'C:\msys64\home\appveyor\.ccache'
   - 'C:\msys64\var\cache\pacman\pkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,8 @@ test_script:
   - ninja -vC build test
 
 artifacts:
-    - path: libvmaf\**\*vmaf*.*
+    - path: libvmaf\build\src\libvmaf*.*
+    - path: libvmaf\build\tools\*vmaf*.exe
 
 cache:
   - 'C:\msys64\home\appveyor\.ccache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
 test_script:
   - ninja -vC build test
 
-after_build: 7z a vmaf-win-$(arch).zip libvmaf\build\*.*
+after_build: 7z a vmaf-win-%arch%.zip libvmaf\build\*.*
 
 artifacts:
   - path: libvmaf\build\*.zip

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -18,7 +18,7 @@ vmaf_rc = executable(
     include_directories : [libvmaf_inc, vmaf_include],
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf_rc,
+    link_with : libvmaf_rc.get_static_lib(),
     install : false,
 )
 
@@ -28,7 +28,7 @@ psnr = executable(
     include_directories : libvmaf_inc,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf,
+    link_with : libvmaf.get_static_lib(),
     install : false,
 )
 
@@ -38,7 +38,7 @@ moment = executable(
     include_directories : libvmaf_inc,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf,
+    link_with : libvmaf.get_static_lib(),
     install : false,
 )
 
@@ -48,7 +48,7 @@ ssim = executable(
     include_directories : libvmaf_inc,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf,
+    link_with : libvmaf.get_static_lib(),
     install : false,
 )
 
@@ -58,7 +58,7 @@ ms_ssim = executable(
     include_directories : libvmaf_inc,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf,
+    link_with : libvmaf.get_static_lib(),
     install : false,
 )
 
@@ -68,6 +68,6 @@ vmaf = executable(
     include_directories : libvmaf_inc,
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf,
+    link_with : libvmaf.get_static_lib(),
     install : false,
 )


### PR DESCRIPTION
The uploading of artifacts to AppVeyor was removed in #384 with the change to the Meson build system. This PR re-enables the uploading of libvmaf and the vmaf tools to AppVeyor, as well as the Meson logs and a zip of the whole libvmaf/build directory.

@Elypha Does this satisfy your requirements? Or do you need anything else uploaded?

Closes #477.