### PR TITLE
libvmaf feature options: public api, cli

### DIFF
--- a/libvmaf/include/libvmaf/feature.h
+++ b/libvmaf/include/libvmaf/feature.h
@@ -1,0 +1,26 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_FEATURE_H__
+#define __VMAF_FEATURE_H__
+
+typedef struct VmafFeatureDictionary VmafFeatureDictionary;
+
+vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val);
+
+#endif /* __VMAF_FEATURE_H__ */

--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -24,6 +24,7 @@
 
 #include "libvmaf/model.h"
 #include "libvmaf/picture.h"
+#include "libvmaf/feature.h"
 
 enum VmafLogLevel {
     VMAF_LOG_LEVEL_NONE = 0,
@@ -94,10 +95,14 @@ int vmaf_use_features_from_model(VmafContext *vmaf, VmafModel *model);
  *
  * @param feature_name Name of feature.
  *
+ * @param opts_dict    Feature extractor options set via
+ *                     `vmaf_feature_dictionary_set()`. If no special options
+ *                     are required this parameter can be set to NULL.
  *
  * @return 0 on success, or < 0 (a negative errno code) on error.
  */
-int vmaf_use_feature(VmafContext *vmaf, const char *feature_name);
+int vmaf_use_feature(VmafContext *vmaf, const char *feature_name,
+                     VmafFeatureDictionary *opts_dict);
 
 /**
  * Import an external feature score.

--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -1,7 +1,9 @@
 #include <errno.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dict.h"
+#include "libvmaf/feature.h"
 
 typedef struct VmafDictionary {
     VmafDictionaryEntry *entry;
@@ -89,6 +91,21 @@ fail:
     return -ENOMEM;
 }
 
+int vmaf_dictionary_copy(VmafDictionary **src, VmafDictionary **dst)
+{
+    if (!src) return -EINVAL;
+    if (!(*src)) return -EINVAL;
+    if (!dst) return -EINVAL;
+
+    int err = 0;
+
+    VmafDictionary *d = *src;
+    for (unsigned i = 0; i < d->cnt; i++)
+        err |= vmaf_dictionary_set(dst, d->entry[i].key, d->entry[i].val, 0);
+
+    return err;
+}
+
 int vmaf_dictionary_free(VmafDictionary **dict)
 {
     if (!dict) return -EINVAL;
@@ -104,4 +121,9 @@ int vmaf_dictionary_free(VmafDictionary **dict)
     *dict = NULL;
 
     return 0;
+}
+
+int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val)
+{
+    return vmaf_dictionary_set((VmafDictionary**)dict, key, val, 0);
 }

--- a/libvmaf/src/dict.h
+++ b/libvmaf/src/dict.h
@@ -37,6 +37,8 @@ int vmaf_dictionary_set(VmafDictionary **dict, const char *key, const char *val,
 const VmafDictionaryEntry *vmaf_dictionary_get(VmafDictionary **dict,
                                                const char *key, uint64_t flags);
 
+int vmaf_dictionary_copy(VmafDictionary **src, VmafDictionary **dst);
+
 int vmaf_dictionary_free(VmafDictionary **dict);
 
 #endif /* __VMAF_SRC_DICT_H__ */

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -130,6 +130,7 @@ int vmaf_fex_ctx_pool_create(VmafFeatureExtractorContextPool **pool,
 
 int vmaf_fex_ctx_pool_aquire(VmafFeatureExtractorContextPool *pool,
                              VmafFeatureExtractor *fex,
+                             VmafDictionary *opts_dict,
                              VmafFeatureExtractorContext **fex_ctx);
 
 int vmaf_fex_ctx_pool_release(VmafFeatureExtractorContextPool *pool,

--- a/libvmaf/test/test_dict.c
+++ b/libvmaf/test/test_dict.c
@@ -87,8 +87,17 @@ static char *test_vmaf_dictionary()
               !strcmp(entry->key, pre_existing_key) &&
               !strcmp(entry->val, new_value));
 
+    VmafDictionary *new_dict = NULL;
+    err = vmaf_dictionary_copy(&dict, &new_dict);
+    mu_assert("problem during vmaf_dictionary_copy", !err);
+    mu_assert("new_dict should no longer be NULL", new_dict);
+    mu_assert("new_dict should have a matching cnt",
+              dict->cnt == new_dict->cnt);
+
     vmaf_dictionary_free(&dict);
     mu_assert("dictionary should be NULL after free", !dict);
+    vmaf_dictionary_free(&new_dict);
+    mu_assert("dictionary should be NULL after free", !new_dict);
 
     return NULL;
 }

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -65,7 +65,7 @@ static char *test_feature_extractor_context_pool()
 
     VmafFeatureExtractorContext *fex_ctx[n_threads];
     for (unsigned i = 0; i < n_threads; i++) {
-        err = vmaf_fex_ctx_pool_aquire(pool, fex, &fex_ctx[i]);
+        err = vmaf_fex_ctx_pool_aquire(pool, fex, NULL, &fex_ctx[i]);
         mu_assert("problem during vmaf_fex_ctx_pool_aquire", !err);
         mu_assert("fex_ctx[i] should be ssim feature extractor",
                   !strcmp(fex_ctx[i]->fex->name, "ssim"));

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -4,10 +4,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <libvmaf/libvmaf.rc.h>
-#include <libvmaf/model.h>
+#include "libvmaf/libvmaf.rc.h"
+#include "libvmaf/model.h"
+#include "libvmaf/feature.h"
 
 #define CLI_SETTINGS_STATIC_ARRAY_LEN 256
+
+typedef struct {
+    const char *name;
+    VmafFeatureDictionary *opts_dict;
+} CLIFeatureConfig;
 
 typedef struct {
     char *path_ref, *path_dist;
@@ -19,7 +25,7 @@ typedef struct {
     enum VmafOutputFormat output_fmt;
     VmafModelConfig model_config[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned model_cnt;
-    char *feature[CLI_SETTINGS_STATIC_ARRAY_LEN];
+    CLIFeatureConfig feature_cfg[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned feature_cnt;
     char *import_path[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned import_cnt;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -211,10 +211,11 @@ int main(int argc, char *argv[])
     }
 
     for (unsigned i = 0; i < c.feature_cnt; i++) {
-        err = vmaf_use_feature(vmaf, c.feature[i]);
+        err = vmaf_use_feature(vmaf, c.feature_cfg[i].name,
+                               c.feature_cfg[i].opts_dict);
         if (err) {
             fprintf(stderr, "problem loading feature extractor: %s\n",
-                    c.feature[i]);
+                    c.feature_cfg[i].name);
             return -1;
         }
     }


### PR DESCRIPTION
Updates the `vmaf_use_feature()` api call to take an options dict, which allows passing of feature options from the public api. This is a breaking change to the `libvmaf_rc` api, but this is still an unpublished release candidate api, so not an issue. 

If you'd like to specify feature options from the `vmaf_rc` command line, usage is as follows. key/value options are set with a `=` and each individual option is delimited with a `:`. This syntax should be familiar if you are used to `libavfilter` filter strings. 

```bash
# register the "psnr" feature extractor
# set values for three separate options (enable_chroma, second_param, third_param)
./vmaf_rc --feature psnr=enable_chroma=false:second_param=123:third_param=1.414 ...`
```

Specifically setting options is not a requirement and thus can be omitted if not required. If a feature extractor has an available option and it is not set, the default value will be used.

```bash
# do not set any specific options, default values will be used.
./vmaf_rc --feature psnr
```

Before this is merged, I still need to verify multithreaded feature extractor options.