### PR TITLE
Modifications to accept yuv 12 bit inputs, removed pixel normalization

### DIFF
--- a/libvmaf/src/combo.c
+++ b/libvmaf/src/combo.c
@@ -365,6 +365,18 @@ void* combo_threadfunc(void* vmaf_thread_data)
                 // max psnr 72.0 for 10-bit per Ioannis
                 ret = compute_ansnr(ref_buf, dis_buf, w, h, stride, stride, &score, &score_psnr, 255.75, 72.0);
             }
+            else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+            {
+                // 12 bit gets normalized to 8 bit, peak is (2^12 - 1) / 16.0 = 255.9375
+                // max psnr 84.0 for 12-bit
+                ret = compute_ansnr(ref_buf, dis_buf, w, h, stride, stride, &score, &score_psnr, 255.9375, 84.0);
+            }
+            else if (!strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le"))
+            {
+                // 16 bit gets normalized to 8 bit, peak is (2^16 - 1)) / 256.0 = 255.99609375
+                // max psnr 108.0 for 16-bit
+                ret = compute_ansnr(ref_buf, dis_buf, w, h, stride, stride, &score, &score_psnr, 255.99609375, 108.0);
+            }
             else
             {
                 sprintf(errmsg, "unknown format %s.\n", fmt);

--- a/libvmaf/src/feature/float_ansnr.c
+++ b/libvmaf/src/feature/float_ansnr.c
@@ -44,8 +44,21 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
-    s->peak = bpc == 8 ? 255.0 : 255.75;
-    s->psnr_max = bpc == 8 ? 60.0 : 72.0;
+    if (bpc == 8) {
+        s->peak = 255.0;
+        s->psnr_max = 60.0;
+    } else if (bpc == 10) {
+        s->peak = 255.75;
+        s->psnr_max = 72.0;
+    } else if (bpc == 12) {
+        s->peak = 255.9375;
+        s->psnr_max = 84.0;
+    } else if (bpc == 16) {
+        s->peak = 255.99609375;
+        s->psnr_max = 108.0;
+    } else {
+        goto fail;
+    }
 
     return 0;
 

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -44,8 +44,21 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->dist = aligned_malloc(s->float_stride * h, 32);
     if (!s->dist) goto free_ref;
 
-    s->peak = bpc == 8 ? 255.0 : 255.75;
-    s->psnr_max = bpc == 8 ? 60.0 : 72.0;
+    if (bpc == 8) {
+        s->peak = 255.0;
+        s->psnr_max = 60.0;
+    } else if (bpc == 10) {
+        s->peak = 255.75;
+        s->psnr_max = 72.0;
+    } else if (bpc == 12) {
+        s->peak = 255.9375;
+        s->psnr_max = 84.0;
+    } else if (bpc == 16) {
+        s->peak = 255.99609375;
+        s->psnr_max = 108.0;
+    } else {
+        goto fail;
+    }
 
     return 0;
 

--- a/libvmaf/src/feature/picture_copy.c
+++ b/libvmaf/src/feature/picture_copy.c
@@ -28,7 +28,8 @@ void picture_copy_hbd(float *dst, ptrdiff_t dst_stride,
 
     for (unsigned i = 0; i < src->h[0]; i++) {
         for (unsigned j = 0; j < src->w[0]; j++) {
-            float_data[j] = (float) data[j] / 4.0 + offset;
+            //float_data[j] = (float) data[j] / 4.0 + offset;
+            float_data[j] = (float)data[j] + offset;
         }
         float_data += dst_stride / sizeof(float);
         data += src->stride[0] / 2;

--- a/libvmaf/src/feature/picture_copy.c
+++ b/libvmaf/src/feature/picture_copy.c
@@ -21,15 +21,14 @@
 #include <libvmaf/picture.h>
 
 void picture_copy_hbd(float *dst, ptrdiff_t dst_stride,
-                      VmafPicture *src, int offset)
+                      VmafPicture *src, int offset, float scaler)
 {
     float *float_data = dst;
     uint16_t *data = src->data[0];
 
     for (unsigned i = 0; i < src->h[0]; i++) {
         for (unsigned j = 0; j < src->w[0]; j++) {
-            //float_data[j] = (float) data[j] / 4.0 + offset;
-            float_data[j] = (float)data[j] + offset;
+            float_data[j] = (float) data[j] / scaler + offset;
         }
         float_data += dst_stride / sizeof(float);
         data += src->stride[0] / 2;
@@ -40,8 +39,12 @@ void picture_copy_hbd(float *dst, ptrdiff_t dst_stride,
 void picture_copy(float *dst, ptrdiff_t dst_stride,
                   VmafPicture *src, int offset, unsigned bpc)
 {
-    if (bpc > 8)
-        return picture_copy_hbd(dst, dst_stride, src, offset);
+    if (bpc == 10)
+        return picture_copy_hbd(dst, dst_stride, src, offset, 4.0f);
+    else if (bpc == 12)
+        return picture_copy_hbd(dst, dst_stride, src, offset, 16.0f);
+    else if (bpc == 16)
+        return picture_copy_hbd(dst, dst_stride, src, offset, 256.0f);
 
     float *float_data = dst;
     uint8_t *data = src->data[0];

--- a/libvmaf/src/feature/psnr_tools.c
+++ b/libvmaf/src/feature/psnr_tools.c
@@ -34,15 +34,22 @@ int psnr_constants(const char *fmt, double *peak, double *psnr_max) {
     {
         // 10 bit gets normalized to 8 bit, peak is 1023 / 4.0 = 255.75
         // max psnr 72.0 for 10-bit per Ioannis
-        //TODO: Need to change these values as we do not normalize to 8 bit
         *peak = 255.75;
         *psnr_max = 72.0;
     }
     else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
-        //TODO: Need to change these values as we do not normalize to 8 bit
-        *peak = 255.75;
-        *psnr_max = 72.0;
+        // 12 bit gets normalized to 8 bit, peak is (2^12 - 1) / 16.0 = 255.9375
+        // max psnr 84.0 for 12-bit
+        *peak = 255.9375;
+        *psnr_max = 84.0;
+    }
+    else if (!strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le"))
+    {
+        // 16 bit gets normalized to 8 bit, peak is (2^16 - 1)) / 256.0 = 255.99609375
+        // max psnr 108.0 for 16-bit
+        *peak = 255.99609375;
+        *psnr_max = 108.0;
     }
     else
     {

--- a/libvmaf/src/feature/psnr_tools.c
+++ b/libvmaf/src/feature/psnr_tools.c
@@ -34,6 +34,13 @@ int psnr_constants(const char *fmt, double *peak, double *psnr_max) {
     {
         // 10 bit gets normalized to 8 bit, peak is 1023 / 4.0 = 255.75
         // max psnr 72.0 for 10-bit per Ioannis
+        //TODO: Need to change these values as we do not normalize to 8 bit
+        *peak = 255.75;
+        *psnr_max = 72.0;
+    }
+    else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    {
+        //TODO: Need to change these values as we do not normalize to 8 bit
         *peak = 255.75;
         *psnr_max = 72.0;
     }

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -118,8 +118,8 @@ static unsigned parse_bitdepth(const char *const optarg, const int option,
                                const char *const app)
 {
     unsigned bitdepth = parse_unsigned(optarg, option, app);
-    if (!((bitdepth == 8) || (bitdepth == 10) || (bitdepth == 12)))
-        error(app, optarg, option, "a valid bitdepth (8/10/12)");
+    if (!((bitdepth == 8) || (bitdepth == 10) || (bitdepth == 12) || (bitdepth == 16)))
+        error(app, optarg, option, "a valid bitdepth (8/10/12/16)");
     return bitdepth;
 }
 

--- a/libvmaf/tools/main.cpp
+++ b/libvmaf/tools/main.cpp
@@ -49,7 +49,7 @@ static bool cmdOptionExists(char** begin, char** end, const std::string& option)
 static void print_usage(int argc, char *argv[])
 {
     fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--ssim] [--ms-ssim] [--phone-model] [--pool pool_method] [--ci]\n", argv[0]);
-    fprintf(stderr, "fmt:\n\tyuv420p\n\tyuv422p\n\tyuv444p\n\tyuv420p10le\n\tyuv422p10le\n\tyuv444p10le\n\n");
+    fprintf(stderr, "fmt:\n\tyuv420p\n\tyuv422p\n\tyuv444p\n\tyuv420p10le\n\tyuv422p10le\n\tyuv444p10le\n\tyuv420p12le\n\tyuv422p12le\n\tyuv444p12le\n\tyuv420p16le\n\tyuv422p16le\n\tyuv444p16le\n\n");
     fprintf(stderr, "log_fmt:\n\txml (default)\n\tjson\n\tcsv\n\n");
     fprintf(stderr, "n_thread:\n\tmaximum threads to use (default 0 - use all threads)\n\n");
     fprintf(stderr, "n_subsample:\n\tn indicates computing on one of every n frames (default 1)\n\n");
@@ -119,7 +119,7 @@ static int run_wrapper(char *fmt, int width, int height, char *ref_path, char *d
     s->ref_rfile = NULL;
     s->dis_rfile = NULL;
 
-    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv420p10le"))
+    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv420p16le"))
     {
         if ((width * height) % 2 != 0)
         {
@@ -129,11 +129,11 @@ static int run_wrapper(char *fmt, int width, int height, char *ref_path, char *d
         }
         s->offset = width * height / 2;
     }
-    else if (!strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv422p10le"))
+    else if (!strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv422p16le"))
     {
         s->offset = width * height;
     }
-    else if (!strcmp(fmt, "yuv444p") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv444p") || !strcmp(fmt, "yuv444p10le") || !strcmp(fmt, "yuv444p12le") || !strcmp(fmt, "yuv444p16le"))
     {
         s->offset = width * height * 2;
     }
@@ -170,7 +170,10 @@ static int run_wrapper(char *fmt, int width, int height, char *ref_path, char *d
 #endif
         {
             size_t frame_size = width * height + s->offset;
-            if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+            if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le")
+                || !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le")
+                || !strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le")
+            )
             {
                 frame_size *= 2;
             }

--- a/libvmaf/tools/moment_main.c
+++ b/libvmaf/tools/moment_main.c
@@ -35,7 +35,13 @@ static void usage(void)
          "\tyuv444p\n"
          "\tyuv420p10le\n"
          "\tyuv422p10le\n"
-         "\tyuv444p10le"
+         "\tyuv444p10le\n"
+         "\tyuv420p12le\n"
+         "\tyuv422p12le\n"
+         "\tyuv444p12le\n"
+         "\tyuv420p16le\n"
+         "\tyuv422p16le\n"
+         "\tyuv444p16le"
     );
 }
 

--- a/libvmaf/tools/ms_ssim_main.c
+++ b/libvmaf/tools/ms_ssim_main.c
@@ -32,7 +32,13 @@ static void usage(void)
          "\tyuv444p\n"
          "\tyuv420p10le\n"
          "\tyuv422p10le\n"
-         "\tyuv444p10le"
+         "\tyuv444p10le\n"
+         "\tyuv420p12le\n"
+         "\tyuv422p12le\n"
+         "\tyuv444p12le\n"
+         "\tyuv420p16le\n"
+         "\tyuv422p16le\n"
+         "\tyuv444p16le\n"
     );
 }
 

--- a/libvmaf/tools/psnr_main.c
+++ b/libvmaf/tools/psnr_main.c
@@ -32,7 +32,13 @@ static void usage(void)
          "\tyuv444p\n"
          "\tyuv420p10le\n"
          "\tyuv422p10le\n"
-         "\tyuv444p10le"
+         "\tyuv444p10le\n"
+         "\tyuv420p12le\n"
+         "\tyuv422p12le\n"
+         "\tyuv444p12le\n"
+         "\tyuv420p16le\n"
+         "\tyuv422p16le\n"
+         "\tyuv444p16le\n"
     );
 }
 

--- a/libvmaf/tools/read_frame.c
+++ b/libvmaf/tools/read_frame.c
@@ -132,8 +132,9 @@ static int read_image_w(FILE * rfile, float *buf, float off, int width, int heig
 
 		for (j = 0; j < width; ++j)
 		{
-			row_ptr[j] = tmp_buf[j] / 4.0 + off; // '/4' to convert from 10 to 8-bit
-		}
+			//row_ptr[j] = tmp_buf[j] / 4.0 + off; // '/4' to convert from 10 to 8-bit
+            row_ptr[j] = tmp_buf[j] + off; 
+        }
 
 		byte_ptr += stride;
 	}
@@ -160,7 +161,8 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     {
         ret = read_image_b(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
     }
@@ -183,7 +185,8 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
@@ -210,7 +213,8 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
             goto fail_or_end;
         }
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         if (fread(temp_data, 2, user_data->offset, user_data->ref_rfile) != (size_t)user_data->offset)
         {
@@ -233,7 +237,8 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
             goto fail_or_end;
         }
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -267,7 +272,8 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
@@ -294,7 +300,8 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
             goto fail_or_end;
         }
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -315,7 +322,7 @@ fail_or_end:
 
 int get_frame_offset(const char *fmt, int w, int h, size_t *offset)
 {
-    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv420p10le"))
+    if (!strcmp(fmt, "yuv420p") || !strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv420p12le"))
     {
         if ((w * h) % 2 != 0)
         {
@@ -324,11 +331,11 @@ int get_frame_offset(const char *fmt, int w, int h, size_t *offset)
         }
         *offset = w * h / 2;
     }
-    else if (!strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv422p10le"))
+    else if (!strcmp(fmt, "yuv422p") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv422p12le"))
     {
         *offset = w * h;
     }
-    else if (!strcmp(fmt, "yuv444p") || !strcmp(fmt, "yuv444p10le"))
+    else if (!strcmp(fmt, "yuv444p") || !strcmp(fmt, "yuv444p10le") || !strcmp(fmt, "yuv444p12le"))
     {
         *offset = w * h * 2;
     }

--- a/libvmaf/tools/read_frame.c
+++ b/libvmaf/tools/read_frame.c
@@ -101,7 +101,7 @@ fail_or_end:
 /**
  * Note: stride is in terms of bytes; image is 10-bit little-endian
  */
-static int read_image_w(FILE * rfile, float *buf, float off, int width, int height, int stride)
+static int read_image_w(FILE * rfile, float *buf, float off, int width, int height, int stride, float scaler)
 {
 	// make sure unsigned short is 2 bytes
 	assert(sizeof(unsigned short) == 2);
@@ -132,8 +132,7 @@ static int read_image_w(FILE * rfile, float *buf, float off, int width, int heig
 
 		for (j = 0; j < width; ++j)
 		{
-			//row_ptr[j] = tmp_buf[j] / 4.0 + off; // '/4' to convert from 10 to 8-bit
-            row_ptr[j] = tmp_buf[j] + off; 
+			row_ptr[j] = tmp_buf[j] / scaler + off; // '/4' to convert from x-bit to 8-bit
         }
 
 		byte_ptr += stride;
@@ -161,10 +160,17 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     {
         ret = read_image_b(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
     {
-        ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte);
+        ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte, 4.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    {
+        ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte, 16.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le"))
+    {
+        ret = read_image_w(user_data->ref_rfile, ref_data, 0, w, h, stride_byte, 256.0f);
     }
     else
     {
@@ -185,10 +191,17 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
     {
-        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 4.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    {
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 16.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le"))
+    {
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 256.0f);
     }
     else
     {
@@ -214,7 +227,9 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
         }
     }
     else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le") ||
+             !strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le")
+            )
     {
         if (fread(temp_data, 2, user_data->offset, user_data->ref_rfile) != (size_t)user_data->offset)
         {
@@ -238,7 +253,9 @@ int read_frame(float *ref_data, float *dis_data, float *temp_data, int stride_by
         }
     }
     else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le") ||
+             !strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le")
+            )
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {
@@ -272,10 +289,17 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
     {
         ret = read_image_b(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
     }
-    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le"))
     {
-        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte);
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 4.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+    {
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 16.0f);
+    }
+    else if (!strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le"))
+    {
+        ret = read_image_w(user_data->dis_rfile, dis_data, 0, w, h, stride_byte, 256.0f);
     }
     else
     {
@@ -301,7 +325,9 @@ int read_noref_frame(float *dis_data, float *temp_data, int stride_byte, void *s
         }
     }
     else if (!strcmp(fmt, "yuv420p10le") || !strcmp(fmt, "yuv422p10le") || !strcmp(fmt, "yuv444p10le") ||
-             !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le"))
+            !strcmp(fmt, "yuv420p12le") || !strcmp(fmt, "yuv422p12le") || !strcmp(fmt, "yuv444p12le") ||
+            !strcmp(fmt, "yuv420p16le") || !strcmp(fmt, "yuv422p16le") || !strcmp(fmt, "yuv444p16le")
+             )
     {
         if (fread(temp_data, 2, user_data->offset, user_data->dis_rfile) != (size_t)user_data->offset)
         {

--- a/libvmaf/tools/read_frame.h
+++ b/libvmaf/tools/read_frame.h
@@ -21,7 +21,7 @@
 
 struct data
 {
-    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
+    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le, yuv420p12le, yuv422p12le, yuv444p12le, yuv420p16le, yuv422p16le, yuv444p16le */
     int width;
     int height;
     size_t offset;
@@ -32,7 +32,7 @@ struct data
 
 struct noref_data
 {
-    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le */
+    char* format; /* yuv420p, yuv422p, yuv444p, yuv420p10le, yuv422p10le, yuv444p10le, yuv420p12le, yuv422p12le, yuv444p12le, yuv420p16le, yuv422p16le, yuv444p16le */
     int width;
     int height;
     size_t offset;

--- a/libvmaf/tools/ssim_main.c
+++ b/libvmaf/tools/ssim_main.c
@@ -32,7 +32,13 @@ static void usage(void)
          "\tyuv444p\n"
          "\tyuv420p10le\n"
          "\tyuv422p10le\n"
-         "\tyuv444p10le"
+         "\tyuv444p10le\n"
+         "\tyuv420p12le\n"
+         "\tyuv422p12le\n"
+         "\tyuv444p12le\n"
+         "\tyuv420p16le\n"
+         "\tyuv422p16le\n"
+         "\tyuv444p16le\n"
     );
 }
 

--- a/libvmaf/tools/vmaf_feature_main.c
+++ b/libvmaf/tools/vmaf_feature_main.c
@@ -35,7 +35,13 @@ static void usage(void)
          "\tyuv444p\n"
          "\tyuv420p10le\n"
          "\tyuv422p10le\n"
-         "\tyuv444p10le"
+         "\tyuv444p10le\n"
+         "\tyuv420p12le\n"
+         "\tyuv422p12le\n"
+         "\tyuv444p12le\n"
+         "\tyuv420p16le\n"
+         "\tyuv422p16le\n"
+         "\tyuv444p16le"
     );
 }
 

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -11,7 +11,9 @@ from vmaf.core.feature_extractor import VmafFeatureExtractor, MomentFeatureExtra
 from vmaf.core.asset import Asset
 from vmaf.core.result_store import FileSystemResultStore
 
-from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing
+from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing, \
+    set_default_576_324_10bit_videos_for_testing, set_default_576_324_12bit_videos_for_testing, \
+    set_default_576_324_16bit_videos_for_testing
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -229,6 +231,87 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['Moment_feature_dis1st_score'], 59.788567297525134, places=4)
         self.assertAlmostEqual(results[1]['Moment_feature_dis2nd_score'], 4696.668388042269, places=4)
         self.assertAlmostEqual(results[1]['Moment_feature_disvar_score'], 1121.519917231203, places=4)
+
+    def test_run_moment_fextractor_10bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing()
+
+        self.fextractor = MomentFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Moment_feature_ref1st_score'], 59.788567297525134 * 4, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_ref2nd_score'], 4696.668388042269 * 16, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_refvar_score'], 1121.519917231203 * 16, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis1st_score'], 61.332006624999984 * 4, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis2nd_score'], 4798.659574041666 * 16, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_disvar_score'], 1036.837184348847 * 16, places=4)
+
+        self.assertAlmostEqual(results[1]['Moment_feature_ref1st_score'], 59.788567297525134 * 4, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_ref2nd_score'], 4696.668388042269 * 16, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_refvar_score'], 1121.519917231203 * 16, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis1st_score'], 59.788567297525134 * 4, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis2nd_score'], 4696.668388042269 * 16, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_disvar_score'], 1121.519917231203 * 16, places=4)
+
+    def test_run_moment_fextractor_12bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+
+        self.fextractor = MomentFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Moment_feature_ref1st_score'], 979.6711819844536, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_ref2nd_score'], 1238135.8363054413, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_refvar_score'], 278292.25886465114, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis1st_score'], 996.2818072702333, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis2nd_score'], 1255533.4389574758, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_disvar_score'], 262952.8893540034, places=4)
+
+        self.assertAlmostEqual(results[1]['Moment_feature_ref1st_score'], 979.6711819844536, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_ref2nd_score'], 1238135.8363054413, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_refvar_score'], 278292.25886465114, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis1st_score'], 979.6711819844536, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis2nd_score'], 1238135.8363054413, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_disvar_score'], 278292.25886465114, places=4)
+
+    def test_run_moment_fextractor_16bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
+
+        self.fextractor = MomentFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Moment_feature_ref1st_score'], 979.6711819844536 * 16.0, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_ref2nd_score'], 1238135.8363054413 * 256.0, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_refvar_score'], 278292.25886465114 * 256.0, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis1st_score'], 996.2818072702333 * 16.0, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_dis2nd_score'], 1255533.4389574758 * 256.0, places=4)
+        self.assertAlmostEqual(results[0]['Moment_feature_disvar_score'], 262952.8893540034 * 256.0, places=4)
+
+        self.assertAlmostEqual(results[1]['Moment_feature_ref1st_score'], 979.6711819844536 * 16.0, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_ref2nd_score'], 1238135.8363054413 * 256.0, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_refvar_score'], 278292.25886465114 * 256.0, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis1st_score'], 979.6711819844536 * 16.0, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_dis2nd_score'], 1238135.8363054413 * 256.0, places=4)
+        self.assertAlmostEqual(results[1]['Moment_feature_disvar_score'], 278292.25886465114 * 256.0, places=4)
 
     def test_run_psnr_fextractor(self):
 

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -7,7 +7,7 @@ import re
 from vmaf.config import VmafConfig
 from vmaf.core.feature_extractor import VmafFeatureExtractor, MomentFeatureExtractor, \
     PsnrFeatureExtractor, SsimFeatureExtractor, MsSsimFeatureExtractor, VifFrameDifferenceFeatureExtractor, \
-    AnsnrFeatureExtractor
+    AnsnrFeatureExtractor, PypsnrFeatureExtractor
 from vmaf.core.asset import Asset
 from vmaf.core.result_store import FileSystemResultStore
 
@@ -525,6 +525,86 @@ class FeatureExtractorTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['PSNR_feature_psnr_score'], 27.645446604166665, places=8)
         self.assertAlmostEqual(results[1]['PSNR_feature_psnr_score'], 31.87683660416667, places=8)
+
+    def test_run_pypsnr_fextractor(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+
+        self.fextractor = PypsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 30.755063979166664, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 38.449441057158786, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 40.9919102486235, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 60.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 60.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 60.0, places=4)
+
+    def test_run_pypsnr_fextractor_10bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing()
+
+        self.fextractor = PypsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 30.780573260053277, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 38.769832063651364, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 41.28418847734209, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 72.0, places=4)
+
+    def test_run_pypsnr_fextractor_12bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+
+        self.fextractor = PypsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 32.577817940053734, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 39.044961148023255, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 41.28696563449846, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 84.0, places=4)
+
+    def test_run_pypsnr_fextractor_16bit(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
+
+        self.fextractor = PypsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 32.579806240311484, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 39.046949448281005, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 41.288953934756215, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 108.0, places=4)
 
 
 class ParallelFeatureExtractorTest(unittest.TestCase):

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -13,7 +13,7 @@ from vmaf.core.result_store import FileSystemResultStore
 
 from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing, \
     set_default_576_324_10bit_videos_for_testing, set_default_576_324_12bit_videos_for_testing, \
-    set_default_576_324_16bit_videos_for_testing
+    set_default_576_324_16bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -562,6 +562,26 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 30.780573260053277, places=4)
         self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 38.769832063651364, places=4)
         self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 41.28418847734209, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 72.0, places=4)
