### PR TITLE
feature/float_*: avx2 convolution assumes float buf stride is mod32

### DIFF
--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -50,7 +50,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     AdmState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -71,8 +71,8 @@ static int extract(VmafFeatureExtractor *fex,
     AdmState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/float_ansnr.c
+++ b/libvmaf/src/feature/float_ansnr.c
@@ -38,7 +38,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     AnsnrState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -62,8 +62,8 @@ static int extract(VmafFeatureExtractor *fex,
     AnsnrState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);
 
     double score, score_psnr;
     err = compute_ansnr(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_moment.c
+++ b/libvmaf/src/feature/float_moment.c
@@ -37,7 +37,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     MomentState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -58,8 +58,8 @@ static int extract(VmafFeatureExtractor *fex,
     MomentState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);
 
     double score[4];
     err = compute_1st_moment(s->ref, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -55,7 +55,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 {
     MotionState *s = fex->priv;
 
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     s->tmp = aligned_malloc(s->float_stride * h, 32);
     s->blur[0] = aligned_malloc(s->float_stride * h, 32);
@@ -99,7 +99,7 @@ static int extract(VmafFeatureExtractor *fex,
     unsigned blur_idx_1 = (index + 1) % 3;
     unsigned blur_idx_2 = (index + 2) % 3;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
     convolution_f32_c_s(FILTER_5_s, 5, s->ref, s->blur[blur_idx_0], s->tmp,
                         ref_pic->w[0], ref_pic->h[0],
                         s->float_stride / sizeof(float),

--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -48,7 +48,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     MsSsimState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -69,8 +69,8 @@ static int extract(VmafFeatureExtractor *fex,
     MsSsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);
 
     double score, l_scores[5], c_scores[5], s_scores[5];
     err = compute_ms_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -38,7 +38,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     PsnrState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -62,8 +62,8 @@ static int extract(VmafFeatureExtractor *fex,
     PsnrState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);
 
     double score;
     err = compute_psnr(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -48,7 +48,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     SsimState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -69,8 +69,8 @@ static int extract(VmafFeatureExtractor *fex,
     SsimState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, 0, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, 0, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);
 
     double score, l_score, c_score, s_score;
     err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0], s->float_stride,

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -50,7 +50,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     VifState *s = fex->priv;
-    s->float_stride = sizeof(float) * w;
+    s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
@@ -71,8 +71,8 @@ static int extract(VmafFeatureExtractor *fex,
     VifState *s = fex->priv;
     int err = 0;
 
-    picture_copy(s->ref, ref_pic, -128, ref_pic->bpc);
-    picture_copy(s->dist, dist_pic, -128, dist_pic->bpc);
+    picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
+    picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);
 
     double score, score_num, score_den;
     double scores[8];

--- a/libvmaf/src/feature/picture_copy.c
+++ b/libvmaf/src/feature/picture_copy.c
@@ -20,7 +20,8 @@
 
 #include <libvmaf/picture.h>
 
-void picture_copy_hbd(float *dst, VmafPicture *src, int offset)
+void picture_copy_hbd(float *dst, ptrdiff_t dst_stride,
+                      VmafPicture *src, int offset)
 {
     float *float_data = dst;
     uint16_t *data = src->data[0];
@@ -29,16 +30,17 @@ void picture_copy_hbd(float *dst, VmafPicture *src, int offset)
         for (unsigned j = 0; j < src->w[0]; j++) {
             float_data[j] = (float) data[j] / 4.0 + offset;
         }
-        float_data += src->w[0];
+        float_data += dst_stride / sizeof(float);
         data += src->stride[0] / 2;
     }
     return;
 }
 
-void picture_copy(float *dst, VmafPicture *src, int offset, unsigned bpc)
+void picture_copy(float *dst, ptrdiff_t dst_stride,
+                  VmafPicture *src, int offset, unsigned bpc)
 {
     if (bpc > 8)
-        return picture_copy_hbd(dst, src, offset);
+        return picture_copy_hbd(dst, dst_stride, src, offset);
 
     float *float_data = dst;
     uint8_t *data = src->data[0];
@@ -47,7 +49,7 @@ void picture_copy(float *dst, VmafPicture *src, int offset, unsigned bpc)
         for (unsigned j = 0; j < src->w[0]; j++) {
             float_data[j] = (float) data[j] + offset;
         }
-        float_data += src->w[0];
+        float_data += dst_stride / sizeof(float);
         data += src->stride[0];
     }
 

--- a/libvmaf/src/feature/picture_copy.h
+++ b/libvmaf/src/feature/picture_copy.h
@@ -15,5 +15,7 @@
  *     limitations under the License.
  *
  */
+#include <stddef.h>
 
-void picture_copy(float *dst, VmafPicture *src, int offset, unsigned bpc);
+void picture_copy(float *dst, ptrdiff_t dst_stride, VmafPicture *src,
+                  int offset, unsigned bpc);


### PR DESCRIPTION
`convolution_f32_avx_s` operates with the assumption that float buffer strides are always mod32, which means float buffers need to be padded whenever `((w * sizeof(float)) % 32) != 0`. I've gone ahead and padded all of them, even though not all of them call the convolution. This fixes a mismatch in `float_motion`.