### PR TITLE
libvmaf: add support for JSON logging

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -33,6 +33,7 @@ enum VmafLogLevel {
 enum VmafOutputFormat {
     VMAF_OUTPUT_FORMAT_NONE = 0,
     VMAF_OUTPUT_FORMAT_XML,
+    VMAF_OUTPUT_FORMAT_JSON,
 };
 
 enum VmafPoolingMethod {

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -336,6 +336,9 @@ int vmaf_write_output(VmafContext *vmaf, FILE *outfile,
     case VMAF_OUTPUT_FORMAT_XML:
         return vmaf_write_output_xml(vmaf->feature_collector, outfile,
                                      vmaf->cfg.n_subsample);
+    case VMAF_OUTPUT_FORMAT_JSON:
+        return vmaf_write_output_json(vmaf->feature_collector, outfile,
+                                      vmaf->cfg.n_subsample);
     default:
         return 0;
     }

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -9,7 +9,7 @@
 
 #include <libvmaf/libvmaf.rc.h>
 
-static const char short_opts[] = "r:d:w:h:p:b:m:o:x:t:f:i:s:c:n:v:";
+static const char short_opts[] = "r:d:w:h:p:b:m:o:xjt:f:i:s:c:nv";
 
 static const struct option long_opts[] = {
     { "reference",        1, NULL, 'r' },
@@ -21,6 +21,7 @@ static const struct option long_opts[] = {
     { "model",            1, NULL, 'm' },
     { "output",           1, NULL, 'o' },
     { "xml",              0, NULL, 'x' },
+    { "json",             0, NULL, 'j' },
     { "threads",          1, NULL, 't' },
     { "feature",          1, NULL, 'f' },
     { "import",           1, NULL, 'i' },
@@ -52,6 +53,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             "                               path=foo.pkl:name=foo:enable_transform\n"
             " --output/-o $path:         path to output file\n"
             " --xml/-x:                  write output file as XML (default)\n"
+            " --json/-j:                 write output file as JSON\n"
             " --threads/-t $unsigned:    number of threads to use\n"
             " --feature/-f $string:      additional feature\n"
             " --import/-i $path:         path to precomputed feature log\n"
@@ -192,6 +194,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'x':
             settings->output_fmt = VMAF_OUTPUT_FORMAT_XML;
+            break;
+        case 'j':
+            settings->output_fmt = VMAF_OUTPUT_FORMAT_JSON;
             break;
         case 'm':
             if (settings->model_cnt == CLI_SETTINGS_STATIC_ARRAY_LEN) {


### PR DESCRIPTION
Add support for JSON output.  Set `--json` from the `vmaf_rc` command line to use.