+
+    def test_run_pypsnr_fextractor_10bit_b(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing_b()
+
+        self.fextractor = PypsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            result_store=None
+        )
+        self.fextractor.run()
+
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnry_score'], 32.57145231892744, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnru_score'], 39.03859552689696, places=4)
+        self.assertAlmostEqual(results[0]['Pypsnr_feature_psnrv_score'], 41.28060001337217, places=4)
         self.assertAlmostEqual(results[1]['Pypsnr_feature_psnry_score'], 72.0, places=4)
         self.assertAlmostEqual(results[1]['Pypsnr_feature_psnru_score'], 72.0, places=4)
         self.assertAlmostEqual(results[1]['Pypsnr_feature_psnrv_score'], 72.0, places=4)

--- a/python/test/quality_runner_test.py
+++ b/python/test/quality_runner_test.py
@@ -14,7 +14,8 @@ from vmaf.core.quality_runner import VmafLegacyQualityRunner, VmafQualityRunner,
 from vmaf.core.result_store import FileSystemResultStore
 from vmaf.tools.stats import ListStats
 
-from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing
+from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing, \
+    set_default_576_324_10bit_videos_for_testing, set_default_576_324_12bit_videos_for_testing
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -65,21 +66,7 @@ class QualityRunnerTest(unittest.TestCase):
 
     def test_run_vmaf_legacy_runner_10le(self):
 
