### PR TITLE
Add meson options to disable tests and documentation

### DIFF
--- a/libvmaf/doc/meson.build
+++ b/libvmaf/doc/meson.build
@@ -1,3 +1,8 @@
+# Leave subdir if documentation is disabled
+if not get_option('documentation')
+    subdir_done()
+endif
+
 doxygen = find_program('doxygen', required: false)
 
 if doxygen.found()

--- a/libvmaf/meson_options.txt
+++ b/libvmaf/meson_options.txt
@@ -1,0 +1,9 @@
+option('tests', 
+    type: 'boolean', 
+    value: true, 
+    description: 'Enable libvmaf tests')
+
+option('documentation', 
+    type: 'boolean', 
+    value: true, 
+    description: 'Build documentation')

--- a/libvmaf/meson_options.txt
+++ b/libvmaf/meson_options.txt
@@ -7,3 +7,4 @@ option('documentation',
     type: 'boolean', 
     value: true, 
     description: 'Build documentation')
+    

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -1,3 +1,8 @@
+# Leave subdir if tests are disabled
+if not get_option('tests')
+    subdir_done()
+endif
+
 test_inc = include_directories('.')
 
 test_picture = executable('test_picture',


### PR DESCRIPTION
Since tests and documentation are not always required (multilib | 32 bit on
64 bit), allow disabling building and running tests or generating documentation.

Signed-off-by: Alexandre Demers <alexandre.f.demers@gmail.com>