### PR TITLE
libvmaf/motion: support motion in addition to motion2

### DIFF
--- a/libvmaf/src/feature/alias.c
+++ b/libvmaf/src/feature/alias.c
@@ -28,8 +28,16 @@ static Alias alias_map[] = {
         .alias = "adm2",
     },
     {
+        .name = "'VMAF_feature_motion_score'",
+        .alias = "motion",
+    },
+    {
         .name = "'VMAF_feature_motion2_score'",
         .alias = "motion2",
+    },
+    {
+        .name = "'VMAF_feature_motion_integer_score'",
+        .alias = "integer_motion",
     },
     {
         .name = "'VMAF_feature_motion2_integer_score'",

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -93,15 +93,24 @@ static int extract(VmafFeatureExtractor *fex,
                         s->float_stride / sizeof(float),
                         s->float_stride / sizeof(float));
 
-    if (index == 0)
-        return vmaf_feature_collector_append(feature_collector,
+    if (index == 0) {
+        err = vmaf_feature_collector_append(feature_collector,
+                                            "'VMAF_feature_motion_score'",
+                                            0., index);
+        err |= vmaf_feature_collector_append(feature_collector,
                                              "'VMAF_feature_motion2_score'",
                                              0., index);
+        return err;
+    }
 
     double score;
     err = compute_motion(s->blur[blur_idx_2], s->blur[blur_idx_0],
                          ref_pic->w[0], ref_pic->h[0],
                          s->float_stride, s->float_stride, &score);
+    if (err) return err;
+    err = vmaf_feature_collector_append(feature_collector,
+                                        "'VMAF_feature_motion_score'",
+                                        score, index);
     if (err) return err;
     s->score = score;
 
@@ -113,6 +122,7 @@ static int extract(VmafFeatureExtractor *fex,
                          ref_pic->w[0], ref_pic->h[0],
                          s->float_stride, s->float_stride, &score2);
     if (err) return err;
+
     score2 = score2 < score ? score2 : score;
     err = vmaf_feature_collector_append(feature_collector,
                                         "'VMAF_feature_motion2_score'",
@@ -135,7 +145,7 @@ static int close(VmafFeatureExtractor *fex)
 }
 
 static const char *provided_features[] = {
-    "'VMAF_feature_motion2_score'",
+    "'VMAF_feature_motion_score'", "'VMAF_feature_motion2_score'",
     NULL
 };
 

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -303,15 +303,24 @@ static int extract(VmafFeatureExtractor *fex,
 
     s->convolution(ref_pic, &s->blur[blur_idx_0], &s->tmp);
 
-    if (index == 0)
-        return vmaf_feature_collector_append(feature_collector,
+    if (index == 0) {
+        err = vmaf_feature_collector_append(feature_collector,
+                                            "'VMAF_feature_motion_integer_score'",
+                                             0., index);
+        err |= vmaf_feature_collector_append(feature_collector,
                                              "'VMAF_feature_motion2_integer_score'",
                                              0., index);
+        return err;
+    }
 
     uint64_t sad;
     s->sad(&s->blur[blur_idx_2], &s->blur[blur_idx_0], &sad);
     double score = s->score =
         normalize_and_scale_sad(sad, ref_pic->h[0], ref_pic->w[0]);
+    err = vmaf_feature_collector_append(feature_collector,
+                                        "'VMAF_feature_motion_integer_score'",
+                                         score, index);
+    if (err) return err;
 
     if (index == 1) return 0;
 
@@ -341,6 +350,7 @@ static int close(VmafFeatureExtractor *fex)
 }
 
 static const char *provided_features[] = {
+    "'VMAF_feature_motion_integer_score'",
     "'VMAF_feature_motion2_integer_score'",
     NULL
 };


### PR DESCRIPTION
Some published VMAF models require a feature called `motion` which is similar, but has no look-ahead like `motion2`. This PR adds the `motion` feature to both the float/integer motion feature extractors.

```xml
<VMAF version="85b492c">
  <params qualityWidth="1920" qualityHeight="1080" />
  <fyi fps="60.80" />
  <frames>
    <frame frameNum="0" motion="0.000000" motion2="0.000000" integer_motion="0.000000" integer_motion2="0.000000" />
    <frame frameNum="1" motion="4.913140" motion2="4.828127" integer_motion="4.913157" integer_motion2="4.828149" />
    <frame frameNum="2" motion="4.828127" motion2="4.678761" integer_motion="4.828149" integer_motion2="4.678786" />
    <frame frameNum="3" motion="4.678761" motion2="4.678761" integer_motion="4.678786" integer_motion2="4.678786" />
  </frames>
</VMAF>

```