### PR TITLE
libvmaf: VmafDictionary, VmafOption, parameterized feature extraction

### DIFF
--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -1,0 +1,107 @@
+#include <errno.h>
+#include <string.h>
+
+#include "dict.h"
+
+typedef struct VmafDictionary {
+    VmafDictionaryEntry *entry;
+    unsigned size, cnt;
+} VmafDictionary;
+
+const VmafDictionaryEntry *vmaf_dictionary_get(VmafDictionary **dict,
+                                               const char *key, uint64_t flags)
+{
+    if (!dict) return NULL;
+    if (!(*dict)) return NULL;
+    if (!key) return NULL;
+
+    (void) flags; // available for possible future use
+
+    VmafDictionary *d = *dict;
+    for (unsigned i = 0; i < d->cnt; i++) {
+       if (!strcmp(key, d->entry[i].key))
+           return &d->entry[i];
+    }
+
+    return NULL;
+}
+
+int vmaf_dictionary_set(VmafDictionary **dict, const char *key, const char *val,
+                        uint64_t flags)
+{
+    if (!dict) return -EINVAL;
+    if (!key) return -EINVAL;
+    if (!val) return -EINVAL;
+
+    VmafDictionary *d = *dict;
+
+    if (!d) {
+        d = *dict = malloc(sizeof(*d));
+        if (!d) goto fail;
+        memset(d, 0, sizeof(*d));
+        const size_t initial_sz = 8 * sizeof(*d->entry);
+        d->entry = malloc(initial_sz);
+        if (!d->entry) {
+            free(d);
+            *dict = NULL;
+            goto fail;
+        }
+        memset(d->entry, 0, initial_sz);
+        d->size = 8;
+    }
+
+    VmafDictionaryEntry *existing_entry = vmaf_dictionary_get(&d, key, 0);
+    if (existing_entry && (flags & VMAF_DICT_DO_NOT_OVERWRITE))
+        return -EINVAL;
+
+    if (d->cnt == d->size) {
+        const size_t sz = d->size * sizeof(*d->entry) * 2;
+        VmafDictionaryEntry *entry = realloc(d->entry, sz);
+        if (!entry) goto fail;
+        d->entry = entry;
+        d->size *= 2;
+    }
+
+    const char *val_copy = strdup(val);
+    if (!val_copy) goto fail;
+
+    if (existing_entry && !(flags & VMAF_DICT_DO_NOT_OVERWRITE)) {
+        free(existing_entry->val);
+        existing_entry->val = val_copy;
+        return 0;
+    }
+
+    const char *key_copy = strdup(key);
+    if (!key_copy) goto free_val_copy;
+
+    VmafDictionaryEntry entry = {
+        .key = key_copy,
+        .val = val_copy,
+    };
+
+    d->entry[d->cnt++] = entry;
+
+    return 0;
+
+free_val_copy:
+    free(val_copy);
+fail:
+    return -ENOMEM;
+}
+
+int vmaf_dictionary_free(VmafDictionary **dict)
+{
+    if (!dict) return -EINVAL;
+    if (!(*dict)) return 0;
+
+    VmafDictionary *d = *dict;
+    for (unsigned i = 0; i < d->cnt; i++) {
+       if (d->entry[i].key) free(d->entry[i].key);
+       if (d->entry[i].val) free(d->entry[i].val);
+    }
+    free(d->entry);
+    free(d);
+    *dict = NULL;
+
+    return 0;
+}

--- a/libvmaf/src/dict.h
+++ b/libvmaf/src/dict.h
@@ -1,0 +1,42 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_SRC_DICT_H__
+#define __VMAF_SRC_DICT_H__
+
+#include <stdint.h>
+
+typedef struct VmafDictionary VmafDictionary;
+
+typedef struct VmafDictionaryEntry {
+    const char *key, *val;
+} VmafDictionaryEntry;
+
+enum VmafDictionaryFlags {
+    VMAF_DICT_DO_NOT_OVERWRITE = 1 << 0,
+};
+
+int vmaf_dictionary_set(VmafDictionary **dict, const char *key, const char *val,
+                        uint64_t flags);
+
+const VmafDictionaryEntry *vmaf_dictionary_get(VmafDictionary **dict,
+                                               const char *key, uint64_t flags);
+
+int vmaf_dictionary_free(VmafDictionary **dict);
+
+#endif /* __VMAF_SRC_DICT_H__ */

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -22,7 +22,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "dict.h"
 #include "feature_collector.h"
+#include "opt.h"
 
 #include "libvmaf/picture.h"
 
