### PR TITLE
libvmaf_write_output: avoid use of FILE type in public api

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -236,16 +236,17 @@ int vmaf_close(VmafContext *vmaf);
 /**
  * Write VMAF stats to an output file.
  *
- * @param vmaf    The VMAF context allocated with `vmaf_init()`.
+ * @param vmaf         The VMAF context allocated with `vmaf_init()`.
  *
- * @param logfile Output file, previously `fopen()`'d by calling application.
+ * @param output_path  Output file path.
  *
- * @param fmt     Output file format. See `enum VmafOutputFormat` for options.
+ * @param fmt          Output file format.
+ *                     See `enum VmafOutputFormat` for options.
  *
  *
  * @return 0 on success, or < 0 (a negative errno code) on error.
  */
-int vmaf_write_output(VmafContext *vmaf, FILE *logfile,
+int vmaf_write_output(VmafContext *vmaf, const char *output_path,
                       enum VmafOutputFormat fmt);
 
 /**

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -272,15 +272,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "%s: %f\n", c.model_config[i].path, vmaf_score);
     }
 
-    if (c.output_path) {
-        FILE *outfile = fopen(c.output_path, "w");
-        if (!outfile) {
-            fprintf(stderr, "could not open file: %s\n", c.output_path);
-            return -1;
-        }
-        vmaf_write_output(vmaf, outfile, c.output_fmt);
-        fclose(outfile);
-    }
+    if (c.output_path)
+        vmaf_write_output(vmaf, c.output_path, c.output_fmt);
 
     for (unsigned i = 0; i < c.model_cnt; i++) {
         vmaf_model_destroy(model[i]);


### PR DESCRIPTION
Replaces the use of `FILE *` with `const char *` in `vmaf_write_output()`. Solves #632.