-        ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv")
-        dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv422p10le.yuv")
-        asset = Asset(dataset="test", content_id=0, asset_id=0,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=dis_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
-
-        asset_original = Asset(dataset="test", content_id=0, asset_id=1,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=ref_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing()
 
         self.runner = VmafLegacyQualityRunner(
             [asset, asset_original],
@@ -103,6 +90,33 @@ class QualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAF_legacy_score'], 65.37503585467225, places=4)
         self.assertAlmostEqual(results[1]['VMAF_legacy_score'], 96.444658329804156, places=4)
+
+    def test_run_vmaf_legacy_runner_12le(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+
+        self.runner = VmafLegacyQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            delete_workdir=True,
+            result_store=None
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.5129766666666666, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 2.932176666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_adm_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_ansnr_score'], 24.906395333333336, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAF_feature_vif_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 2.932176666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_feature_adm_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_feature_ansnr_score'], 31.004588333333334, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAF_legacy_score'], 72.18465772375357, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_legacy_score'], 95.94112242732263, places=4)
 
     def test_run_vmaf_legacy_runner_with_result_store(self):
 

--- a/python/test/reader_test.py
+++ b/python/test/reader_test.py
@@ -172,10 +172,10 @@ class YuvReaderTest10le(unittest.TestCase):
     def test_yuv_reader(self):
 
         with YuvReader(
-            filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv"),
-            width=576,
-            height=324,
-            yuv_type='yuv422p10le'
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv422p10le'
         ) as yuv_reader:
             self.assertEqual(yuv_reader.num_bytes, 35831808)
             self.assertEqual(yuv_reader.num_frms, 48)
@@ -184,10 +184,10 @@ class YuvReaderTest10le(unittest.TestCase):
     def test_with(self):
 
         with YuvReader(
-            filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv"),
-            width=576,
-            height=324,
-            yuv_type='yuv422p10le'
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv422p10le'
         ) as yuv_reader:
 
             y, u, v = yuv_reader.next()
@@ -246,6 +246,168 @@ class YuvReaderTest10le(unittest.TestCase):
         self.assertEqual(len(y_2ndmoments), 48)
         self.assertAlmostEqual(float(np.mean(y_1stmoments)), 61.332006624999984, places=4)
         self.assertAlmostEqual(float(np.mean(y_2ndmoments)), 4798.659574041666, places=4)
+
+
+class YuvReaderTest12le(unittest.TestCase):
+
+    def test_yuv_reader(self):
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p12le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv420p12le'
+        ) as yuv_reader:
+            self.assertEqual(yuv_reader.num_bytes, 1679616)
+            self.assertEqual(yuv_reader.num_frms, 3)
+            self.assertEqual(yuv_reader._get_uv_width_height_multiplier(), (0.5, 0.5))
+
+    def test_with(self):
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p12le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv420p12le'
+        ) as yuv_reader:
+
+            y, u, v = yuv_reader.next()
+            y, u, v = y.astype(np.double) / 16.0, u.astype(np.double) / 16.0, v.astype(np.double) / 16.0
+
+            self.assertEqual(y[0][0], 87)
+            self.assertEqual(y[0][1], 131)
+            self.assertEqual(y[1][0], 95)
+
+            self.assertEqual(u[0][0], 92)
+            self.assertEqual(u[0][1], 97)
+            self.assertEqual(u[1][0], 90)
+
+            self.assertEqual(v[0][0], 121)
+            self.assertEqual(v[0][1], 126)
+            self.assertEqual(v[1][0], 122)
+
+            self.assertAlmostEqual(y.mean(), 61.928749785665296, places=4)
+            self.assertAlmostEqual(u.mean(), 114.6326517489712, places=4)
+            self.assertAlmostEqual(v.mean(), 122.05084019204389, places=4)
+
+            y, u, v = yuv_reader.next()
+            y, u, v = y.astype(np.double) / 16.0, u.astype(np.double) / 16.0, v.astype(np.double) / 16.0
+
+            self.assertEqual(y[0][0], 142)
+            self.assertEqual(y[0][1], 128)
+            self.assertEqual(y[1][0], 134)
+
+            self.assertEqual(u[0][0], 93)
+            self.assertEqual(u[0][1], 102)
+            self.assertEqual(u[1][0], 91)
+
+            self.assertEqual(v[0][0], 128)
+            self.assertEqual(v[0][1], 126)
+            self.assertEqual(v[1][0], 124)
+
+            self.assertAlmostEqual(y.mean(), 61.265260631001375, places=4)
+            self.assertAlmostEqual(u.mean(), 114.72515860768175, places=4)
+            self.assertAlmostEqual(v.mean(), 122.12022033607681, places=4)
+
+    def test_iteration(self):
+
+        y_1stmoments = []
+        y_2ndmoments = []
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p12le.yuv"),
+                width=576, height=324, yuv_type='yuv420p12le') as yuv_reader:
+
+            for y, u, v in yuv_reader:
+                y, u, v = y.astype(np.double) / 16.0, u.astype(np.double) / 16.0, v.astype(np.double) / 16.0
+                y_1stmoments.append(y.mean())
+                y_2ndmoments.append(y.var() + y.mean() * y.mean())
+
+        self.assertEqual(len(y_1stmoments), 3)
+        self.assertEqual(len(y_2ndmoments), 3)
+        self.assertAlmostEqual(float(np.mean(y_1stmoments)), 62.267612954389584, places=4)
+        self.assertAlmostEqual(float(np.mean(y_2ndmoments)), 4904.42749592764, places=4)
+
+
+class YuvReaderTest16le(unittest.TestCase):
+
+    def test_yuv_reader(self):
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p16le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv420p16le'
+        ) as yuv_reader:
+            self.assertEqual(yuv_reader.num_bytes, 1679616)
+            self.assertEqual(yuv_reader.num_frms, 3)
+            self.assertEqual(yuv_reader._get_uv_width_height_multiplier(), (0.5, 0.5))
+
+    def test_with(self):
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p16le.yuv"),
+                width=576,
+                height=324,
+                yuv_type='yuv420p16le'
+        ) as yuv_reader:
+
+            y, u, v = yuv_reader.next()
+            y, u, v = y.astype(np.double) / 256.0, u.astype(np.double) / 256.0, v.astype(np.double) / 256.0
+
+            self.assertEqual(y[0][0], 87)
+            self.assertEqual(y[0][1], 131)
+            self.assertEqual(y[1][0], 95)
+
+            self.assertEqual(u[0][0], 92)
+            self.assertEqual(u[0][1], 97)
+            self.assertEqual(u[1][0], 90)
+
+            self.assertEqual(v[0][0], 121)
+            self.assertEqual(v[0][1], 126)
+            self.assertEqual(v[1][0], 122)
+
+            self.assertAlmostEqual(y.mean(), 61.928749785665296, places=4)
+            self.assertAlmostEqual(u.mean(), 114.6326517489712, places=4)
+            self.assertAlmostEqual(v.mean(), 122.05084019204389, places=4)
+
+            y, u, v = yuv_reader.next()
+            y, u, v = y.astype(np.double) / 256.0, u.astype(np.double) / 256.0, v.astype(np.double) / 256.0
+
+            self.assertEqual(y[0][0], 142)
+            self.assertEqual(y[0][1], 128)
+            self.assertEqual(y[1][0], 134)
+
+            self.assertEqual(u[0][0], 93)
+            self.assertEqual(u[0][1], 102)
+            self.assertEqual(u[1][0], 91)
+
+            self.assertEqual(v[0][0], 128)
+            self.assertEqual(v[0][1], 126)
+            self.assertEqual(v[1][0], 124)
+
+            self.assertAlmostEqual(y.mean(), 61.265260631001375, places=4)
+            self.assertAlmostEqual(u.mean(), 114.72515860768175, places=4)
+            self.assertAlmostEqual(v.mean(), 122.12022033607681, places=4)
+
+    def test_iteration(self):
+
+        y_1stmoments = []
+        y_2ndmoments = []
+
+        with YuvReader(
+                filepath=VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p16le.yuv"),
+                width=576, height=324, yuv_type='yuv420p16le') as yuv_reader:
+
+            for y, u, v in yuv_reader:
+                y, u, v = y.astype(np.double) / 256.0, u.astype(np.double) / 256.0, v.astype(np.double) / 256.0
+                y_1stmoments.append(y.mean())
+                y_2ndmoments.append(y.var() + y.mean() * y.mean())
+
+        self.assertEqual(len(y_1stmoments), 3)
+        self.assertEqual(len(y_2ndmoments), 3)
+        self.assertAlmostEqual(float(np.mean(y_1stmoments)), 62.267612954389584, places=4)
+        self.assertAlmostEqual(float(np.mean(y_2ndmoments)), 4904.42749592764, places=4)
 
 
 if __name__ == '__main__':

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -61,6 +61,26 @@ def set_default_576_324_10bit_videos_for_testing():
     return ref_path, dis_path, asset, asset_original
 
 
