### PR TITLE
libvmaf: add multithreading, feature extractor parallelization

### DIFF
--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -79,6 +79,9 @@ int vmaf_fex_ctx_pool_aquire(VmafFeatureExtractorContextPool *pool,
 int vmaf_fex_ctx_pool_release(VmafFeatureExtractorContextPool *pool,
                              VmafFeatureExtractorContext *fex_ctx);
 
+int vmaf_fex_ctx_pool_flush(VmafFeatureExtractorContextPool *pool,
+                            VmafFeatureCollector *feature_collector);
+
 int vmaf_fex_ctx_pool_destroy(VmafFeatureExtractorContextPool *pool);
 
 #endif /* __VMAF_FEATURE_EXTRACTOR_H__ */


### PR DESCRIPTION
Implements multithreaded feature extraction in `libvmaf_rc`. Multithreading compares similarly to `vmafossexec` for now, but there is opportunity for more speed as each feature extractor is improved to reference `VmafPicture` pixel data directly. See the tables and graphs [here](https://docs.google.com/spreadsheets/d/1NZ-PZq9rbHLcB-R53lulxQCbaakc3B9T9wX_3Y5I2AU/edit#gid=0) for speed measurements.

