### PR TITLE
libvmaf/feature_extractor: update extract() callback to receive 90-degree translated pics

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -150,7 +150,8 @@ int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
 }
 
 int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
-                                           VmafPicture *ref, VmafPicture *dist,
+                                           VmafPicture *ref, VmafPicture *ref_90,
+                                           VmafPicture *dist, VmafPicture *dist_90,
                                            unsigned pic_index,
                                            VmafFeatureCollector *vfc)
 {
@@ -167,7 +168,8 @@ int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
         if (err) return err;
     }
 
-    return fex_ctx->fex->extract(fex_ctx->fex, ref, dist, pic_index, vfc);
+    return fex_ctx->fex->extract(fex_ctx->fex, ref, ref_90, dist, dist_90,
+                                 pic_index, vfc);
 }
 
 int vmaf_feature_extractor_context_flush(VmafFeatureExtractorContext *fex_ctx,

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -54,12 +54,15 @@ typedef struct VmafFeatureExtractor {
      *
      * @param               fex self.
      * @param           ref_pic Reference VmafPicture.
+     * @param        ref_pic_90 Reference VmafPicture, translated 90 degrees.
      * @param          dist_pic Distorted VmafPicture.
+     * @param       dist_pic_90 Distorted VmafPicture, translated 90 degrees.
      * @param             index Picture index.
      * @param feature_collector VmafFeatureCollector used to write out scores.
      */
     int (*extract)(struct VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector);
     /**
      * Buffer flush callback. Optional.
@@ -105,7 +108,8 @@ int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
                                         unsigned bpc, unsigned w, unsigned h);
 
 int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
-                                           VmafPicture *ref, VmafPicture *dist,
+                                           VmafPicture *ref, VmafPicture *ref_90,
+                                           VmafPicture *dist, VmafPicture *dist_90,
                                            unsigned pic_index,
                                            VmafFeatureCollector *vfc);
 

--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -76,11 +76,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     AdmState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);

--- a/libvmaf/src/feature/float_ansnr.c
+++ b/libvmaf/src/feature/float_ansnr.c
@@ -56,11 +56,15 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     AnsnrState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);

--- a/libvmaf/src/feature/float_moment.c
+++ b/libvmaf/src/feature/float_moment.c
@@ -52,11 +52,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     MomentState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -97,11 +97,16 @@ static int flush(VmafFeatureExtractor *fex,
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     MotionState *s = fex->priv;
     int err = 0;
+
+    (void) dist_pic;
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     if (s->motion_force_zero) {
         err = vmaf_feature_collector_append(feature_collector,

--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -63,11 +63,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     MsSsimState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);

--- a/libvmaf/src/feature/float_psnr.c
+++ b/libvmaf/src/feature/float_psnr.c
@@ -56,11 +56,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     PsnrState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -63,11 +63,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     SsimState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, 0, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, 0, dist_pic->bpc);

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -76,11 +76,15 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     VifState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     picture_copy(s->ref, s->float_stride, ref_pic, -128, ref_pic->bpc);
     picture_copy(s->dist, s->float_stride, dist_pic, -128, dist_pic->bpc);

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -2636,11 +2636,15 @@ free_ref:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     AdmState *s = fex->priv;
     int err = 0;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     double score;
     double scores[8];

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -292,11 +292,15 @@ static inline double normalize_and_scale_sad(uint64_t sad,
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     MotionState *s = fex->priv;
+
     (void) dist_pic;
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     s->index = index;
     const unsigned blur_idx_0 = (index + 0) % 3;

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -116,10 +116,14 @@ static int psnr10(VmafPicture *ref_pic, VmafPicture *dist_pic,
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     PsnrState *s = fex->priv;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
 
     switch(ref_pic->bpc) {
     case 8:

--- a/libvmaf/src/feature/integer_ssim.c
+++ b/libvmaf/src/feature/integer_ssim.c
@@ -203,9 +203,13 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dist_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
+    (void) ref_pic_90;
+    (void) dist_pic_90;
+
     double score =
         calc_ssim(ref_pic->data[0], ref_pic->stride[0],
                   dist_pic->data[0], dist_pic->stride[0], 1.0, ref_pic->bpc,

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -618,23 +618,28 @@ fail:
 }
 
 static int extract(VmafFeatureExtractor *fex,
-                   VmafPicture *ref_pic, VmafPicture *dis_pic,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
                    unsigned index, VmafFeatureCollector *feature_collector)
 {
     VifState *s = fex->priv;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
+
     unsigned w = ref_pic->w[0];
-    unsigned h = dis_pic->h[0];
+    unsigned h = dist_pic->h[0];
 
     void *ref_in = ref_pic->data[0];
-    void *dis_in = dis_pic->data[0];
+    void *dis_in = dist_pic->data[0];
     void *ref_out = s->buf.ref;
     void *dis_out = s->buf.dis;
 
     for (unsigned i = 0; i < h; i++) {
         memcpy(ref_out, ref_in, ref_pic->stride[0]);
-        memcpy(dis_out, dis_in, dis_pic->stride[0]);
+        memcpy(dis_out, dis_in, dist_pic->stride[0]);
         ref_in += ref_pic->stride[0];
-        dis_in += dis_pic->stride[0];
+        dis_in += dist_pic->stride[0];
         ref_out += s->buf.stride;
         dis_out += s->buf.stride;
     }

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -190,8 +190,8 @@ static void threaded_extract_func(void *e)
 {
     struct ThreadData *f = e;
 
-    f->err = vmaf_feature_extractor_context_extract(f->fex_ctx, &f->ref,
-                                                    &f->dist, f->index,
+    f->err = vmaf_feature_extractor_context_extract(f->fex_ctx, &f->ref, NULL,
+                                                    &f->dist, NULL, f->index,
                                                     f->feature_collector);
     f->err = vmaf_fex_ctx_pool_release(f->fex_ctx_pool, f->fex_ctx);
     vmaf_picture_unref(&f->ref);
@@ -301,7 +301,8 @@ int vmaf_read_pictures(VmafContext *vmaf, VmafPicture *ref, VmafPicture *dist,
             continue;
         }
 
-        err = vmaf_feature_extractor_context_extract(fex_ctx, ref, dist, index,
+        err = vmaf_feature_extractor_context_extract(fex_ctx, ref, NULL, dist,
+                                                     NULL, index,
                                                      vmaf->feature_collector);
         if (err) return err;
     }

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -97,12 +97,14 @@ static char *test_feature_extractor_flush()
     mu_assert("vmaf_feature_collector_init", !err);
 
     double score;
-    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, &dist, 0, vfc);
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, NULL, &dist,
+                                                 NULL, 0, vfc);
     mu_assert("problem during vmaf_feature_extractor_context_extract", !err);
     err = vmaf_feature_collector_get_score(vfc, "'VMAF_feature_motion2_score'",
                                            &score, 0);
     mu_assert("problem during vmaf_feature_collector_get_score", !err);
-    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, &dist, 1, vfc);
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, NULL, &dist,
+                                                 NULL, 1, vfc);
     mu_assert("problem during vmaf_feature_extractor_context_extract", !err);
     err = vmaf_feature_collector_get_score(vfc, "'VMAF_feature_motion2_score'",
                                            &score, 0);
@@ -143,7 +145,8 @@ static char *test_feature_extractor_initialization_options()
     err = vmaf_feature_collector_init(&vfc);
     mu_assert("problem during vmaf_feature_collector_init", !err);
 
-    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, &dist, 0, vfc);
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &ref, NULL, &dist,
+                                                 NULL, 0, vfc);
     mu_assert("problem during vmaf_feature_extractor_context_extract", !err);
 
     double score;


### PR DESCRIPTION
This PR lays the groundwork for the feature extractors to receive 90-degree translated versions of the pics in the `.extract()` callback. Note that pics are not being passed yet, but the API now supports it. Creation and passing of pics will come in a future PR.