### PR TITLE
vmaf: add --quiet/-q option

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -11,7 +11,7 @@
 #include "libvmaf/libvmaf.rc.h"
 #include "libvmaf/model.h"
 
-static const char short_opts[] = "r:d:w:h:p:b:m:o:nv";
+static const char short_opts[] = "r:d:w:h:p:b:m:o:nvq";
 
 enum {
     ARG_OUTPUT_XML = 256,
@@ -43,6 +43,7 @@ static const struct option long_opts[] = {
     { "cpumask",          1, NULL, ARG_CPUMASK },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
+    { "quiet",            0, NULL, 'q' },
     { NULL,               0, NULL, 0 },
 };
 
@@ -77,6 +78,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --feature $string:         additional feature\n"
             " --cpumask: $bitmask        restrict permitted CPU instruction sets\n"
             " --subsample: $unsigned     compute scores only every N frames\n"
+            " --quiet/-q:                disable FPS meter when run in a TTY\n"
             " --no_prediction/-n:        no prediction, extract features only\n"
             " --version/-v:              print version and exit\n"
            );
@@ -287,6 +289,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'n':
             settings->no_prediction = true;
+            break;
+        case 'q':
+            settings->quiet = true;
             break;
         case 'v':
             fprintf(stderr, "%s\n", vmaf_version());

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -31,6 +31,7 @@ typedef struct {
     unsigned subsample;
     unsigned thread_cnt;
     bool no_prediction;
+    bool quiet;
     unsigned cpumask;
 } CLISettings;
 

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -220,7 +220,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    const time_t t = clock();
+    float fps = 0.;
+    const time_t t0 = clock();
     unsigned picture_index;
     for (picture_index = 0 ;; picture_index++) {
         VmafPicture pic_ref, pic_dist;
@@ -243,12 +244,15 @@ int main(int argc, char *argv[])
             break;
         }
 
-        if (istty) {
+        if (istty && !c.quiet) {
+            if (picture_index > 0 && !(picture_index % 10)) {
+                fps = (picture_index + 1) /
+                      (((float)clock() - t0) / CLOCKS_PER_SEC);
+            }
+
             fprintf(stderr, "\r%d frame%s %s %.2f FPS\033[K",
                     picture_index + 1, picture_index ? "s" : " ",
-                    spinner[picture_index % spinner_length],
-                    (picture_index + 1) /
-                    (((float)clock() - t) / CLOCKS_PER_SEC));
+                    spinner[picture_index % spinner_length], fps);
             fflush(stderr);
         }
 


### PR DESCRIPTION
Adds an option (`--quiet/-q`) for manually disabling the realtime fps meter when run in a tty, useful for avoiding the overhead the fps meter brings when benchmarking. Also in this PR is a modification to how often FPS is computed. Instead of computing fps every frame, now fps is computed every 10 frames.