### PR TITLE
Restore extern "C" for C++ consumers

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -19,8 +19,16 @@
 #ifndef LIBVMAF_H_
 #define LIBVMAF_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int compute_vmaf(double* vmaf_score, char* fmt, int width, int height, int (*read_frame)(float *ref_data, float *main_data, float *temp_data, int stride_byte, void *user_data),
 				 void *user_data, char *model_path, char *log_path, char *log_fmt, int disable_clip, int disable_avx, int enable_transform, int phone_model, int do_psnr,
 				 int do_ssim, int do_ms_ssim, char *pool_method, int n_thread, int n_subsample, int enable_conf_interval);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _LIBVMAF_H */


### PR DESCRIPTION
Regressed by 82a86e040371

```
$ hg clone https://bitbucket.org/multicoreware/x265/
$ cmake -GNinja -DENABLE_LIBVMAF=on x265/source
$ ninja
[...
ld: error: undefined symbol: compute_vmaf(double*, char*, int, int, int (*)(float*, float*, float*, int, void*), void*, char*, char*, char*, int, int, int, int, int, int, int, char*, int, int, int)
>>> referenced by api.cpp
>>>               api.cpp.o:(x265_calculate_vmafscore) in archive libx265.a
>>> referenced by api.cpp
>>>               api.cpp.o:(x265_calculate_vmaf_framelevelscore) in archive libx265.a
>>> did you mean: extern "C" compute_vmaf
>>> defined in: /usr/lib/libvmaf.so
```

```
$ git clone https://github.com/HomeOfVapourSynthEvolution/VapourSynth-VMAF
$ cd VapourSynth-VMAF
$ LDFLAGS=-Wl,-z,defs meson _build
$ ninja -C _build
ld: error: undefined symbol: compute_vmaf(double*, char*, int, int, int (*)(float*, float*, float*, int, void*), void*, char*, char*, char*, int, int, int, int, int, int, int, char*, int, int, int)
>>> referenced by VMAF.cpp
>>>               vmaf@sha/VMAF_VMAF.cpp.o:(callVMAF(VMAFData*))
>>> referenced by VMAF.cpp
>>>               vmaf@sha/VMAF_VMAF.cpp.o:(callVMAF(VMAFData*))
$ nm -D _build/libvmaf.so | fgrep compute_vmaf
                 U _Z12compute_vmafPdPciiPFiPfS1_S1_iPvES2_S0_S0_S0_iiiiiiiS0_iii
```
