### PR TITLE
libvmaf/output: add width, height, fps to xml log

### DIFF
--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -129,6 +129,9 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
     pthread_mutex_lock(&(feature_collector->lock));
     int err = 0;
 
+    if (!feature_collector->timer.begin)
+        feature_collector->timer.begin = clock();
+
     FeatureVector *feature_vector =
         find_feature_vector(feature_collector, feature_name);
 
@@ -157,6 +160,7 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
     err = feature_vector_append(feature_vector, picture_index, score);
 
 unlock:
+    feature_collector->timer.end = clock();
     pthread_mutex_unlock(&(feature_collector->lock));
     return err;
 }

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -21,6 +21,7 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <time.h>
 
 typedef struct {
     char *name;
@@ -34,6 +35,7 @@ typedef struct {
 typedef struct VmafFeatureCollector {
     FeatureVector **feature_vector;
     unsigned cnt, capacity;
+    struct { clock_t begin, end; } timer;
     pthread_mutex_t lock;
 } VmafFeatureCollector;
 

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -37,14 +37,18 @@ static unsigned max_capacity(VmafFeatureCollector *fc)
 }
 
 int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile,
-                          unsigned subsample)
+                          unsigned subsample, unsigned width, unsigned height,
+                          double fps)
 {
     if (!fc) return -EINVAL;
     if (!outfile) return -EINVAL;
 
     fprintf(outfile, "<VMAF version=\"%s\">\n", vmaf_version());
-    fprintf(outfile, "  <frames>\n");
+    fprintf(outfile, "  <params qualityWidth=\"%d\" qualityHeight=\"%d\" />\n",
+            width, height);
+    fprintf(outfile, "  <fyi fps=\"%.2f\" />\n", fps);
 
+    fprintf(outfile, "  <frames>\n");
     for (unsigned i = 0 ; i < max_capacity(fc); i++) {
         if ((subsample > 1) && (i % subsample))
             continue;
@@ -71,8 +75,8 @@ int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile,
         }
         fprintf(outfile, "/>\n");
     }
-
     fprintf(outfile, "  </frames>\n");
+
     fprintf(outfile, "</VMAF>\n");
 
     return 0;

--- a/libvmaf/src/output.h
+++ b/libvmaf/src/output.h
@@ -16,4 +16,17 @@
  *
  */
 
-int vmaf_write_log_xml(VmafFeatureCollector *fc, FILE *logfile);
+#ifndef __VMAF_OUTPUT_H__
+#define __VMAF_OUTPUT_H__
+
+int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile,
+                          unsigned subsample, unsigned width, unsigned height,
+                          double fps);
+
+int vmaf_write_output_json(VmafFeatureCollector *fc, FILE *outfile,
+                           unsigned subsample);
+
+int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
+                           unsigned subsample);
+
+#endif /* __VMAF_OUTPUT_H__ */


### PR DESCRIPTION
Adds width, height, and fps stats to the XML output file.

```xml
<VMAF version="RELEASE_CANDIDATE">
  <params width="576" height="324" />
  <fyi fps="66.44" />
  <frames>
    <frame frameNum="0" motion2="0.000000" adm2="0.962171" adm_scale0="0.946342" adm_scale1="0.939103" adm_scale2="0.957538" adm_scale3="0.981014" vif_scale0="0.505393" vif_scale1="0.878155" vif_scale2="0.937589" vif_scale3="0.964358" ../model/vmaf_v0.6.1.pkl="83.868099" />
    <frame frameNum="1" motion2="4.215693" adm2="0.949842" adm_scale0="0.929862" adm_scale1="0.916670" adm_scale2="0.938517" adm_scale3="0.978180" vif_scale0="0.411091" vif_scale1="0.811943" vif_scale2="0.894037" vif_scale3="0.937140" ../model/vmaf_v0.6.1.pkl="82.661630" />
    <frame frameNum="2" motion2="4.070274" adm2="0.943535" adm_scale0="0.912681" adm_scale1="0.902340" adm_scale2="0.927663" adm_scale3="0.981115" vif_scale0="0.381398" vif_scale1="0.797620" vif_scale2="0.888710" vif_scale3="0.936691" ../model/vmaf_v0.6.1.pkl="81.053467" />
    <frame frameNum="3" motion2="3.825236" adm2="0.948045" adm_scale0="0.915596" adm_scale1="0.909747" adm_scale2="0.937121" adm_scale3="0.982282" vif_scale0="0.390273" vif_scale1="0.800916" vif_scale2="0.891099" vif_scale3="0.938725" ../model/vmaf_v0.6.1.pkl="81.935266" />
    <frame frameNum="4" motion2="3.825236" adm2="0.937779" adm_scale0="0.908689" adm_scale1="0.892088" adm_scale2="0.922616" adm_scale3="0.977720" vif_scale0="0.349535" vif_scale1="0.760889" vif_scale2="0.862231" vif_scale3="0.919330" ../model/vmaf_v0.6.1.pkl="77.519625" />
  </frames>
</VMAF>

```