### PR TITLE
Update meson.build to next release version (1.5.2) to sync libvmaf.pc

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -1,5 +1,5 @@
 project('libvmaf', ['c', 'cpp'],
-    version : '1.3.16',
+    version : '1.5.2',
     default_options : ['c_std=c99',
                        'cpp_std=c++11',
                        'warning_level=2',


### PR DESCRIPTION
libvmaf.pc version wasn't properly sync when we moved from 1.3.15 to 1.5.1.
Increase meson.project_version() to resync release and .pc file.

Signed-off-by: Alexandre Demers <alexandre.f.demers@gmail.com>