### PR TITLE
libvmaf: add bootstrap ci implementation

### DIFF
--- a/libvmaf/src/bootstrap.c
+++ b/libvmaf/src/bootstrap.c
@@ -1,0 +1,59 @@
+#include <math.h>
+#include <stdlib.h>
+
+#include "feature_collector.h"
+#include "model.h"
+#include "predict.h"
+
+static int score_compare(const void *a, const void *b)
+{
+    const double *x = a;
+    const double *y = b;
+    if (*x > *y) return 1;
+    else if (*x < *y) return -1;
+    else return 0;
+}
+
+static double percentile(double *scores, unsigned n_scores, double perc)
+{
+    const double p = perc * (n_scores - 1) / 100.;
+    const int idx_l = floor(p);
+    const int idx_r = ceil(p);
+
+    return (idx_l == idx_r) ? scores[idx_l] :
+        scores[idx_l] * (idx_r - p) + scores[idx_r] * (p - idx_l);
+}
+
+int vmaf_bootstrap_predict_score_at_index(VmafModel *model, unsigned model_cnt,
+                                          VmafFeatureCollector *feature_collector,
+                                          unsigned index, double *vmaf_score,
+                                          double *ci_lo, double *ci_hi)
+{
+    int err = 0;
+    double scores[model_cnt]; //FIXME: without VLA
+
+    for (unsigned i = 0; i < model_cnt; i++) {
+        err = vmaf_predict_score_at_index(&model[i], feature_collector, index,
+                                          &scores[i]);
+        if (err) return err;
+    }
+
+    double sum = 0.;
+    for (unsigned i = 0; i < model_cnt; i++)
+        sum += scores[i]; 
+    const double mean = sum / model_cnt;
+    *vmaf_score = mean;
+
+    //double ssd = 0.;
+    //for (unsigned i = 0; i < model_cnt; i++)
+    //    ssd += pow(scores[i] - mean, 2);
+    //const double std = sqrt(ssd / model_cnt);
+
+    qsort(scores, model_cnt, sizeof(double), score_compare);
+    const double c95_lo = percentile(scores, model_cnt, 2.5);
+    const double c95_hi = percentile(scores, model_cnt, 97.5);
+    *ci_lo = c95_lo;
+    *ci_hi = c95_hi;
+
+    return 0;
+}

--- a/libvmaf/src/bootstrap.h
+++ b/libvmaf/src/bootstrap.h
@@ -1,0 +1,27 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_SRC_BOOTSTRAP_H__
+#define __VMAF_SRC_BOOTSTRAP_H__
+
+int vmaf_bootstrap_predict_score_at_index(VmafModel *model, unsigned model_cnt,
+                                          VmafFeatureCollector *feature_collector,
+                                          unsigned index, double *vmaf_score,
+                                          double *ci_lo, double *ci_hi);
+
+#endif /* __VMAF_SRC_BOOTSTRAP_H__ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -310,6 +310,7 @@ libvmaf_rc_sources = [
     src_dir + 'dict.c',
     src_dir + 'opt.c',
     src_dir + 'ref.c',
+    src_dir + 'bootstrap.c',
 ]
 
 libvmaf_rc = both_libraries(


### PR DESCRIPTION
Function for writing out bootstrap scores and CI numbers. Testing and integration will happen in another PR.