### PR TITLE
libvmaf, add subtitle output format

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -35,6 +35,7 @@ enum VmafOutputFormat {
     VMAF_OUTPUT_FORMAT_XML,
     VMAF_OUTPUT_FORMAT_JSON,
     VMAF_OUTPUT_FORMAT_CSV,
+    VMAF_OUTPUT_FORMAT_SUB,
 };
 
 enum VmafPoolingMethod {

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -390,7 +390,10 @@ int vmaf_write_output(VmafContext *vmaf, FILE *outfile,
     case VMAF_OUTPUT_FORMAT_CSV:
         return vmaf_write_output_csv(vmaf->feature_collector, outfile,
                                      vmaf->cfg.n_subsample);
+    case VMAF_OUTPUT_FORMAT_SUB:
+        return vmaf_write_output_sub(vmaf->feature_collector, outfile,
+                                     vmaf->cfg.n_subsample);
     default:
-        return 0;
+        return -EINVAL;
     }
 }

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -165,3 +165,35 @@ int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
 
     return 0;
 }
+
+int vmaf_write_output_sub(VmafFeatureCollector *fc, FILE *outfile,
+                          unsigned subsample)
+{
+    for (unsigned i = 0 ; i < max_capacity(fc); i++) {
+        if ((subsample > 1) && (i % subsample))
+            continue;
+
+        unsigned cnt = 0;
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (fc->feature_vector[j]->score[i].written)
+                cnt++;
+        }
+        if (!cnt) continue;
+
+        fprintf(outfile, "{%d}{%d}frame: %d|", i, i + 1, i);
+        for (unsigned j = 0; j < fc->cnt; j++) {
+            if (i > fc->feature_vector[j]->capacity)
+                continue;
+            if (!fc->feature_vector[j]->score[i].written)
+                continue;
+            fprintf(outfile, "%s: %.6f|",
+                    vmaf_feature_name_alias(fc->feature_vector[j]->name),
+                    fc->feature_vector[j]->score[i].value);
+        }
+        fprintf(outfile, "\n");
+    }
+
+    return 0;
+}

--- a/libvmaf/src/output.h
+++ b/libvmaf/src/output.h
@@ -29,4 +29,7 @@ int vmaf_write_output_json(VmafFeatureCollector *fc, FILE *outfile,
 int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
                            unsigned subsample);
 
+int vmaf_write_output_sub(VmafFeatureCollector *fc, FILE *outfile,
+                          unsigned subsample);
+
 #endif /* __VMAF_OUTPUT_H__ */

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -11,6 +11,10 @@
 
 static const char short_opts[] = "r:d:w:h:p:b:m:o:xjet:f:i:s:c:nv";
 
+enum {
+    ARG_SUB = 256,
+};
+
 static const struct option long_opts[] = {
     { "reference",        1, NULL, 'r' },
     { "distorted",        1, NULL, 'd' },
@@ -23,6 +27,7 @@ static const struct option long_opts[] = {
     { "xml",              0, NULL, 'x' },
     { "json",             0, NULL, 'j' },
     { "csv",              0, NULL, 'e' },
+    { "sub",              0, NULL, ARG_SUB },
     { "threads",          1, NULL, 't' },
     { "feature",          1, NULL, 'f' },
     { "import",           1, NULL, 'i' },
@@ -59,6 +64,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --xml/-x:                  write output file as XML (default)\n"
             " --json/-j:                 write output file as JSON\n"
             " --csv/-c:                  write output file as CSV\n"
+            " --sub:                     write output file as subtitle\n"
             " --threads/-t $unsigned:    number of threads to use\n"
             " --feature/-f $string:      additional feature\n"
             " --import/-i $path:         path to precomputed feature log\n"
@@ -205,6 +211,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'e':
             settings->output_fmt = VMAF_OUTPUT_FORMAT_CSV;
+            break;
+        case ARG_SUB:
+            settings->output_fmt = VMAF_OUTPUT_FORMAT_SUB;
             break;
         case 'm':
             if (settings->model_cnt == CLI_SETTINGS_STATIC_ARRAY_LEN) {


### PR DESCRIPTION
This PR adds an additional output format for subtitles. These subtitles are in the [MicroDVD](https://en.wikipedia.org/wiki/MicroDVD) format which can be played back via `ffplay`, `mpv`, `vlc`, etc. I chose this format because it is frame accurate and requires no timing information (unlike srt). Usage with `vmaf_rc` is as follows:

```sh
./build/tools/vmaf_rc \
    --reference ./y4ms/ducks.y4m  \
    --distorted ./y4ms/ducks_dist.y4m \
    --model path=../model/vmaf_v0.6.1.pkl \
    --output output.sub \
    --sub
```

Playback looks like this (pick one):

```
mpv y4ms/ducks_dist.y4m --sub-file output.sub
```
```
vlc y4ms/ducks_dist.y4m --sub-file output.sub
```
```
ffplay -vf subtitles=output.sub -i y4ms/ducks_dist.y4m 
```

<img width="1008" alt="Screen Shot 2020-06-05 at 6 14 45 PM" src="https://user-images.githubusercontent.com/4442504/83932718-8431b700-a759-11ea-96a6-a299c28de0ea.png">

Using the player of your choice, you may use the transport to step frame by frame and examine anything interesting. Additionally, subtitles can be toggled on/off if your player supports it.