### PR TITLE
force-remove file that possibly does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 clean:
 	cd third_party/libsvm && make clean && cd -
 	rm -rf libvmaf/build
-	rm python/vmaf/core/adm_dwt2_cy.c*
+	rm -f python/vmaf/core/adm_dwt2_cy.c*
 
 install:
 	meson setup libvmaf/build libvmaf --buildtype release && \


### PR DESCRIPTION
This file does not actually exist during build, so it fails when running "rm".
Running "rm -f" is a workaround in case it might exist.