### PR TITLE
libvmaf: introduce VmafModelCollection

### DIFF
--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -32,12 +32,19 @@ enum VmafModelFlags {
 
 typedef struct VmafModelConfig {
     char *name;
-    char *path;
     uint64_t flags;
 } VmafModelConfig;
 
-int vmaf_model_load_from_path(VmafModel **model, VmafModelConfig *cfg);
+int vmaf_model_load_from_path(VmafModel **model, VmafModelConfig *cfg,
+                              const char *path);
 
 void vmaf_model_destroy(VmafModel *model);
+
+typedef struct VmafModelCollection VmafModelCollection;
+
+int vmaf_model_collection_append(VmafModelCollection **model_collection,
+                                 VmafModel *model);
+
+void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
 
 #endif /* __VMAF_MODEL_H__ */

--- a/libvmaf/src/model.h
+++ b/libvmaf/src/model.h
@@ -64,4 +64,9 @@ typedef struct VmafModel {
     struct svm_model *svm;
 } VmafModel;
 
+typedef struct VmafModelCollection {
+    VmafModel **model;
+    unsigned cnt, size;
+} VmafModelCollection;
+
 #endif /* __VMAF_SRC_MODEL_H__ */

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -25,10 +25,9 @@ static char *test_model_load_and_destroy()
     int err;
 
     VmafModel *model;
-    VmafModelConfig cfg = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
-    };
-    err = vmaf_model_load_from_path(&model, &cfg);
+    VmafModelConfig cfg = { 0 };
+    const char *path = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
 
     /*
@@ -45,16 +44,44 @@ static char *test_model_load_and_destroy()
     return NULL;
 }
 
+static char *test_model_collection()
+{
+    int err;
+
+    VmafModel *model_a;
+    VmafModelConfig cfg_a = { 0 };
+    const char *path_a = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model_a, &cfg_a, path_a);
+    mu_assert("problem during vmaf_model_load_from_path", !err);
+
+    VmafModel *model_b;
+    VmafModelConfig cfg_b = { 0 };
+    const char *path_b = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model_b, &cfg_b, path_b);
+    mu_assert("problem during vmaf_model_load_from_path", !err);
+
+    VmafModelCollection *model_collection = NULL;
+    err = vmaf_model_collection_append(&model_collection, model_a);
+    mu_assert("problem during vmaf_model_collection_append", !err);
+
+    err = vmaf_model_collection_append(&model_collection, model_b);
+    mu_assert("problem during vmaf_model_collection_append", !err);
+
+    vmaf_model_collection_destroy(model_collection);
+
+    return NULL;
+}
+
 static char *test_model_check_default_behavior_unset_flags()
 {
     int err;
 
     VmafModel *model;
     VmafModelConfig cfg = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
         .name = "some_vmaf",
     };
-    err = vmaf_model_load_from_path(&model, &cfg);
+    const char *path = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Model name is inconsistent.\n", !strcmp(model->name, "some_vmaf"));
     mu_assert("Clipping must be enabled by default.\n", model->score_clip.enabled);
@@ -73,11 +100,11 @@ static char *test_model_check_default_behavior_set_flags()
 
     VmafModel *model;
     VmafModelConfig cfg = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
         .name = "some_vmaf",
         .flags = VMAF_MODEL_FLAGS_DEFAULT,
     };
-    err = vmaf_model_load_from_path(&model, &cfg);
+    const char *path = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Model name is inconsistent.\n", !strcmp(model->name, "some_vmaf"));
     mu_assert("Clipping must be enabled by default.\n", model->score_clip.enabled);
@@ -96,10 +123,10 @@ static char *test_model_set_flags()
 
     VmafModel *model1;
     VmafModelConfig cfg1 = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
         .flags = VMAF_MODEL_FLAG_ENABLE_TRANSFORM,
     };
-    err = vmaf_model_load_from_path(&model1, &cfg1);
+    const char *path1 = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model1, &cfg1, path1);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Score transform must be enabled.\n",
               model1->score_transform.enabled);
@@ -109,10 +136,10 @@ static char *test_model_set_flags()
 
     VmafModel *model2;
     VmafModelConfig cfg2 = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
         .flags = VMAF_MODEL_FLAG_DISABLE_CLIP,
     };
-    err = vmaf_model_load_from_path(&model2, &cfg2);
+    const char *path2 = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model2, &cfg2, path2);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Score transform must be disabled.\n",
               !model2->score_transform.enabled);
@@ -121,10 +148,9 @@ static char *test_model_set_flags()
     vmaf_model_destroy(model2);
 
     VmafModel  *model3;
-    VmafModelConfig  cfg3 = {
-            .path = "../../model/vmaf_v0.6.1.pkl",
-    };
-    err = vmaf_model_load_from_path(&model3, &cfg3);
+    VmafModelConfig  cfg3 = { 0 };
+    const char *path3 = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model3, &cfg3, path3);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("feature[0].opts_dict must be NULL.\n",
               !model3->feature[0].opts_dict);
@@ -140,10 +166,9 @@ static char *test_model_set_flags()
               !model3->feature[5].opts_dict);
 
     VmafModel  *model4;
-    VmafModelConfig  cfg4 = {
-            .path = "../../model/vmaf_v0.6.1neg.pkl",
-    };
-    err = vmaf_model_load_from_path(&model4, &cfg4);
+    VmafModelConfig  cfg4 = { 0 };
+    const char *path4 = "../../model/vmaf_v0.6.1neg.pkl";
+    err = vmaf_model_load_from_path(&model4, &cfg4, path4);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("feature[0].opts_dict must not be NULL.\n",
               model4->feature[0].opts_dict);
@@ -191,6 +216,7 @@ static char *test_model_set_flags()
 char *run_tests()
 {
     mu_run_test(test_model_load_and_destroy);
+    mu_run_test(test_model_collection);
     mu_run_test(test_model_check_default_behavior_unset_flags);
     mu_run_test(test_model_check_default_behavior_set_flags);
     mu_run_test(test_model_set_flags);

--- a/libvmaf/test/test_predict.c
+++ b/libvmaf/test/test_predict.c
@@ -33,11 +33,11 @@ static char *test_predict_score_at_index()
 
     VmafModel *model;
     VmafModelConfig cfg = {
-        .path = "../../model/vmaf_v0.6.1.pkl",
         .name = "vmaf",
         .flags = VMAF_MODEL_FLAGS_DEFAULT,
     };
-    err = vmaf_model_load_from_path(&model, &cfg);
+    const char *path = "../../model/vmaf_v0.6.1.pkl";
+    err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
 
     for (unsigned i = 0; i < model->n_features; i++) {

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -155,41 +155,40 @@ static char *strsep(char **sp, char *sep)
 }
 #endif
 
-static VmafModelConfig parse_model_config(const char *const optarg,
-                                          const char *const app)
+static CLIModelConfig parse_model_config(const char *const optarg,
+                                         const char *const app)
 {
-    /* some initializations */
-    VmafModelConfig cfg = {
-        .flags = VMAF_MODEL_FLAGS_DEFAULT,
+    char *optarg_copy = (char *)optarg;
+    CLIModelConfig cli_cfg = {
+        .cfg = { .flags = VMAF_MODEL_FLAGS_DEFAULT, },
+        .path = NULL,
     };
+
     char *token;
     char delim[] = "=:";
-    bool path_set = false;
-    char *optarg_copy = (char *)optarg;
     token = strtok(optarg_copy, delim);
-    /* loop over tokens and populate model configuration */
+
     while (token != 0) {
         if(!strcmp(token, "path")) {
-            path_set = true;
-            cfg.path = strtok(0, delim);
+            cli_cfg.path = strtok(0, delim);
         } else if (!strcmp(token, "name")) {
-            cfg.name = strtok(0, delim);
+            cli_cfg.cfg.name = strtok(0, delim);
         } else if (!strcmp(token, "disable_clip")) {
-            cfg.flags |= VMAF_MODEL_FLAG_DISABLE_CLIP;
+            cli_cfg.cfg.flags |= VMAF_MODEL_FLAG_DISABLE_CLIP;
         } else if (!strcmp(token, "enable_transform")) {
-            cfg.flags |= VMAF_MODEL_FLAG_ENABLE_TRANSFORM;
+            cli_cfg.cfg.flags |= VMAF_MODEL_FLAG_ENABLE_TRANSFORM;
         } else if (!strcmp(token, "enable_ci")) {
-            cfg.flags |= VMAF_MODEL_FLAG_ENABLE_CONFIDENCE_INTERVAL;
+            cli_cfg.cfg.flags |= VMAF_MODEL_FLAG_ENABLE_CONFIDENCE_INTERVAL;
         } else {
             usage(app, "Unknown parameter %s for model.\n", token);
         }
         token = strtok(0, delim);
     }
-    /* path always needs to be set for each model specified */
-    if (!path_set) {
+
+    if (!cli_cfg.path)
         usage(app, "For every model, path needs to be set.\n");
-    }
-    return cfg;
+
+    return cli_cfg;
 }
 
 static CLIFeatureConfig parse_feature_config(const char *const optarg,

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -16,6 +16,11 @@ typedef struct {
 } CLIFeatureConfig;
 
 typedef struct {
+    const char *path;
+    VmafModelConfig cfg;
+} CLIModelConfig;
+
+typedef struct {
     char *path_ref, *path_dist;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;
@@ -23,7 +28,7 @@ typedef struct {
     bool use_yuv;
     char *output_path;
     enum VmafOutputFormat output_fmt;
-    VmafModelConfig model_config[CLI_SETTINGS_STATIC_ARRAY_LEN];
+    CLIModelConfig model_config[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned model_cnt;
     CLIFeatureConfig feature_cfg[CLI_SETTINGS_STATIC_ARRAY_LEN];
     unsigned feature_cnt;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -195,7 +195,8 @@ int main(int argc, char *argv[])
 
     VmafModel *model[c.model_cnt];
     for (unsigned i = 0; i < c.model_cnt; i++) {
-        err = vmaf_model_load_from_path(&model[i], &c.model_config[i]);
+        err = vmaf_model_load_from_path(&model[i], &c.model_config[i].cfg,
+                                        c.model_config[i].path);
         if (err) {
             fprintf(stderr, "problem loading model file: %s\n",
                     c.model_config[i].path);


### PR DESCRIPTION
This PR introduces a new type called `VmafModelCollection`. It's exactly what it sounds like, a collection of `VmafModel`s. This will be used in conjunction with bootstrap and/or random forest models, i.e. whenever a single prediction involves more than one input models, this type is useful. 

Also of note for RC users, this PR includes a breaking change:`vmaf_load_model_from_path()`. This is likely the very last breaking change to the API before `libvmaf_rc` becomes `libvmaf`.