### PR TITLE
Fix test include directories in older meson versions

### DIFF
--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -6,25 +6,25 @@ test_inc = include_directories('.')
 
 test_picture = executable('test_picture',
     ['test.c', 'test_picture.c', '../src/picture.c', '../src/mem.c'],
-    include_directories : [libvmaf_inc, test_inc, '../src/'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     dependencies:[stdatomic_dependency],
 )
 
 test_feature_collector = executable('test_feature_collector',
     ['test.c', 'test_feature_collector.c',],
-    include_directories : [libvmaf_inc, test_inc, '../src/feature/'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/feature/')],
 )
 
 test_thread_pool = executable('test_thread_pool',
     ['test.c', 'test_thread_pool.c', '../src/thread_pool.c'],
-    include_directories : [libvmaf_inc, test_inc, '../src/'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     dependencies : thread_lib,
 )
 
 test_model = executable('test_model',
     ['test.c', 'test_model.c', '../src/svm.cpp', '../src/unpickle.cpp'],
     include_directories : [libvmaf_inc, test_inc, opencontainers_include,
-                           '../src/third_party/ptools/', '../src'],
+                           include_directories('../src/third_party/ptools/'), include_directories('../src')],
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
     objects : libptools.extract_all_objects(),
@@ -36,7 +36,7 @@ test_predict = executable('test_predict',
      '../src/feature/feature_collector.c', '../src/model.c', '../src/svm.cpp',
      '../src/unpickle.cpp'],
     include_directories : [libvmaf_inc, test_inc, opencontainers_include,
-                           '../src/third_party/ptools/', '../src'],
+                           include_directories('../src/third_party/ptools/'), include_directories('../src')],
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
     objects : libptools.extract_all_objects(),
@@ -46,7 +46,7 @@ test_predict = executable('test_predict',
 test_feature_extractor = executable('test_feature_extractor',
     ['test.c', 'test_feature_extractor.c', '../src/mem.c', '../src/picture.c',
      '../src/dict.c', '../src/opt.c'],
-    include_directories : [libvmaf_inc, test_inc, '../src/'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     dependencies : [math_lib, stdatomic_dependency],
     objects : [
       convolution_and_psnr_avx_static_lib.extract_all_objects(),
@@ -57,7 +57,7 @@ test_feature_extractor = executable('test_feature_extractor',
 
 test_dict = executable('test_dict',
     ['test.c', 'test_dict.c'],
-    include_directories : [libvmaf_inc, test_inc, '../src/'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
 )
 
 test('test_picture', test_picture)


### PR DESCRIPTION
This should fix #518 which affects building with meson versions before 0.50.0.