### PR TITLE
libvmaf: add support for hbd integer psnr

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -108,10 +108,9 @@ int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
     if (!ref) return -EINVAL;
     if (!dist) return -EINVAL;
     if (!vfc) return -EINVAL;
-    if (!fex_ctx->fex->init) return -EINVAL;
     if (!fex_ctx->fex->extract) return -EINVAL;
 
-    if (!fex_ctx->is_initialized) {
+    if (fex_ctx->fex->init && !fex_ctx->is_initialized) {
         int err =
             vmaf_feature_extractor_context_init(fex_ctx, ref->pix_fmt, ref->bpc,
                                                 ref->w[0], ref->h[0]);

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -1,21 +1,15 @@
+#include <errno.h>
 #include <math.h>
 #include <string.h>
 
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
-static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
-                unsigned bpc, unsigned w, unsigned h)
-{
-    return 0;
-}
-
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
-static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
-                   unsigned index, VmafFeatureCollector *feature_collector)
+static int psnr8(VmafPicture *ref_pic, VmafPicture *dist_pic,
+                 unsigned index, VmafFeatureCollector *feature_collector)
 {
     int err = 0;
 
@@ -36,7 +30,7 @@ static int extract(VmafFeatureExtractor *fex,
 
         double eps = 1e-10;
         double psnr_max = 60.;
-        unsigned peak = pow(2, ref_pic->bpc) - 1;
+        double peak = 255.0;
         double score = MIN(10 * log10(peak * peak / MAX(noise, eps)), psnr_max);
 
         const char *feature_name[3] = { "psnr_y", "psnr_cb", "psnr_cr" };
@@ -48,9 +42,52 @@ static int extract(VmafFeatureExtractor *fex,
     return 0;
 }
 
-static int close(VmafFeatureExtractor *fex)
+static int psnr10(VmafPicture *ref_pic, VmafPicture *dist_pic,
+                  unsigned index, VmafFeatureCollector *feature_collector)
 {
+    int err = 0;
+
+    for (unsigned i = 0; i < 3; i++) {
+        uint16_t *ref = ref_pic->data[i];
+        uint16_t *dist = dist_pic->data[i];
+
+        double noise = 0.;
+        for (unsigned j = 0; j < ref_pic->h[i]; j++) {
+            for (unsigned k = 0; k < ref_pic->w[i]; k++) {
+                double diff = (ref[k] / 4.0) - (dist[k] / 4.0);
+                noise += diff * diff;
+            }
+            ref += (ref_pic->stride[i] / 2);
+            dist += (dist_pic->stride[i] / 2);
+        }
+        noise /= (ref_pic->w[i] * ref_pic->h[i]);
+
+        double eps = 1e-10;
+        double psnr_max = 72.;
+        double peak = 255.75;
+        double score = MIN(10 * log10(peak * peak / MAX(noise, eps)), psnr_max);
+
+        const char *feature_name[3] = { "psnr_y", "psnr_cb", "psnr_cr" };
+        err = vmaf_feature_collector_append(feature_collector, feature_name[i],
+                                            score, index);
+        if (err) return err;
+    }
+
     return 0;
+}
+
+static int extract(VmafFeatureExtractor *fex,
+                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   unsigned index, VmafFeatureCollector *feature_collector)
+{
+    switch(ref_pic->bpc) {
+    case 8:
+        return psnr8(ref_pic, dist_pic, index, feature_collector);
+    case 10:
+        return psnr10(ref_pic, dist_pic, index, feature_collector);
+    default:
+        return -EINVAL;
+    }
 }
 
 static const char *provided_features[] = {
@@ -60,8 +97,6 @@ static const char *provided_features[] = {
 
 VmafFeatureExtractor vmaf_fex_psnr = {
     .name = "psnr",
-    .init = init,
     .extract = extract,
-    .close = close,
     .provided_features = provided_features,
 };


### PR DESCRIPTION
This adds support for 10-bit PSNR, calculation is consistent with the `psnr_float` 10-bit feature extractor.