### PR TITLE
Mutex unlock before destroy

### DIFF
--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -204,6 +204,7 @@ void vmaf_feature_collector_destroy(VmafFeatureCollector *feature_collector)
     for (unsigned i = 0; i < feature_collector->cnt; i++)
         feature_vector_destroy(feature_collector->feature_vector[i]);
     free(feature_collector->feature_vector);
+    pthread_mutex_unlock(&(feature_collector->lock));
     pthread_mutex_destroy(&(feature_collector->lock));
     free(feature_collector);
 }


### PR DESCRIPTION
Mutex should be unlocked before destruction. Otherwise, this may lead to undefined behaviour (see https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_destroy.html)