### PR TITLE
libvmaf: add api functions to retrieve individual and pooled feature scores

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -163,7 +163,24 @@ int vmaf_score_at_index(VmafContext *vmaf, VmafModel *model, double *score,
                         unsigned index);
 
 /**
- * Predict pooled VMAF score for a specific interval.
+ * Fetch feature score at specific index.
+ *
+ * @param vmaf          The VMAF context allocated with `vmaf_init()`.
+ *
+ * @param feature_name  Name of the feature to fetch.
+ *
+ * @param index         Picture index.
+ *
+ * @param score         Score.
+ *
+ *
+ * @return 0 on success, or < 0 (a negative errno code) on error.
+ */
+int vmaf_feature_score_at_index(VmafContext *vmaf, const char *feature_name,
+                                double *score, unsigned index);
+
+/**
+ * Pooled VMAF score for a specific interval.
  *
  * @param vmaf         The VMAF context allocated with `vmaf_init()`.
  *
@@ -171,7 +188,7 @@ int vmaf_score_at_index(VmafContext *vmaf, VmafModel *model, double *score,
  *
  * @param pool_method  Temporal pooling method to use.
  *
- * @param score        Predicted score.
+ * @param score        Pooled score.
  *
  * @param index_low    Low picture index of pooling interval.
  *
@@ -183,6 +200,28 @@ int vmaf_score_at_index(VmafContext *vmaf, VmafModel *model, double *score,
 int vmaf_score_pooled(VmafContext *vmaf, VmafModel *model,
                       enum VmafPoolingMethod pool_method, double *score,
                       unsigned index_low, unsigned index_high);
+
+/**
+ * Pooled feature score for a specific interval.
+ *
+ * @param vmaf          The VMAF context allocated with `vmaf_init()`.
+ *
+ * @param feature_name  Name of the feature to fetch.
+ *
+ * @param pool_method   Temporal pooling method to use.
+ *
+ * @param score         Pooled score.
+ *
+ * @param index_low     Low picture index of pooling interval.
+ *
+ * @param index_high    High picture index of pooling interval.
+ *
+ *
+ * @return 0 on success, or < 0 (a negative errno code) on error.
+ */
+int vmaf_feature_score_pooled(VmafContext *vmaf, const char *feature_name,
+                              enum VmafPoolingMethod pool_method, double *score,
+                              unsigned index_low, unsigned index_high);
 
 /**
  * Close a VMAF instance and free all associated memory.

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -349,7 +349,7 @@ int vmaf_feature_score_pooled(VmafContext *vmaf, const char *feature_name,
 {
     if (!vmaf) return -EINVAL;
     if (!feature_name) return -EINVAL;
-    if (index_low >= index_high) return -EINVAL;
+    if (index_low > index_high) return -EINVAL;
     if (!pool_method) return -EINVAL;
 
     vmaf_thread_pool_wait(vmaf->thread_pool);
@@ -399,7 +399,7 @@ int vmaf_score_pooled(VmafContext *vmaf, VmafModel *model,
 {
     if (!vmaf) return -EINVAL;
     if (!score) return -EINVAL;
-    if (index_low >= index_high) return -EINVAL;
+    if (index_low > index_high) return -EINVAL;
     if (!pool_method) return -EINVAL;
 
     vmaf_thread_pool_wait(vmaf->thread_pool);

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -4,6 +4,13 @@ endif
 
 test_inc = include_directories('.')
 
+test_context = executable('test_context',
+    ['test.c', 'test_context.c'],
+    include_directories : [libvmaf_inc, test_inc],
+    link_with : libvmaf_rc.get_static_lib(),
+    dependencies:[stdatomic_dependency],
+)
+
 test_picture = executable('test_picture',
     ['test.c', 'test_picture.c', '../src/picture.c', '../src/mem.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],

--- a/libvmaf/test/test_context.c
+++ b/libvmaf/test/test_context.c
@@ -23,9 +23,7 @@ static char *test_context_init_and_close()
 {
     int err = 0;
     VmafContext *vmaf;
-    VmafConfiguration cfg;
-
-    vmaf_default_configuration(&cfg);
+    VmafConfiguration cfg = { 0 };
 
     err = vmaf_init(&vmaf, cfg);
     mu_assert("problem during vmaf_init", !err);
@@ -35,8 +33,46 @@ static char *test_context_init_and_close()
     return NULL;
 }
 
+static char *test_get_feature_score()
+{
+    int err = 0;
+    VmafContext *vmaf;
+    VmafConfiguration cfg = { 0 };
+
+    err = vmaf_init(&vmaf, cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    err = vmaf_import_feature_score(vmaf, "feature_a", 100., 0);
+    err |= vmaf_import_feature_score(vmaf, "feature_a", 200., 1);
+    err |= vmaf_import_feature_score(vmaf, "feature_a", 300., 2);
+    mu_assert("problem during vmaf_import_feature_score", !err);
+
+    double score;
+    err = vmaf_feature_score_at_index(vmaf, "feature_a", &score, 0);
+    mu_assert("problem during vmaf_feature_score_at_index", !err);
+    mu_assert("retrieved feature score does not match", score == 100.);
+    err = vmaf_feature_score_at_index(vmaf, "feature_a", &score, 1);
+    mu_assert("problem during vmaf_feature_score_at_index", !err);
+    mu_assert("retrieved feature score does not match", score == 200.);
+    err = vmaf_feature_score_at_index(vmaf, "feature_a", &score, 2);
+    mu_assert("problem during vmaf_feature_score_at_index", !err);
+    mu_assert("retrieved feature score does not match", score == 300.);
+
+    err = vmaf_feature_score_pooled(vmaf, "feature_a", VMAF_POOL_METHOD_MEAN,
+                                    &score, 0, 2);
+    mu_assert("problem during vmaf_feature_score_pooled", !err);
+    mu_assert("pooled feature score does not match expected value",
+              score == 200.);
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_context_init_and_close);
+    mu_run_test(test_get_feature_score);
     return NULL;
 }

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
     for (unsigned i = 0; i < c.model_cnt; i++) {
         double vmaf_score;
         err = vmaf_score_pooled(vmaf, model[i], VMAF_POOL_METHOD_MEAN,
-                                &vmaf_score, 0, picture_index);
+                                &vmaf_score, 0, picture_index - 1);
         if (err) {
             fprintf(stderr, "problem generating pooled VMAF score\n");
             return -1;


### PR DESCRIPTION
This PR adds two API functions which brings the following functionality:
- Retrieve an individual feature score at a specific index.
- Retrieve a pooled score for a specific feature on a given interval.

`vmaf_feature_score_at_index()`
`vmaf_feature_score_pooled()`