### PR TITLE
remove unnecessary ImportError, addresses #541

### DIFF
--- a/python/src/vmaf/config.py
+++ b/python/src/vmaf/config.py
@@ -29,8 +29,6 @@ class VmafExternalConfig(object):
                 return path
 
         except ImportError:
-            print('ImportError')
-
             pass
 
         return None


### PR DESCRIPTION
The error is printed when externals (e.g. psnr) are not found. At the moment it is not very helpful and should be removed.

That said, I'm not sure what happens when these externals are not found and still called by the Python code? But this should be handled when it happens, not via this `ImportError` message.