### PR TITLE
bug fix:  No module named 'vmaf' and module 'vmaf.svmutil' has no attribute 'svm_load_model'

### DIFF
--- a/python/vmaf/script/run_vmaf.py
+++ b/python/vmaf/script/run_vmaf.py
@@ -6,8 +6,12 @@ matplotlib.use('Agg')
 import sys
 import os
 
-import numpy as np
+curpath = os.path.abspath(os.path.dirname(__file__))
+root_path = os.path.split(os.path.split(curpath)[0])[0]
+if root_path not in sys.path:
+    sys.path.append(root_path)
 
+import numpy as np
 from vmaf.config import VmafConfig, DisplayConfig
 from vmaf.core.asset import Asset
 from vmaf.core.quality_runner import VmafQualityRunner
@@ -32,10 +36,12 @@ def print_usage():
 
 
 def main():
+    # 检查参数数量
     if len(sys.argv) < 6:
         print_usage()
         return 2
 
+    # 获取各参赛
     try:
         fmt = sys.argv[1]
         width = int(sys.argv[2])
@@ -46,17 +52,21 @@ def main():
         print_usage()
         return 2
 
+    # 检查width height
     if width < 0 or height < 0:
         print("width and height must be non-negative, but are {w} and {h}".format(w=width, h=height))
         print_usage()
         return 2
 
+    # 检查fmt
     if fmt not in FMTS:
         print_usage()
         return 2
 
+    # 如果有model，获取model_path
     model_path = get_cmd_option(sys.argv, 6, len(sys.argv), '--model')
 
+    # 获取out_fmt
     out_fmt = get_cmd_option(sys.argv, 6, len(sys.argv), '--out-fmt')
     if not (out_fmt is None
             or out_fmt == 'xml'
@@ -65,6 +75,7 @@ def main():
         print_usage()
         return 2
 
+    # 获取pool method
     pool_method = get_cmd_option(sys.argv, 6, len(sys.argv), '--pool')
     if not (pool_method is None
             or pool_method in POOL_METHODS):

--- a/python/vmaf/svmutil.py
+++ b/python/vmaf/svmutil.py
@@ -5,20 +5,20 @@ from __future__ import absolute_import
 import sys
 from vmaf.config import VmafConfig
 
+if VmafConfig.root_path() not in sys.path:
+    sys.path.append(VmafConfig.root_path())
 
 # This will work only when running with a checked out vmaf source, but not via pip install
-libsvm_path = VmafConfig.root_path('third_party', 'libsvm', 'python')
-
-
-if libsvm_path not in sys.path:
-    # Inject {project}/src/libsvm/python to PYTHONPATH dynamically
-    sys.path.append(libsvm_path)
-
+# libsvm_path = VmafConfig.root_path('third_party', 'libsvm', 'python')
+# if libsvm_path not in sys.path:
+#     # Inject {project}/src/libsvm/python to PYTHONPATH dynamically
+#     sys.path.append(libsvm_path)
 
 try:
     # This import will work only if above injection was meaningful (ie: user has the files in the right place)
-    from svmutil import *           # noqa
+    # from svmutil import *           # noqa
+    from third_party.libsvm.python.svmutil import *
 
 except ImportError as e:
-    print("Can't import svmutil from %s: %s" % (libsvm_path, e))
+    print("Can't import svmutil from %s: %s" % (VmafConfig.root_path()+".third_party.libsvm.python.svmutil", e))
     sys.exit(1)


### PR DESCRIPTION
Sorry, I have updated the pull request information.
1.  bug fix:  "No module named 'vmaf'"

```
# the error info:
from vmaf.config import VmafConfig, DisplayConfig
ModuleNotFoundError: No module named 'vmaf'
```

2. bug fix: "module error 'svmutil'  "
```
File /vmaf/python/vmaf/core/train_test_model.py, line 905, in _from_info_loaded
    model = svmutil.svm_load_model(filename + '.model')
AttributeError: module 'vmaf.svmutil' has no attribute 'svm_load_model'
```