### PR TITLE
libvmaf: implement cpumask

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -1,6 +1,7 @@
 #ifndef __VMAF_H__
 #define __VMAF_H__
 
+#include <stdint.h>
 #include <stdio.h>
 
 #include "libvmaf/model.h"
@@ -27,6 +28,7 @@ typedef struct VmafConfiguration {
     enum VmafLogLevel log_level;
     unsigned n_threads;
     unsigned n_subsample;
+    uint32_t cpumask;
 } VmafConfiguration;
 
 typedef struct VmafContext VmafContext;

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -33,7 +34,7 @@ int vmaf_init(VmafContext **vmaf, VmafConfiguration cfg)
     if (!vmaf) return -EINVAL;
     int err = 0;
 
-    cpu = cpu_autodetect(); //FIXME, see above
+    cpu = cpu_autodetect() & (~cfg.cpumask); //FIXME, see above
 
     VmafContext *const v = *vmaf = malloc(sizeof(*v));
     if (!v) goto fail;

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -9,7 +9,7 @@
 
 #include <libvmaf/libvmaf.rc.h>
 
-static const char short_opts[] = "r:d:w:h:p:b:m:o:x:t:f:i:s:n:v:";
+static const char short_opts[] = "r:d:w:h:p:b:m:o:x:t:f:i:s:c:n:v:";
 
 static const struct option long_opts[] = {
     { "reference",        1, NULL, 'r' },
@@ -25,6 +25,7 @@ static const struct option long_opts[] = {
     { "feature",          1, NULL, 'f' },
     { "import",           1, NULL, 'i' },
     { "subsample",        1, NULL, 's' },
+    { "cpumask",          1, NULL, 'c' },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { NULL,               0, NULL, 0 },
@@ -54,6 +55,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --threads/-t $unsigned:    number of threads to use\n"
             " --feature/-f $string:      additional feature\n"
             " --import/-i $path:         path to precomputed feature log\n"
+            " --cpumask/-c: $mask        restrict permitted CPU instruction sets\n"
             " --subsample/-s: $unsigned  compute scores only every N frames\n"
             " --no_prediction/-n:        no prediction, extract features only\n"
             " --version/-v:              print version and exit\n"
@@ -218,6 +220,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 's':
             settings->subsample = parse_unsigned(optarg, 's', argv[0]);
+            break;
+        case 'c':
+            settings->cpumask = parse_unsigned(optarg, 'c', argv[0]);
             break;
         case 'n':
             settings->no_prediction = true;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -2,6 +2,7 @@
 #define __VMAF_CLI_PARSE_H__
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <libvmaf/libvmaf.rc.h>
 #include <libvmaf/model.h>
@@ -26,6 +27,7 @@ typedef struct {
     unsigned subsample;
     unsigned thread_cnt;
     bool no_prediction;
+    uint32_t cpumask;
 } CLISettings;
 
 void cli_parse(const int argc, char *const *const argv,

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -177,6 +177,7 @@ int main(int argc, char *argv[])
         .log_level = VMAF_LOG_LEVEL_INFO,
         .n_threads = c.thread_cnt,
         .n_subsample = c.subsample,
+        .cpumask = c.cpumask,
     };
 
     VmafContext *vmaf;


### PR DESCRIPTION
This implements a CPU mask feature, which allows a user to restrict permitted CPU instruction sets. This is an incomplete solution, imho, since we currently only support x86 instruction sets. The fix for that will come later since it is indeed more involved, but for now the `vmafossexec` flag `--disable-avx` can be replicated in `vmaf_rc` with `--cpumask -1`.