### PR TITLE
Add INSTALL_PREFIX to top level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+INSTALL_PREFIX?=/usr/local
+
 all:
 	cd third_party/libsvm && make lib
 
-	meson setup libvmaf/build libvmaf --buildtype release && \
+	meson setup libvmaf/build libvmaf --buildtype release --prefix=${INSTALL_PREFIX} && \
 	ninja -vC libvmaf/build
 	cd python && python3 setup.py build_ext --build-lib .
 
@@ -11,5 +13,5 @@ clean:
 	rm python/vmaf/core/adm_dwt2_cy.c*
 
 install:
-	meson setup libvmaf/build libvmaf --buildtype release && \
+	meson setup libvmaf/build libvmaf --buildtype release --prefix=${INSTALL_PREFIX} && \
 	ninja -vC libvmaf/build install


### PR DESCRIPTION
The top level Makefile did not provide a way to override the meson default installation path prefix. This allows the build process to override the default by passing in a variable on the make execution if required.

Signed-off-by: Kevin Wheatley <kevin.j.wheatley@gmail.com>