### PR TITLE
travis: build libvmaf with sanitizers enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: CC=gcc-7 CXX=g++-7
       script: &base-gcc-script
         - mkdir libvmaf/build && cd libvmaf/build
-        - LDFLAGS='-fsanitize=address' meson .. --buildtype debug -Db_sanitize=address
+        - LDFLAGS='-fsanitize=address,undefined' meson build --buildtype debug -Db_sanitize=address,undefined -Db_lundef=false
         - sudo ninja -v install
         - sudo ninja -v test
         - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: CC=gcc-7 CXX=g++-7
       script: &base-gcc-script
         - mkdir libvmaf/build && cd libvmaf/build
-        - LDFLAGS='-fsanitize=address,undefined' meson .. --buildtype debug -Db_sanitize=address,undefined
+        - LDFLAGS='-fsanitize=address' meson .. --buildtype debug -Db_sanitize=address
         - sudo ninja -v install
         - sudo ninja -v test
         - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: CC=gcc-7 CXX=g++-7
       script: &base-gcc-script
         - mkdir libvmaf/build && cd libvmaf/build
-        - meson .. --buildtype debug -Db_sanitize=address,undefined
+        - LDFLAGS='-fsanitize=address,undefined' meson .. --buildtype debug -Db_sanitize=address,undefined
         - sudo ninja -v install
         - sudo ninja -v test
         - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: CC=gcc-7 CXX=g++-7
       script: &base-gcc-script
         - mkdir libvmaf/build && cd libvmaf/build
-        - meson .. --buildtype release
+        - meson .. --buildtype debug -Db_sanitize=address,undefined
         - sudo ninja -v install
         - sudo ninja -v test
         - cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Sets the Travis jobs to build all `libvmaf` libs/bins and unit tests with sanitizers enabled. With this enabled, we should catch undefined behavior, address problems, and memory leaks on CI. The tradeoff is execution speed, but penalty is < x2.