+def set_default_576_324_10bit_videos_for_testing_b():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p10le.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p10le.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324,
+                              'yuv_type': 'yuv420p10le'})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324,
+                                       'yuv_type': 'yuv420p10le'})
+
+    return ref_path, dis_path, asset, asset_original
+
+
 def set_default_576_324_12bit_videos_for_testing():
     ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p12le.yuv")
     dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p12le.yuv")

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -61,6 +61,46 @@ def set_default_576_324_10bit_videos_for_testing():
     return ref_path, dis_path, asset, asset_original
 
 
+def set_default_576_324_12bit_videos_for_testing():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p12le.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p12le.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324,
+                              'yuv_type': 'yuv420p12le'})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324,
+                                       'yuv_type': 'yuv420p12le'})
+
+    return ref_path, dis_path, asset, asset_original
+
+
+def set_default_576_324_16bit_videos_for_testing():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv420p16le.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv420p16le.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324,
+                              'yuv_type': 'yuv420p16le'})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324,
+                                       'yuv_type': 'yuv420p16le'})
+
+    return ref_path, dis_path, asset, asset_original
+
+
 def set_default_576_324_noref_videos_for_testing():
     ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
     dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")

--- a/python/test/vmafossexec_test.py
+++ b/python/test/vmafossexec_test.py
@@ -7,7 +7,9 @@ from vmaf.core.asset import Asset
 from vmaf.core.quality_runner import VmafossExecQualityRunner
 from vmaf.core.result_store import FileSystemResultStore
 