@@ -73,6 +75,7 @@ typedef struct VmafFeatureExtractor {
      * @param               fex self.
      */
     int (*close)(struct VmafFeatureExtractor *fex);
+    const VmafOption *options; ///< Optional initialization options.
     void *priv; ///< Custom data.
     size_t priv_size; ///< sizeof private data.
     uint64_t flags; ///< Feauture extraction flags, binary or'd.
@@ -84,11 +87,13 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name);
 
 typedef struct VmafFeatureExtractorContext {
     bool is_initialized, is_closed;
+    VmafDictionary *opts_dict;
     VmafFeatureExtractor *fex;
 } VmafFeatureExtractorContext;
 
 int vmaf_feature_extractor_context_create(VmafFeatureExtractorContext **fex_ctx,
-                                          VmafFeatureExtractor *fex);
+                                          VmafFeatureExtractor *fex,
+                                          VmafDictionary *opts_dict);
 
 int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
                                         enum VmafPixelFormat pix_fmt,

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -131,7 +131,7 @@ int vmaf_use_feature(VmafContext *vmaf, const char *feature_name)
     if (!fex) return -EINVAL;
 
     VmafFeatureExtractorContext *fex_ctx;
-    err = vmaf_feature_extractor_context_create(&fex_ctx, fex);
+    err = vmaf_feature_extractor_context_create(&fex_ctx, fex, NULL);
     if (err) return err;
 
     RegisteredFeatureExtractors *rfe = &(vmaf->registered_feature_extractors);
@@ -157,7 +157,7 @@ int vmaf_use_features_from_model(VmafContext *vmaf, VmafModel *model)
         if (!fex) return -EINVAL;
 
         VmafFeatureExtractorContext *fex_ctx;
