### PR TITLE
libvmaf: add pooled metrics to xml/json output

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -42,8 +42,10 @@ enum VmafOutputFormat {
 enum VmafPoolingMethod {
     VMAF_POOL_METHOD_UNKNOWN = 0,
     VMAF_POOL_METHOD_MIN,
+    VMAF_POOL_METHOD_MAX,
     VMAF_POOL_METHOD_MEAN,
     VMAF_POOL_METHOD_HARMONIC_MEAN,
+    VMAF_POOL_METHOD_NB
 };
 
 typedef struct VmafConfiguration {

--- a/libvmaf/src/output.h
+++ b/libvmaf/src/output.h
@@ -19,12 +19,12 @@
 #ifndef __VMAF_OUTPUT_H__
 #define __VMAF_OUTPUT_H__
 
-int vmaf_write_output_xml(VmafFeatureCollector *fc, FILE *outfile,
+int vmaf_write_output_xml(VmafContext *vmaf, VmafFeatureCollector *fc, FILE *outfile,
                           unsigned subsample, unsigned width, unsigned height,
                           double fps);
 
-int vmaf_write_output_json(VmafFeatureCollector *fc, FILE *outfile,
-                           unsigned subsample);
+int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
+                           FILE *outfile, unsigned subsample);
 
 int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
                            unsigned subsample);


### PR DESCRIPTION
This PR adds pooled metrics to the XML/JSON output. By default all metrics are logged with all available pooling methods. Schema examples are presented below:

```xml
<VMAF version="65aa63bb">
  <params qualityWidth="1920" qualityHeight="1080" />
  <fyi fps="6.50" />
  <frames>
    <frame frameNum="0" adm2="0.965322" adm_scale0="0.919776" adm_scale1="0.936752" adm_scale2="0.969591" adm_scale3="0.984926" motion2="0.000000" vif_scale0="0.491630" vif_scale1="0.912308" vif_scale2="0.955577" vif_scale3="0.974090" vmaf="86.119865" />
    <frame frameNum="1" adm2="0.887379" adm_scale0="0.880019" adm_scale1="0.846873" adm_scale2="0.879327" adm_scale3="0.910632" motion2="4.728896" vif_scale0="0.321134" vif_scale1="0.583292" vif_scale2="0.664394" vif_scale3="0.741000" vmaf="52.280668" />
    <frame frameNum="2" adm2="0.877280" adm_scale0="0.871811" adm_scale1="0.826573" adm_scale2="0.867308" adm_scale3="0.905404" motion2="4.728896" vif_scale0="0.329228" vif_scale1="0.587013" vif_scale2="0.665722" vif_scale3="0.741320" vmaf="50.326346" />
    ...
  </frames>
  <pooled_metrics>
    <metric name="adm2" min="0.750137" max="0.965322" mean="0.835064" harmonic_mean="0.834486" />
    <metric name="adm_scale0" min="0.792456" max="0.919776" mean="0.834790" harmonic_mean="0.834486" />
    <metric name="adm_scale1" min="0.687503" max="0.936752" mean="0.768889" harmonic_mean="0.767991" />
    <metric name="adm_scale2" min="0.740905" max="0.969591" mean="0.824219" harmonic_mean="0.823634" />
    <metric name="adm_scale3" min="0.757838" max="0.984926" mean="0.873733" harmonic_mean="0.873179" />
    <metric name="motion2" min="0.000000" max="7.927029" mean="5.958491" harmonic_mean="5.832961" />
    <metric name="vif_scale0" min="0.181497" max="0.491630" mean="0.257899" harmonic_mean="0.256447" />
    <metric name="vif_scale1" min="0.461912" max="0.912308" mean="0.534051" harmonic_mean="0.533379" />
    <metric name="vif_scale2" min="0.549885" max="0.955577" mean="0.622654" harmonic_mean="0.622188" />
    <metric name="vif_scale3" min="0.619730" max="0.974090" mean="0.699257" harmonic_mean="0.698842" />
    <metric name="vmaf" min="25.797399" max="86.119865" mean="41.995590" harmonic_mean="41.032981" />
  </pooled_metrics>
</VMAF>
```

```json
{
  "version": "d92a9d8f",
  "frames": [
    {
      "frameNum": 0,
      "metrics": {
        "adm2": 0.965322,
        "adm_scale0": 0.919776,
        "adm_scale1": 0.936752,
        "adm_scale2": 0.969591,
        "adm_scale3": 0.984926,
        "motion2": 0.000000,
        "vif_scale0": 0.491630,
        "vif_scale1": 0.912308,
        "vif_scale2": 0.955577,
        "vif_scale3": 0.974090,
        "vmaf": 86.119865
      }
    },
    {
      "frameNum": 1,
      "metrics": {
        "adm2": 0.887379,
        "adm_scale0": 0.880019,
        "adm_scale1": 0.846873,
        "adm_scale2": 0.879327,
        "adm_scale3": 0.910632,
        "motion2": 4.728896,
        "vif_scale0": 0.321134,
        "vif_scale1": 0.583292,
        "vif_scale2": 0.664394,
        "vif_scale3": 0.741000,
        "vmaf": 52.280668
      }
    },
    {
      "frameNum": 2,
      "metrics": {
        "adm2": 0.877280,
        "adm_scale0": 0.871811,
        "adm_scale1": 0.826573,
        "adm_scale2": 0.867308,
        "adm_scale3": 0.905404,
        "motion2": 4.728896,
        "vif_scale0": 0.329228,
        "vif_scale1": 0.587013,
        "vif_scale2": 0.665722,
        "vif_scale3": 0.741320,
        "vmaf": 50.326346
      }
    },
  ...
  ],
  "pooled_metrics": [
    {
      "metric": "adm2",
      "pooling_methods": {
        "min": 0.750137,
        "max": 0.965322,
        "mean": 0.835064,
        "harmonic_mean": 0.834486
      }
    },
    {
      "metric": "adm_scale0",
      "pooling_methods": {
        "min": 0.792456,
        "max": 0.919776,
        "mean": 0.834790,
        "harmonic_mean": 0.834486
      }
    },
    {
      "metric": "adm_scale1",
      "pooling_methods": {
        "min": 0.687503,
        "max": 0.936752,
        "mean": 0.768889,
        "harmonic_mean": 0.767991
      }
    },
    {
      "metric": "adm_scale2",
      "pooling_methods": {
        "min": 0.740905,
        "max": 0.969591,
        "mean": 0.824219,
        "harmonic_mean": 0.823634
      }
    },
    {
      "metric": "adm_scale3",
      "pooling_methods": {
        "min": 0.757838,
        "max": 0.984926,
        "mean": 0.873733,
        "harmonic_mean": 0.873179
      }
    },
    {
      "metric": "motion2",
      "pooling_methods": {
        "min": 0.000000,
        "max": 7.927029,
        "mean": 5.958491,
        "harmonic_mean": 5.832961
      }
    },
    {
      "metric": "vif_scale0",
      "pooling_methods": {
        "min": 0.181497,
        "max": 0.491630,
        "mean": 0.257899,
        "harmonic_mean": 0.256447
      }
    },
    {
      "metric": "vif_scale1",
      "pooling_methods": {
        "min": 0.461912,
        "max": 0.912308,
        "mean": 0.534051,
        "harmonic_mean": 0.533379
      }
    },
    {
      "metric": "vif_scale2",
      "pooling_methods": {
        "min": 0.549885,
        "max": 0.955577,
        "mean": 0.622654,
        "harmonic_mean": 0.622188
      }
    },
    {
      "metric": "vif_scale3",
      "pooling_methods": {
        "min": 0.619730,
        "max": 0.974090,
        "mean": 0.699257,
        "harmonic_mean": 0.698842
      }
    },
    {
      "metric": "vmaf",
      "pooling_methods": {
        "min": 25.797399,
        "max": 86.119865,
        "mean": 41.995590,
        "harmonic_mean": 41.032981
      }
    }
  ]
}
```