### PR TITLE
vmaf_rc: add --pool to cli

### DIFF
--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -19,6 +19,7 @@ typedef struct {
     char *path_ref, *path_dist;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;
+    enum VmafPoolingMethod pool_method;
     unsigned bitdepth;
     bool use_yuv;
     char *output_path;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 
     for (unsigned i = 0; i < c.model_cnt; i++) {
         double vmaf_score;
-        err = vmaf_score_pooled(vmaf, model[i], VMAF_POOL_METHOD_MEAN,
+        err = vmaf_score_pooled(vmaf, model[i], c.pool_method,
                                 &vmaf_score, 0, picture_index);
         if (err) {
             fprintf(stderr, "problem generating pooled VMAF score\n");


### PR DESCRIPTION
This PR adds a `--pool` arg to the vmaf_rc command line tool. This flag is used to control the pooling method used when the pooled vmaf score is printed. A future commit will also give this flag control over pooled metrics in output logs.