-        err = vmaf_feature_extractor_context_create(&fex_ctx, fex);
+        err = vmaf_feature_extractor_context_create(&fex_ctx, fex, NULL);
         if (err) return err;
         err = feature_extractor_vector_append(rfe, fex_ctx);
         if (err) {

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -192,6 +192,7 @@ libvmaf_rc_sources = [
     src_dir + 'output.c',
     src_dir + 'fex_ctx_vector.c',
     src_dir + 'thread_pool.c',
+    src_dir + 'dict.c',
 ]
 
 libvmaf_rc = both_libraries(

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -193,6 +193,7 @@ libvmaf_rc_sources = [
     src_dir + 'fex_ctx_vector.c',
     src_dir + 'thread_pool.c',
     src_dir + 'dict.c',
+    src_dir + 'opt.c',
 ]
 
 libvmaf_rc = both_libraries(

--- a/libvmaf/src/opt.c
+++ b/libvmaf/src/opt.c
@@ -1,0 +1,83 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "opt.h"
+
+static int set_option_bool(bool *dst, bool default_val, const char *val)
+{
+    *dst = default_val;
+    if (!val) return 0;
+
+    if (!strcmp(val, "true")) *dst = true;
+    else if (!strcmp(val, "false")) *dst = false;
+    else return -EINVAL;
+
+    return 0;
+}
+
+static int set_option_int(int *dst, int default_val, const char *val,
+                          int min, int max)
+{
+    *dst = default_val;
+    if (!val) return 0;
+
+    const int n = atoi(val);
+    if (n == 0 && val[0] != '0') return -EINVAL;
+    if (n < min) return -EINVAL;
+    if (n > max) return -EINVAL;
+    *dst = n;
+    return 0;
+}
+
+static int set_option_double(double *dst, double default_val, const char *val,
+                             double min, double max)
+{
+    *dst = default_val;
+    if (!val) return 0;
+
+    const double n = atof(val);
+    if (n == 0 && val[0] != '0') return -EINVAL;
+    if (n < min) return -EINVAL;
+    if (n > max) return -EINVAL;
+    *dst = n;
+    return 0;
+}
+
+int vmaf_option_set(VmafOption *opt, void *obj, const char *val)
+{
+    if (!obj) return -EINVAL;
+    if (!opt) return -EINVAL;
+
+    void *dst = (uint8_t*)obj + opt->offset;
+
+    switch (opt->type) {
+    case VMAF_OPT_TYPE_BOOL:
+        return set_option_bool(dst, opt->default_val.b, val);
+    case VMAF_OPT_TYPE_INT:
+        return set_option_int(dst, opt->default_val.i, val, opt->min, opt->max);
+    case VMAF_OPT_TYPE_DOUBLE:
+        return set_option_double(dst, opt->default_val.d, val, opt->min,
+                                 opt->max);
+    default:
+        return -EINVAL;
+    }
+}

--- a/libvmaf/src/opt.h
+++ b/libvmaf/src/opt.h
@@ -1,0 +1,46 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_SRC_OPT_H__
+#define __VMAF_SRC_OPT_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+enum VmafOptionType {
+    VMAF_OPT_TYPE_BOOL,
+    VMAF_OPT_TYPE_INT,
+    VMAF_OPT_TYPE_DOUBLE,
+};
+
+typedef struct VmafOption {
+    const char *name;
+    const char *help;
+    int offset;
+    enum VmafOptionType type;
+    union {
+        bool b;
+        int i;
+        double d;
+    } default_val;
+    double min, max;
+} VmafOption;
+
+int vmaf_option_set(VmafOption *opt, void *obj, const char *val);
+
+#endif /* __VMAF_SRC_OPT_H__ */

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -54,9 +54,15 @@ test_feature_extractor = executable('test_feature_extractor',
     ]
 )
 
+test_dict = executable('test_dict',
+    ['test.c', 'test_dict.c'],
+    include_directories : [libvmaf_inc, test_inc, '../src/'],
+)
+
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
 test('test_thread_pool', test_thread_pool)
 test('test_model', test_model)
 test('test_predict', test_predict)
 test('test_feature_extractor', test_feature_extractor)
+test('test_dict', test_dict)

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -44,7 +44,8 @@ test_predict = executable('test_predict',
 )
 
 test_feature_extractor = executable('test_feature_extractor',
-    ['test.c', 'test_feature_extractor.c', '../src/mem.c', '../src/picture.c'],
+    ['test.c', 'test_feature_extractor.c', '../src/mem.c', '../src/picture.c',
+     '../src/dict.c', '../src/opt.c'],
     include_directories : [libvmaf_inc, test_inc, '../src/'],
     dependencies : [math_lib, stdatomic_dependency],
     objects : [

--- a/libvmaf/test/test_dict.c
+++ b/libvmaf/test/test_dict.c
@@ -1,0 +1,100 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "test.h"
+#include "dict.h"
+
+#include "dict.c"
+
+static char *test_vmaf_dictionary()
+{
+    int err = 0;
+
+    VmafDictionary *dict = NULL;
+    const char *test_key_1 = "key_1";
+    const char *test_val_1 = "val_1";
+    err |= vmaf_dictionary_set(&dict, test_key_1, test_val_1, 0);
+    mu_assert("problem during vmaf_dictionary_set", !err);
+    mu_assert("new dictionary should have been created", dict);
+    const unsigned initial_size = dict->size;
+    mu_assert("this test asserts that initial_size is 8", initial_size == 8);
+    const char *test_key_2 = "key_2";
+    const char *test_val_2 = "val_2";
+    err |= vmaf_dictionary_set(&dict, test_key_2, test_val_2, 0);
+    const char *test_key_3 = "key_3";
+    const char *test_val_3 = "val_3";
+    err |= vmaf_dictionary_set(&dict, test_key_3, test_val_3, 0);
+    const char *test_key_4 = "key_4";
+    const char *test_val_4 = "val_4";
+    err |= vmaf_dictionary_set(&dict, test_key_4, test_val_4, 0);
+    const char *test_key_5 = "key_5";
+    const char *test_val_5 = "val_5";
+    err |= vmaf_dictionary_set(&dict, test_key_5, test_val_5, 0);
+    const char *test_key_6 = "key_6";
+    const char *test_val_6 = "val_6";
+    err |= vmaf_dictionary_set(&dict, test_key_6, test_val_6, 0);
+    const char *test_key_7 = "key_7";
+    const char *test_val_7 = "val_7";
+    err |= vmaf_dictionary_set(&dict, test_key_7, test_val_7, 0);
+    const char *test_key_8 = "key_8";
+    const char *test_val_8 = "val_8";
+    err |= vmaf_dictionary_set(&dict, test_key_8, test_val_8, 0);
+    mu_assert("problem during vmaf_dictionary_set", !err);
+    mu_assert("dictionary should be completely full",
+              dict->size == initial_size && dict->size == dict->cnt);
+    const char *test_key_9 = "key_9";
+    const char *test_val_9 = "val_9";
+    err |= vmaf_dictionary_set(&dict, test_key_9, test_val_9, 0);
+    mu_assert("problem during vmaf_dictionary_set", !err);
+    mu_assert("dictionary capacity should have doubled",
+              dict->cnt == initial_size + 1 && dict->size == initial_size * 2);
+
+    VmafDictionaryEntry *entry = NULL;
+    entry = vmaf_dictionary_get(&dict, "key_5", 0);
+    mu_assert("dictionary should return an entry with valid key", entry);
+
+    entry = vmaf_dictionary_get(&dict, "invalid_key", 0);
+    mu_assert("dictionary should return NULL with invalid key", !entry);
+
+    const char *pre_existing_key = "key_9";
+    const char *new_value = "new_value";
+    err = vmaf_dictionary_set(&dict, pre_existing_key, new_value,
+                               VMAF_DICT_DO_NOT_OVERWRITE);
+    mu_assert("vmaf_dictionary_set should fail with pre-existing key", err);
+    entry = vmaf_dictionary_get(&dict, pre_existing_key, 0);
+    mu_assert("dictionary should return original value with pre-existing key",
+              !strcmp(entry->key, pre_existing_key) &&
+              !strcmp(entry->val, "val_9"));
+    err = vmaf_dictionary_set(&dict, pre_existing_key, new_value, 0);
+    mu_assert("problem during vmaf_dictionary_set", !err);
+    entry = vmaf_dictionary_get(&dict, pre_existing_key, 0);
+    mu_assert("dictionary should return new value with pre-existing key",
+              !strcmp(entry->key, pre_existing_key) &&
+              !strcmp(entry->val, new_value));
+
+    vmaf_dictionary_free(&dict);
+    mu_assert("dictionary should be NULL after free", !dict);
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_vmaf_dictionary);
+    return NULL;
+}


### PR DESCRIPTION
Simple key/value dictionary. This dictionary will be used to implement filter initialization options. See `test/test_dict.c` for api usage examples.