### PR TITLE
improve installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         build-essential \
         git \
         ninja-build \
+        doxygen \
         python3 \
         python3-dev \
         python3-pip \

--- a/libvmaf/README.md
+++ b/libvmaf/README.md
@@ -15,6 +15,12 @@ sudo apt install python3 python3-pip python3-setuptools python3-wheel ninja-buil
 pip3 install --user meson
 ```
 
+Make sure your user install executable directory is on your PATH. Add this to the end of `~/.bashrc` (or `~/.bash_profile` under macOS) and restart your shell:
+
+```
+export PATH="$PATH:$HOME/.local/bin"
+```
+
 Under macOS, install [Homebrew](https://brew.sh), then:
 
 ```
@@ -22,6 +28,12 @@ brew install meson doxygen
 ```
 
 ## Compile
+
+First, change to the `libvmaf` directory:
+
+```
+cd libvmaf
+```
 
 Run:
 
@@ -45,11 +57,13 @@ ninja -vC build test
 
 ## Install
 
-Install using:
+Install the libraries and models to `/usr/local` using:
 
 ```
 ninja -vC build install
 ```
+
+Under Linux, you may need `sudo` for the above command.
 
 ## Documentation
 

--- a/libvmaf/README.md
+++ b/libvmaf/README.md
@@ -11,14 +11,14 @@ Install these dependencies under Ubuntu with:
 
 ```
 sudo apt update -qq && \
-sudo apt install python3 python3-pip python3-setuptools python3-wheel ninja-build
+sudo apt install python3 python3-pip python3-setuptools python3-wheel ninja-build doxygen
 pip3 install --user meson
 ```
 
 Under macOS, install [Homebrew](https://brew.sh), then:
 
 ```
-brew install meson
+brew install meson doxygen
 ```
 
 ## Compile

--- a/resource/doc/VMAF_Python_library.md
+++ b/resource/doc/VMAF_Python_library.md
@@ -68,7 +68,7 @@ One can run VMAF either in single mode by `run_vmaf` or in batch mode by `run_vm
 To run VMAF on a single reference/distorted video pair, run:
 
 ```
-./run_vmaf format width height reference_path distorted_path [--out-fmt output_format]
+run_vmaf format width height reference_path distorted_path [--out-fmt output_format]
 ```
 
 The arguments are the following:
@@ -86,7 +86,7 @@ The arguments are the following:
 For example:
 
 ```
-./run_vmaf yuv420p 576 324 \
+run_vmaf yuv420p 576 324 \
   python/test/resource/yuv/src01_hrc00_576x324.yuv \
   python/test/resource/yuv/src01_hrc01_576x324.yuv \
   --out-fmt json
@@ -132,7 +132,7 @@ yuv420p 576 324 python/test/resource/yuv/src01_hrc00_576x324.yuv \
 After that, run:
 
 ```
-./run_vmaf_in_batch input_file [--out-fmt out_fmt] [--parallelize]
+run_vmaf_in_batch input_file [--out-fmt out_fmt] [--parallelize]
 ```
 
 where enabling `--parallelize` allows execution on multiple reference-distorted video pairs in parallel.
@@ -140,7 +140,7 @@ where enabling `--parallelize` allows execution on multiple reference-distorted 
 For example:
 
 ```
-./run_vmaf_in_batch resource/example/example_batch_input --parallelize
+run_vmaf_in_batch resource/example/example_batch_input --parallelize
 ```
 
 ### Using `ffmpeg2vmaf`
@@ -148,7 +148,7 @@ For example:
 There is also an `ffmpeg2vmaf` command line tool which can compare any file format decodable by `ffmpeg`. `ffmpeg2vmaf` essentially pipes FFmpeg-decoded videos to VMAF. Note that you need a recent version of `ffmpeg` installed (for the first time, run the command line, follow the prompted instruction to specify the path of `ffmpeg`). 
 
 ```
-./ffmpeg2vmaf quality_width quality_height reference_path distorted_path \
+ffmpeg2vmaf quality_width quality_height reference_path distorted_path \
   [--model model_path] [--out-fmt out_fmt]
 ```
 
@@ -163,19 +163,19 @@ VMAF follows a machine-learning based approach to first extract a number of qual
 In addition to the basic commands, the VMAF package also provides a framework to allow any user to train his/her own perceptual quality assessment model. For example, directory [`model`](../../model) contains a number of pre-trained models, which can be loaded by the aforementioned commands:
 
 ```
