### PR TITLE
Travis CI: Update build environments (Xcode 11.4 and Python 3.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
       script: *base-gcc-script
     - name: Python3 Tox
       language: python
-      python: "3.7"
+      python: "3.8"
       env: CC=gcc-7 CXX=g++-7
       cache: &python-cache
         pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
       script: *base-gcc-script
     - name: libvmaf AppleClang
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.4
       compiler: clang
       script: *base-gcc-script
     - name: Python3 Tox


### PR DESCRIPTION
- Updates Xcode to 11.4 in libvmaf AppleClang job
- Updates Python to 3.8 in Python3 Tox job