### PR TITLE
libvmaf: add support for CSV logging

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -34,6 +34,7 @@ enum VmafOutputFormat {
     VMAF_OUTPUT_FORMAT_NONE = 0,
     VMAF_OUTPUT_FORMAT_XML,
     VMAF_OUTPUT_FORMAT_JSON,
+    VMAF_OUTPUT_FORMAT_CSV,
 };
 
 enum VmafPoolingMethod {

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -339,6 +339,9 @@ int vmaf_write_output(VmafContext *vmaf, FILE *outfile,
     case VMAF_OUTPUT_FORMAT_JSON:
         return vmaf_write_output_json(vmaf->feature_collector, outfile,
                                       vmaf->cfg.n_subsample);
+    case VMAF_OUTPUT_FORMAT_CSV:
+        return vmaf_write_output_csv(vmaf->feature_collector, outfile,
+                                     vmaf->cfg.n_subsample);
     default:
         return 0;
     }

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -123,3 +123,41 @@ int vmaf_write_output_json(VmafFeatureCollector *fc, FILE *outfile,
     fprintf(outfile, "}\n");
     return 0;
 }
+
+int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
+                           unsigned subsample)
+{
+
+    fprintf(outfile, "Frame,");
+    for (unsigned i = 0; i < fc->cnt; i++) {
+        fprintf(outfile, "%s,",
+                vmaf_feature_name_alias(fc->feature_vector[i]->name));
+    }
+    fprintf(outfile, "\n");
+
+    for (unsigned i = 0 ; i < max_capacity(fc); i++) {
+        if ((subsample > 1) && (i % subsample))
+            continue;
+
+        unsigned cnt = 0;
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (fc->feature_vector[j]->score[i].written)
+                cnt++;
+        }
+        if (!cnt) continue;
+
+        fprintf(outfile, "%d,", i);
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (!fc->feature_vector[j]->score[i].written)
+                continue;
+            fprintf(outfile, "%.6f,", fc->feature_vector[j]->score[i].value);
+        }
+        fprintf(outfile, "\n");
+    }
+
+    return 0;
+}

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -9,7 +9,7 @@
 
 #include <libvmaf/libvmaf.rc.h>
 
-static const char short_opts[] = "r:d:w:h:p:b:m:o:xjt:f:i:s:c:nv";
+static const char short_opts[] = "r:d:w:h:p:b:m:o:xjet:f:i:s:c:nv";
 
 static const struct option long_opts[] = {
     { "reference",        1, NULL, 'r' },
@@ -22,6 +22,7 @@ static const struct option long_opts[] = {
     { "output",           1, NULL, 'o' },
     { "xml",              0, NULL, 'x' },
     { "json",             0, NULL, 'j' },
+    { "csv",              0, NULL, 'e' },
     { "threads",          1, NULL, 't' },
     { "feature",          1, NULL, 'f' },
     { "import",           1, NULL, 'i' },
@@ -54,6 +55,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --output/-o $path:         path to output file\n"
             " --xml/-x:                  write output file as XML (default)\n"
             " --json/-j:                 write output file as JSON\n"
+            " --csv/-c:                  write output file as CSV\n"
             " --threads/-t $unsigned:    number of threads to use\n"
             " --feature/-f $string:      additional feature\n"
             " --import/-i $path:         path to precomputed feature log\n"
@@ -197,6 +199,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'j':
             settings->output_fmt = VMAF_OUTPUT_FORMAT_JSON;
+            break;
+        case 'e':
+            settings->output_fmt = VMAF_OUTPUT_FORMAT_CSV;
             break;
         case 'm':
             if (settings->model_cnt == CLI_SETTINGS_STATIC_ARRAY_LEN) {


### PR DESCRIPTION
Adds support for csv logging to `libvmaf_rc`. Applies on top of #514.