### PR TITLE
vmaf_rc: provide a strsep compatibility shim

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -135,6 +135,19 @@ static enum VmafPixelFormat parse_pix_fmt(const char *const optarg,
     return pix_fmt;
 }
 
+#ifndef HAVE_STRSEP
+char *strsep(char **sp, char *sep)
+{
+    char *p, *s;
+    if (sp == NULL || *sp == NULL || **sp == '\0') return NULL;
+    s = *sp;
+    p = s + strcspn(s, sep);
+    if (*p != '\0') *p++ = '\0';
+    *sp = p;
+    return s;
+}
+#endif
+
 static VmafModelConfig parse_model_config(const char *const optarg,
                                           const char *const app)
 {

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -1,6 +1,7 @@
-libvmaf_dep = declare_dependency(
-    link_with : libvmaf,
-)
+compat_cflags = []
+if cc.has_function('strsep')
+  compat_cflags += '-DHAVE_STRSEP'
+endif
 
 vmafossexec = executable(
     'vmafossexec',
@@ -18,8 +19,7 @@ vmaf_rc = executable(
     ['vmaf.c', 'cli_parse.c', 'y4m_input.c', 'vidinput.c', 'yuv_input.c'],
     include_directories : [libvmaf_inc, vmaf_include],
     dependencies: [stdatomic_dependency],
-    c_args : vmaf_cflags_common,
-    cpp_args : vmaf_cflags_common,
+    c_args : [vmaf_cflags_common, compat_cflags],
     link_with : libvmaf_rc.get_static_lib(),
     install : false,
 )


### PR DESCRIPTION
While `strsep()` is not as portable as `strtok()`, it is a much better alternative. This PR provides a compatibility shim, and should fix the Windows build.
