### PR TITLE
add missing return type to `vmaf_feature_dictionary_set`

### DIFF
--- a/libvmaf/include/libvmaf/feature.h
+++ b/libvmaf/include/libvmaf/feature.h
@@ -21,6 +21,6 @@
 
 typedef struct VmafFeatureDictionary VmafFeatureDictionary;
 
-vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val);
+int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val);
 
 #endif /* __VMAF_FEATURE_H__ */


### PR DESCRIPTION
the return type was missing on `vmaf_feature_dictionary_set` causing compilation problems. This fixes it.