### PR TITLE
add missing includes

### DIFF
--- a/libvmaf/src/darray.c
+++ b/libvmaf/src/darray.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 #include "darray.h"
 #include "common/blur_array.h"
 

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -115,6 +115,8 @@ int vmaf_feature_extractor_context_close(VmafFeatureExtractorContext *fex_ctx);
 
 int vmaf_feature_extractor_context_delete(VmafFeatureExtractorContext *fex_ctx);
 
+int vmaf_feature_extractor_context_destroy(VmafFeatureExtractorContext *fex_ctx);
+
 typedef struct VmafFeatureExtractorContextPool {
     struct fex_list_entry {
         VmafFeatureExtractor *fex;

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -20,6 +20,7 @@
 #include <math.h>
 #include <string.h>
 
+#include "common/alignment.h"
 #include "feature_collector.h"
 #include "feature_extractor.h"
 #include "mem.h"

--- a/libvmaf/src/fex_ctx_vector.c
+++ b/libvmaf/src/fex_ctx_vector.c
@@ -17,6 +17,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "feature/feature_extractor.h"
 #include "fex_ctx_vector.h"

--- a/libvmaf/tools/read_frame.c
+++ b/libvmaf/tools/read_frame.c
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "file_io.h"


### PR DESCRIPTION
Trying to build the latest version lead to a few errors about implicit function declaration, such as

```
../src/darray.c:26:2: error: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Werror,-Wimplicit-function-declaration]
```

Rather than try to work around it I tracked them down and added the missing includes which allows this to build cleanly for me.