-from test.testutil import set_default_576_324_videos_for_testing
+from test.testutil import set_default_576_324_videos_for_testing, set_default_576_324_10bit_videos_for_testing, \
+    set_default_576_324_12bit_videos_for_testing, set_default_576_324_16bit_videos_for_testing, \
+    set_default_576_324_10bit_videos_for_testing_b
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -158,21 +160,7 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
     def test_run_vmafossexec_runner_yuv422p10le(self):
 
-        ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv")
-        dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv422p10le.yuv")
-        asset = Asset(dataset="test", content_id=0, asset_id=0,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=dis_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
-
-        asset_original = Asset(dataset="test", content_id=0, asset_id=1,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=ref_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing()
 
         self.runner = VmafossExecQualityRunner(
             [asset, asset_original],
@@ -206,6 +194,116 @@ class VmafossexecQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 76.68425208333333, places=4)
         self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.94641666666666, places=4)
+
+    def test_run_vmafossexec_runner_yuv420p10le_b(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing_b()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 32.57143333333333, places=4)  # pypsnr: 32.57145231892744
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.14266666666667, places=4)
+
+    def test_run_vmafossexec_runner_yuv420p12le(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            delete_workdir=True,
+            result_store=None,
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 32.57783333333334, places=4)  # pypsnr: 32.577817940053734
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.14266666666667, places=4)
+
+    def test_run_vmafossexec_runner_yuv420p16le(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
+
+        self.runner = VmafossExecQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            delete_workdir=True,
+            result_store=None,
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_psnr_score'], 32.5798, places=4)  # pypsnr: 32.579806240311484
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_psnr_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFOSSEXEC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFOSSEXEC_score'], 99.14266666666667, places=4)
 
     def test_run_vmafossexec_runner_yuv420p10le_sparks(self):
 

--- a/python/test/vmafrc_feature_extractor_test.py
+++ b/python/test/vmafrc_feature_extractor_test.py
@@ -4,9 +4,12 @@ from vmaf.core.asset import Asset
 
 from vmaf.config import VmafConfig
 
-from test.testutil import set_default_576_324_videos_for_testing
+from test.testutil import set_default_576_324_videos_for_testing, set_default_576_324_12bit_videos_for_testing, \
+    set_default_576_324_16bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b
 
-from vmaf.core.vmafrc_feature_extractor import FloatMotionFeatureExtractor, IntegerMotionFeatureExtractor, FloatVifFeatureExtractor, FloatAdmFeatureExtractor, IntegerVifFeatureExtractor, IntegerPsnrFeatureExtractor, IntegerAdmFeatureExtractor
+from vmaf.core.vmafrc_feature_extractor import FloatMotionFeatureExtractor, IntegerMotionFeatureExtractor, \
+    FloatVifFeatureExtractor, FloatAdmFeatureExtractor, IntegerVifFeatureExtractor, IntegerPsnrFeatureExtractor, \
+    IntegerAdmFeatureExtractor
 
 
 class FeatureExtractorTest(unittest.TestCase):
@@ -56,6 +59,18 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['integer_motion_feature_motion2_score'], 3.895345229166667, places=8)
         self.assertAlmostEqual(results[1]['integer_motion_feature_motion2_score'], 3.895345229166667, places=8)
 