-./run_vmaf format width height reference_path distorted_path [--model model_path]
-./run_vmaf_in_batch input_file [--model model_path] --parallelize
+run_vmaf format width height reference_path distorted_path [--model model_path]
+run_vmaf_in_batch input_file [--model model_path] --parallelize
 ```
 
 For example:
 
 ```
-./run_vmaf yuv420p 576 324 \
+run_vmaf yuv420p 576 324 \
   python/test/resource/yuv/src01_hrc00_576x324.yuv \
   python/test/resource/yuv/src01_hrc01_576x324.yuv \
   --model model/nflxtrain_vmafv3.pkl
 
-./run_vmaf_in_batch resource/example/example_batch_input \
+run_vmaf_in_batch resource/example/example_batch_input \
   --model model/nflxtrain_vmafv3.pkl --parallelize
 ```
 
@@ -215,7 +215,7 @@ See the directory [`resource/dataset`](../../resource/dataset) for more examples
 Once a dataset is created, first validate the dataset using existing VMAF or other (PSNR, SSIM or MS-SSIM) metrics. Run:
 
 ```
-./run_testing quality_type test_dataset_file \
+run_testing quality_type test_dataset_file \
 [--vmaf-model optional_VMAF_model_path] [--cache-result] [--parallelize]
 ```
 
@@ -228,7 +228,7 @@ Enabling `--parallelize` allows execution on multiple reference-distorted video 
 For example:
 
 ```
-./run_testing VMAF resource/example/example_dataset.py \
+run_testing VMAF resource/example/example_dataset.py \
   --cache-result --parallelize
 ```
 
@@ -260,14 +260,14 @@ python3 python/script/run_cleaning_cache.py VMAF \
 Now that we are confident that the dataset is created correctly and we have some benchmark result on existing metrics, we proceed to train a new quality assessment model. Run:
 
 ```
-./run_vmaf_training train_dataset_filepath feature_param_file model_param_file \
+run_vmaf_training train_dataset_filepath feature_param_file model_param_file \
   output_model_file [--cache-result] [--parallelize]
 ```
 
 For example:
 
 ```
-./run_vmaf_training resource/example/example_dataset.py \
+run_vmaf_training resource/example/example_dataset.py \
   resource/feature_param/vmaf_feature_v2.py \
   resource/model_param/libsvmnusvr_v2.py \
   workspace/model/test_model.pkl \
@@ -319,13 +319,13 @@ The commands `./run_vmaf_training` and `./run_testing` also support custom subje
 The subjective model option can be specified with option `--subj-model subjective_model`, for example:
 
 ```
-./run_vmaf_training resource/example/example_raw_dataset.py \
+run_vmaf_training resource/example/example_raw_dataset.py \
   resource/feature_param/vmaf_feature_v2.py \
   resource/model_param/libsvmnusvr_v2.py \
   workspace/model/test_model.pkl \
   --subj-model MLE --cache-result --parallelize
 
-./run_testing VMAF resource/example/example_raw_dataset.py \
+run_testing VMAF resource/example/example_raw_dataset.py \
   --subj-model MLE --cache-result --parallelize
 ```
 
@@ -356,14 +356,14 @@ A Bjøntegaard-Delta (BD) rate [implementation](../../python/src/vmaf/tools/bd_r
 An implementation of [LIME](https://arxiv.org/pdf/1602.04938.pdf) is also added as part of the repository. The main idea is to perform a local linear approximation to any regressor or classifier and then use the coefficients of the linearized model as indicators of feature importance. LIME can be used as part of the VMAF regression framework, for example:
 
 ```
-./run_vmaf yuv420p 1920 1080 NFLX_dataset_public/ref/OldTownCross_25fps.yuv \
+run_vmaf yuv420p 1920 1080 NFLX_dataset_public/ref/OldTownCross_25fps.yuv \
     NFLX_dataset_public/dis/OldTownCross_90_1080_4300.yuv --local-explain
 ```
 
 Naturally, LIME can also be applied to any other regression scheme as long as there exists a pre-trained model. For example, applying to BRISQUE:
 
 ```
-./run_vmaf yuv420p 1920 1080 NFLX_dataset_public/ref/OldTownCross_25fps.yuv \
+run_vmaf yuv420p 1920 1080 NFLX_dataset_public/ref/OldTownCross_25fps.yuv \
     NFLX_dataset_public/dis/OldTownCross_90_1080_4300.yuv --local-explain \
     --model model/vmaf_brisque_all_v0.0rc.pkl
 ```


### PR DESCRIPTION
- Fix usage of executables: These can now be called without a `./` prefix.
- Fix installation of libvmaf