+    def test_run_integer_motion_fextractor_12bit(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+        self.fextractor = IntegerMotionFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_motion_feature_motion2_score'], 2.8104533333333332, places=8)
+        self.assertAlmostEqual(results[1]['integer_motion_feature_motion2_score'], 2.8104533333333332, places=8)
+
     def test_run_float_vif_fextractor(self):
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
         self.fextractor = FloatVifFeatureExtractor(
@@ -92,6 +107,24 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale2_score'], 1.0000022916666667, places=6)
         self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale3_score'], 1.0, places=5)
 
+    def test_run_integer_vif_fextractor_12bit(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+        self.fextractor = IntegerVifFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_VIF_feature_vif_scale0_score'], 0.4326293333333333, places=6)
+        self.assertAlmostEqual(results[0]['integer_VIF_feature_vif_scale1_score'], 0.8292446666666665, places=6)
+        self.assertAlmostEqual(results[0]['integer_VIF_feature_vif_scale2_score'], 0.9067896666666667, places=6)
+        self.assertAlmostEqual(results[0]['integer_VIF_feature_vif_scale3_score'], 0.9460693333333333, places=6)
+        self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale0_score'], 1.000002, places=6)
+        self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale1_score'], 1.0000023541666667, places=6)
+        self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale2_score'], 1.0000022916666667, places=6)
+        self.assertAlmostEqual(results[1]['integer_VIF_feature_vif_scale3_score'], 1.0, places=5)
+
     def test_run_float_adm_fextractor(self):
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
         self.fextractor = FloatAdmFeatureExtractor(
@@ -119,6 +152,38 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_y_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cb_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cr_score'], 60.0, places=4)
+
+    def test_run_integer_psnr_fextractor_12bit(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+        self.fextractor = IntegerPsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_y_score'], 32.577818, places=4)
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_cb_score'], 39.044961, places=4)
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_cr_score'], 41.286965333333335, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_y_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cb_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cr_score'], 84.0, places=4)
+
+    def test_run_integer_psnr_fextractor_16bit(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
+        self.fextractor = IntegerPsnrFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_y_score'], 32.579806000000005, places=4)
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_cb_score'], 39.04694966666667, places=4)
+        self.assertAlmostEqual(results[0]['integer_PSNR_feature_psnr_cr_score'], 41.288954, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_y_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cb_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['integer_PSNR_feature_psnr_cr_score'], 108.0, places=4)
 
     def test_run_float_adm_fextractor_akiyo_multiply(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -247,6 +312,17 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.934578625, places=4)
         self.assertAlmostEqual(results[1]['integer_ADM_feature_adm2_score'], 1.000002, places=6)
 
+    def test_run_integer_adm_fextractor_12bit(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+        self.fextractor = IntegerAdmFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9518436666666666, places=4)
+        self.assertAlmostEqual(results[1]['integer_ADM_feature_adm2_score'], 1.000002, places=6)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/test/vmafrc_test.py
+++ b/python/test/vmafrc_test.py
@@ -7,7 +7,8 @@ from vmaf.core.asset import Asset
 from vmaf.core.quality_runner import VmafrcQualityRunner, VmafossExecQualityRunner
 from vmaf.core.result_store import FileSystemResultStore
 from test.testutil import set_default_576_324_videos_for_testing, \
-    set_default_576_324_10bit_videos_for_testing
+    set_default_576_324_10bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b, \
+    set_default_576_324_12bit_videos_for_testing, set_default_576_324_16bit_videos_for_testing
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -290,21 +291,7 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
 
     def test_run_vmafrc_runner_yuv422p10le(self):
 
-        ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv422p10le.yuv")
-        dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv422p10le.yuv")
-        asset = Asset(dataset="test", content_id=0, asset_id=0,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=dis_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
-
-        asset_original = Asset(dataset="test", content_id=0, asset_id=1,
-                      workdir_root=VmafConfig.workdir_path(),
-                      ref_path=ref_path,
-                      dis_path=ref_path,
-                      asset_dict={'width': 576, 'height': 324,
-                                  'yuv_type': 'yuv422p10le'})
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing()
 
         self.runner = VmafrcQualityRunner(
             [asset, asset_original],
@@ -343,6 +330,132 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
 
         self.assertAlmostEqual(results[0]['VMAFRC_score'], 76.68425579166666, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_score'], 99.94641666666666, places=4)
+
+    def test_run_vmafrc_runner_yuv420p10le_b(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_10bit_videos_for_testing_b()
+
+        self.runner = VmafrcQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={
+                'float_psnr': True,
+                'float_ssim': True,
+                'float_ms_ssim': True,
+            }
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 32.57143333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 72.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFRC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_score'], 99.14266666666667, places=4)
+
+    def test_run_vmafrc_runner_yuv420p12le(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
+
+        self.runner = VmafrcQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={
+                'float_psnr': True,
+                'float_ssim': True,
+                'float_ms_ssim': True,
+            }
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 32.577818, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 84.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFRC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_score'], 99.14266666666667, places=4)
+
+    def test_run_vmafrc_runner_yuv420p16le(self):
+
+        ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
+
+        self.runner = VmafrcQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=True,
+            delete_workdir=True,
+            result_store=None,
+            optional_dict={
+                'float_psnr': True,
+                'float_ssim': True,
+                'float_ms_ssim': True,
+            }
+        )
+        self.runner.run()
+
+        results = self.runner.results
+
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale0_score'],0.4326273333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale1_score'], 0.8292393333333333, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale2_score'], 0.9067786666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_vif_scale3_score'], 0.9460626666666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_adm2_score'], 0.9517763333333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_psnr_score'], 32.579806000000005, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ssim_score'], 0.8978630000000001, places=4)
+        self.assertAlmostEqual(results[0]['VMAFRC_float_ms_ssim_score'], 0.9747490000000001, places=4)
+
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999998541666666, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale2_score'], 0.9999996041666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_vif_scale3_score'], 0.9999991458333334, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_motion2_score'], 2.8104600000000004, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_adm2_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_psnr_score'], 108.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ssim_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_float_ms_ssim_score'], 1.0, places=4)
+
+        self.assertAlmostEqual(results[0]['VMAFRC_score'], 82.56596666666667, places=4)
+        self.assertAlmostEqual(results[1]['VMAFRC_score'], 99.14266666666667, places=4)
 
     def test_run_vmafrc_runner_yuv420p10le_sparks(self):
 

--- a/python/vmaf/__init__.py
+++ b/python/vmaf/__init__.py
@@ -55,23 +55,29 @@ def convert_pixel_format_ffmpeg2vmafrc(ffmpeg_pix_fmt):
     :param ffmpeg_pix_fmt: FFmpeg-style pixel format, for example: yuv420p, yuv420p10le
     :return: (pixel_format: str, bitdepth: int), for example: (420, 8), (420, 10)
     '''
-    assert ffmpeg_pix_fmt in ['yuv420p', 'yuv422p', 'yuv444p', 
-                                'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
-                                'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
-    if ffmpeg_pix_fmt in ['yuv420p', 'yuv420p10le', 'yuv420p12le']:
+    assert ffmpeg_pix_fmt in ['yuv420p', 'yuv422p', 'yuv444p',
+                              'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+                              'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+                              'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
+                              ]
+
+    if ffmpeg_pix_fmt in ['yuv420p', 'yuv420p10le', 'yuv420p12le', 'yuv420p16le']:
         pixel_format = '420'
-    elif ffmpeg_pix_fmt in ['yuv422p', 'yuv422p10le', 'yuv422p12le']:
+    elif ffmpeg_pix_fmt in ['yuv422p', 'yuv422p10le', 'yuv422p12le', 'yuv422p16le']:
         pixel_format = '422'
-    elif ffmpeg_pix_fmt in ['yuv444p', 'yuv444p10le', 'yuv444p12le']:
+    elif ffmpeg_pix_fmt in ['yuv444p', 'yuv444p10le', 'yuv444p12le', 'yuv444p16le']:
         pixel_format = '444'
     else:
         assert False
+
     if ffmpeg_pix_fmt in ['yuv420p', 'yuv422p', 'yuv444p']:
         bitdepth = 8
     elif ffmpeg_pix_fmt in ['yuv420p10le', 'yuv422p10le', 'yuv444p10le']:
         bitdepth = 10
     elif ffmpeg_pix_fmt in ['yuv420p12le', 'yuv422p12le', 'yuv444p12le']:
         bitdepth = 12
+    elif ffmpeg_pix_fmt in ['yuv420p16le', 'yuv422p16le', 'yuv444p16le']:
+        bitdepth = 16
     else:
         assert False
     return pixel_format, bitdepth

--- a/python/vmaf/__init__.py
+++ b/python/vmaf/__init__.py
@@ -55,12 +55,14 @@ def convert_pixel_format_ffmpeg2vmafrc(ffmpeg_pix_fmt):
     :param ffmpeg_pix_fmt: FFmpeg-style pixel format, for example: yuv420p, yuv420p10le
     :return: (pixel_format: str, bitdepth: int), for example: (420, 8), (420, 10)
     '''
-    assert ffmpeg_pix_fmt in ['yuv420p', 'yuv422p', 'yuv444p', 'yuv420p10le', 'yuv422p10le', 'yuv444p10le']
-    if ffmpeg_pix_fmt in ['yuv420p', 'yuv420p10le']:
+    assert ffmpeg_pix_fmt in ['yuv420p', 'yuv422p', 'yuv444p', 
+                                'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+                                'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
+    if ffmpeg_pix_fmt in ['yuv420p', 'yuv420p10le', 'yuv420p12le']:
         pixel_format = '420'
-    elif ffmpeg_pix_fmt in ['yuv422p', 'yuv422p10le']:
+    elif ffmpeg_pix_fmt in ['yuv422p', 'yuv422p10le', 'yuv422p12le']:
         pixel_format = '422'
-    elif ffmpeg_pix_fmt in ['yuv444p', 'yuv444p10le']:
+    elif ffmpeg_pix_fmt in ['yuv444p', 'yuv444p10le', 'yuv444p12le']:
         pixel_format = '444'
     else:
         assert False
@@ -68,6 +70,8 @@ def convert_pixel_format_ffmpeg2vmafrc(ffmpeg_pix_fmt):
         bitdepth = 8
     elif ffmpeg_pix_fmt in ['yuv420p10le', 'yuv422p10le', 'yuv444p10le']:
         bitdepth = 10
+    elif ffmpeg_pix_fmt in ['yuv420p12le', 'yuv422p12le', 'yuv444p12le']:
+        bitdepth = 12
     else:
         assert False
     return pixel_format, bitdepth

--- a/python/vmaf/core/asset.py
+++ b/python/vmaf/core/asset.py
@@ -33,6 +33,7 @@ class Asset(WorkdirEnabled):
 
     SUPPORTED_YUV_TYPES = ['yuv420p', 'yuv422p', 'yuv444p',
                            'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+                           'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
                            'notyuv']
     DEFAULT_YUV_TYPE = 'yuv420p'
 

--- a/python/vmaf/core/asset.py
+++ b/python/vmaf/core/asset.py
@@ -34,6 +34,7 @@ class Asset(WorkdirEnabled):
     SUPPORTED_YUV_TYPES = ['yuv420p', 'yuv422p', 'yuv444p',
                            'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
                            'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+                           'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
                            'notyuv']
     DEFAULT_YUV_TYPE = 'yuv420p'
 

--- a/python/vmaf/script/ffmpeg2vmaf.py
+++ b/python/vmaf/script/ffmpeg2vmaf.py
@@ -18,7 +18,11 @@ from vmaf.tools.stats import ListStats
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
-FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 'yuv420p10le', 'yuv422p10le', 'yuv444p10le']
+FMTS = ['yuv420p', 'yuv422p', 'yuv444p',
+        'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+        'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
+        ]
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']
 

--- a/python/vmaf/script/run_psnr.py
+++ b/python/vmaf/script/run_psnr.py
@@ -14,7 +14,11 @@ from vmaf.tools.stats import ListStats
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
-FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 'yuv420p10le', 'yuv422p10le', 'yuv444p10le']
+FMTS = ['yuv420p', 'yuv422p', 'yuv444p',
+        'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+        'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
+        ]
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']
 

--- a/python/vmaf/script/run_vmaf.py
+++ b/python/vmaf/script/run_vmaf.py
@@ -20,7 +20,9 @@ __license__ = "BSD+Patent"
 
 FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 
         'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
-        'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+        'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
+        ]
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']
 

--- a/python/vmaf/script/run_vmaf.py
+++ b/python/vmaf/script/run_vmaf.py
@@ -18,7 +18,9 @@ from vmaf.tools.stats import ListStats
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
-FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 'yuv420p10le', 'yuv422p10le', 'yuv444p10le']
+FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 
+        'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']
 

--- a/python/vmaf/script/run_vmaf_in_batch.py
+++ b/python/vmaf/script/run_vmaf_in_batch.py
@@ -17,7 +17,9 @@ __license__ = "BSD+Patent"
 
 FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 
         'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
-        'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le',
+        'yuv420p16le', 'yuv422p16le', 'yuv444p16le',
+        ]
 
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']

--- a/python/vmaf/script/run_vmaf_in_batch.py
+++ b/python/vmaf/script/run_vmaf_in_batch.py
@@ -15,7 +15,10 @@ from vmaf.tools.stats import ListStats
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
-FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 'yuv420p10le', 'yuv422p10le', 'yuv444p10le']
+FMTS = ['yuv420p', 'yuv422p', 'yuv444p', 
+        'yuv420p10le', 'yuv422p10le', 'yuv444p10le',
+        'yuv420p12le', 'yuv422p12le', 'yuv444p12le']
+
 OUT_FMTS = ['text (default)', 'xml', 'json']
 POOL_METHODS = ['mean', 'harmonic_mean', 'min', 'median', 'perc5', 'perc10', 'perc20']
 
@@ -153,7 +156,7 @@ def main():
             print('Asset {asset_id}:'.format(asset_id=result.asset.asset_id))
             print('============================')
             print(result)
-
+        
     return 0
 
 

--- a/resource/doc/VMAF_Python_library.md
+++ b/resource/doc/VMAF_Python_library.md
@@ -76,6 +76,8 @@ The arguments are the following:
 - `format` can be one of:
     - `yuv420p`, `yuv422p`, `yuv444p` (8-Bit YUV)
     - `yuv420p10le`, `yuv422p10le`, `yuv444p10le` (10-Bit little-endian YUV)
+    - `yuv420p12le`, `yuv422p12le`, `yuv444p12le` (12-Bit little-endian YUV)
+    - `yuv420p16le`, `yuv422p16le`, `yuv444p16le` (16-Bit little-endian YUV)
 - `width` and `height` are the width and height of the videos, in pixels
 - `reference_path` and `distorted_path` are the paths to the reference and distorted video files
 - `output_format` can be one of:


### PR DESCRIPTION
Signed-off-by: Rama <career4rama@gmail.com>
Removed normalization to 8 bit from higher bit depth, not sure this is simple change or we need to change all filter weights, re train etc.
