### PR TITLE
feature/x86: provide avx2 optimizations for adm

### DIFF
--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -16,160 +16,24 @@
  *
  */
 
-#include <errno.h>
-#include <math.h>
-#include <string.h>
 
 #include "feature_collector.h"
 #include "feature_extractor.h"
 
-#include "mem.h"
-#include "adm_options.h"
+#include "cpu.h"
+#include "integer_adm.h"
 
-static int32_t div_lookup[65536];
-static const int32_t div_Q_factor = 1073741824;   //2^30
-
-static inline void div_lookup_generator()
-{
-    for (int i = 1; i <= 32768; ++i)
-    {
-        int32_t recip = (int32_t)(div_Q_factor / i);
-        div_lookup[32768 + i] = recip;
-        div_lookup[32768 - i] = 0 - recip;
-    }
-}
-
-typedef struct adm_dwt_band_t {
-    int16_t *band_a; /* Low-pass V + low-pass H. */
-    int16_t *band_v; /* Low-pass V + high-pass H. */
-    int16_t *band_h; /* High-pass V + low-pass H. */
-    int16_t *band_d; /* High-pass V + high-pass H. */
-} adm_dwt_band_t;
-
-typedef struct i4_adm_dwt_band_t {
-    int32_t *band_a; /* Low-pass V + low-pass H. */
-    int32_t *band_v; /* Low-pass V + high-pass H. */
-    int32_t *band_h; /* High-pass V + low-pass H. */
-    int32_t *band_d; /* High-pass V + high-pass H. */
-} i4_adm_dwt_band_t;
-
-typedef struct AdmBuffer {
-    size_t ind_size_x, ind_size_y;  //strides size for intermidate buffers
-    void *data_buf;                //buffer for adm intermidiate data calculations
-    void *tmp_ref;                 //buffer for adm intermidiate data calculations
-    void *buf_x_orig;              //buffer for storing imgcoeff values along x.
-    void *buf_y_orig;              //buffer for storing imgcoeff values along y.
-    int *ind_y[4], *ind_x[4];
-
-    adm_dwt_band_t ref_dwt2;
-    adm_dwt_band_t dis_dwt2;
-    adm_dwt_band_t decouple_r;
-    adm_dwt_band_t decouple_a;
-    adm_dwt_band_t csf_a;
-    adm_dwt_band_t csf_f;
-
-    i4_adm_dwt_band_t i4_ref_dwt2;
-    i4_adm_dwt_band_t i4_dis_dwt2;
-    i4_adm_dwt_band_t i4_decouple_r;
-    i4_adm_dwt_band_t i4_decouple_a;
-    i4_adm_dwt_band_t i4_csf_a;
-    i4_adm_dwt_band_t i4_csf_f;
-} AdmBuffer;
+#if ARCH_X86
+#include "x86/adm_avx2.h"
+#endif
 
 typedef struct AdmState {
     size_t integer_stride;
     AdmBuffer buf;
+    void (*dwt2_8)(const uint8_t *src, const adm_dwt_band_t *dst,
+                   AdmBuffer *buf, int w, int h, int src_stride,
+                   int dst_stride);
 } AdmState;
-
-#ifndef NUM_BUFS_ADM
-#define NUM_BUFS_ADM 30
-#endif
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338327
-#endif // M_PI
-
-#ifndef ADM_BORDER_FACTOR
-#define ADM_BORDER_FACTOR (0.1)
-#endif // !ADM_BORDER_FACTOR
-
-
-#define DIVS(n, d) ((n) / (d))
-
-static const int16_t dwt2_db2_coeffs_lo[4] = { 15826, 27411, 7345, -4240 };
-static const int16_t dwt2_db2_coeffs_hi[4] = { -4240, -7345, 27411, -15826 };
-
-static const int32_t dwt2_db2_coeffs_lo_sum = 46342;
-static const int32_t dwt2_db2_coeffs_hi_sum = 0;
-
-#ifndef ONE_BY_15
-#define ONE_BY_15 8738
-#endif
-
-#ifndef I4_ONE_BY_15
-#define I4_ONE_BY_15 286331153
-#endif
-
-/* ================= */
-/* Noise floor model */
-/* ================= */
-
-#define VIEW_DIST 3.0f
-
-#define REF_DISPLAY_HEIGHT 1080
-
-/*
- * The following dwt visibility threshold parameters are taken from
- * "Visibility of Wavelet Quantization Noise"
- * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
- * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
- * Page 1170, formula (7) and corresponding Table IV
- * Table IV has 2 entries for Cb and Cr thresholds
- * Chose those corresponding to subject "sfl" since they are lower
- * These thresholds were obtained and modeled for the 7-9 biorthogonal wavelet basis
- */
-
- /*
-  * The following dwt visibility threshold parameters are taken from
-  * "Visibility of Wavelet Quantization Noise"
-  * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
-  * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
-  * Page 1170, formula (7) and corresponding Table IV
-  * Table IV has 2 entries for Cb and Cr thresholds
-  * Chose those corresponding to subject "sfl" since they are lower
-  * These thresholds were obtained and modeled for the 7-9 biorthogonal wavelet basis
-  */
-struct dwt_model_params {
-    float a;
-    float k;
-    float f0;
-    float g[4];
-};
-
-// 0 -> Y, 1 -> Cb, 2 -> Cr
-static const struct dwt_model_params dwt_7_9_YCbCr_threshold[3] = {
-    {.a = 0.495,.k = 0.466,.f0 = 0.401,.g = { 1.501, 1.0, 0.534, 1.0} },
-    {.a = 1.633,.k = 0.353,.f0 = 0.209,.g = { 1.520, 1.0, 0.502, 1.0} },
-    {.a = 0.944,.k = 0.521,.f0 = 0.404,.g = { 1.868, 1.0, 0.516, 1.0} }
-};
-
-/*
- * The following dwt basis function amplitudes, A(lambda,theta), are taken from
- * "Visibility of Wavelet Quantization Noise"
- * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
- * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
- * Page 1172, Table V
- * The table has been transposed, i.e. it can be used directly to obtain A[lambda][theta]
- * These amplitudes were calculated for the 7-9 biorthogonal wavelet basis
- */
-static const float dwt_7_9_basis_function_amplitudes[6][4] = {
-    { 0.62171,  0.67234,  0.72709,  0.67234  },
-    { 0.34537,  0.41317,  0.49428,  0.41317  },
-    { 0.18004,  0.22727,  0.28688,  0.22727  },
-    { 0.091401, 0.11792,  0.15214,  0.11792  },
-    { 0.045943, 0.059758, 0.077727, 0.059758 },
-    { 0.023013, 0.030018, 0.039156, 0.030018 }
-};
 
 /*
  * lambda = 0 (finest scale), 1, 2, 3 (coarsest scale);
@@ -1194,8 +1058,8 @@ static float adm_csf_den_scale(const adm_dwt_band_t *src, int w, int h,
             accum_inner_d += val;
         }
         /**
-         * max_value of h^3, v^3, d^3 is 1.205624776×10^13
-         * accum_h can hold till 1.844674407×10^19
+         * max_value of h^3, v^3, d^3 is 1.205624776 * —10^13
+         * accum_h can hold till 1.844674407 * —10^19
          * accum_h's maximum is reached when it is 2^20 * max(h^3)
          * Therefore the accum_h,v,d is shifted based on width and height subtracted by 20
          */
@@ -1374,12 +1238,12 @@ static float adm_cm(AdmBuffer *buf, int w, int h, int src_stride, int csf_a_stri
         /**
          * max value of xh_sq and xv_sq is 1301381973 and that of xd_sq is 1195806729
          *
-         * max(val before shift for h and v) is 9.995357299×10^17.
-         * 9.995357299×10^17 * 2^4 is close to 2^64.
+         * max(val before shift for h and v) is 9.995357299 * —10^17.
+         * 9.995357299 * —10^17 * 2^4 is close to 2^64.
          * Hence shift is done based on width subtracting 4
          *
-         * max(val before shift for d) is 1.355006643×10^18
-         * 1.355006643×10^18 * 2^3 is close to 2^64
+         * max(val before shift for d) is 1.355006643 * —10^18
+         * 1.355006643 * —10^18 * 2^3 is close to 2^64
          * Hence shift is done based on width subtracting 3
          */
         ADM_CM_ACCUM_ROUND(xh, thr, shift_xhsub, xh_sq, add_shift_xhsq, shift_xhsq, val,
@@ -2080,8 +1944,9 @@ static void i16_to_i32(adm_dwt_band_t *src, i4_adm_dwt_band_t *dst,
     }
 }
 
-static void adm_dwt2_8(const uint8_t *src, const adm_dwt_band_t *dst, AdmBuffer *buf, int w, int h,
-                       int src_stride, int dst_stride)
+static void adm_dwt2_8(const uint8_t *src, const adm_dwt_band_t *dst,
+                       AdmBuffer *buf, int w, int h, int src_stride,
+                       int dst_stride)
 {
     const int16_t *filter_lo = dwt2_db2_coeffs_lo;
     const int16_t *filter_hi = dwt2_db2_coeffs_hi;
@@ -2437,8 +2302,8 @@ static void adm_dwt2_s123_combined(const int32_t *i4_ref_scale, const int32_t *i
     }
 }
 
-void integer_compute_adm(VmafPicture *ref_pic, VmafPicture *dis_pic, double *score,
-                         double *scores, AdmBuffer *buf)
+void integer_compute_adm(AdmState *s, VmafPicture *ref_pic, VmafPicture *dis_pic,
+                         double *score, double *scores, AdmBuffer *buf)
 {
     int w = ref_pic->w[0];
     int h = ref_pic->h[0];
@@ -2470,10 +2335,10 @@ void integer_compute_adm(VmafPicture *ref_pic, VmafPicture *dis_pic, double *sco
         dwt2_src_indices_filt(buf->ind_y, buf->ind_x, w, h);
 		if(scale==0) {
             if (ref_pic->bpc == 8) {
-                adm_dwt2_8(ref_pic->data[0], &buf->ref_dwt2, buf, w, h,
-                           curr_ref_stride, buf_stride);
-                adm_dwt2_8(dis_pic->data[0], &buf->dis_dwt2, buf, w, h,
-                           curr_dis_stride, buf_stride);
+                s->dwt2_8(ref_pic->data[0], &buf->ref_dwt2, buf, w, h,
+                          curr_ref_stride, buf_stride);
+                s->dwt2_8(dis_pic->data[0], &buf->dis_dwt2, buf, w, h,
+                          curr_dis_stride, buf_stride);
             }
             else {
                 adm_dwt2_16(ref_pic->data[0], &buf->ref_dwt2, buf, w, h,
@@ -2588,6 +2453,15 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     (void) pix_fmt;
     (void) bpc;
 
+    s->dwt2_8 = adm_dwt2_8;
+
+#if ARCH_X86
+    unsigned flags = vmaf_get_cpu_flags();
+    if (flags & VMAF_X86_CPU_FLAG_AVX2) {
+        s->dwt2_8 = adm_dwt2_8_avx2;
+    }
+#endif
+
     s->integer_stride   = ALIGN_CEIL(w * sizeof(int32_t));
     s->buf.ind_size_x   = ALIGN_CEIL(((w + 1) / 2) * sizeof(int32_t));
     s->buf.ind_size_y   = ALIGN_CEIL(((h + 1) / 2) * sizeof(int32_t));
@@ -2649,7 +2523,7 @@ static int extract(VmafFeatureExtractor *fex,
     double score;
     double scores[8];
 
-    integer_compute_adm(ref_pic, dist_pic, &score, scores, &s->buf);
+    integer_compute_adm(s, ref_pic, dist_pic, &score, scores, &s->buf);
 
     err |= vmaf_feature_collector_append(feature_collector,
                                         "'VMAF_feature_adm2_integer_score'",

--- a/libvmaf/src/feature/integer_adm.h
+++ b/libvmaf/src/feature/integer_adm.h
@@ -1,0 +1,150 @@
+#ifndef FEATURE_ADM_H_
+#define FEATURE_ADM_H_
+
+#include "adm_options.h"
+#include "mem.h"
+#include "stdio.h"
+#include <errno.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+static int32_t div_lookup[65536];
+static const int32_t div_Q_factor = 1073741824; // 2^30
+
+static inline void div_lookup_generator() {
+    for (int i = 1; i <= 32768; ++i) {
+        int32_t recip = (int32_t)(div_Q_factor / i);
+        div_lookup[32768 + i] = recip;
+        div_lookup[32768 - i] = 0 - recip;
+    }
+}
+
+typedef struct adm_dwt_band_t {
+    int16_t *band_a; /* Low-pass V + low-pass H. */
+    int16_t *band_v; /* Low-pass V + high-pass H. */
+    int16_t *band_h; /* High-pass V + low-pass H. */
+    int16_t *band_d; /* High-pass V + high-pass H. */
+} adm_dwt_band_t;
+
+typedef struct i4_adm_dwt_band_t {
+    int32_t *band_a; /* Low-pass V + low-pass H. */
+    int32_t *band_v; /* Low-pass V + high-pass H. */
+    int32_t *band_h; /* High-pass V + low-pass H. */
+    int32_t *band_d; /* High-pass V + high-pass H. */
+} i4_adm_dwt_band_t;
+
+typedef struct AdmBuffer {
+    size_t ind_size_x, ind_size_y; // strides size for intermidate buffers
+    void *data_buf;   // buffer for adm intermidiate data calculations
+    void *tmp_ref;    // buffer for adm intermidiate data calculations
+    void *buf_x_orig; // buffer for storing imgcoeff values along x.
+    void *buf_y_orig; // buffer for storing imgcoeff values along y.
+    int *ind_y[4], *ind_x[4];
+
+    adm_dwt_band_t ref_dwt2;
+    adm_dwt_band_t dis_dwt2;
+    adm_dwt_band_t decouple_r;
+    adm_dwt_band_t decouple_a;
+    adm_dwt_band_t csf_a;
+    adm_dwt_band_t csf_f;
+
+    i4_adm_dwt_band_t i4_ref_dwt2;
+    i4_adm_dwt_band_t i4_dis_dwt2;
+    i4_adm_dwt_band_t i4_decouple_r;
+    i4_adm_dwt_band_t i4_decouple_a;
+    i4_adm_dwt_band_t i4_csf_a;
+    i4_adm_dwt_band_t i4_csf_f;
+} AdmBuffer;
+
+#ifndef NUM_BUFS_ADM
+#define NUM_BUFS_ADM 30
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327
+#endif // M_PI
+
+#ifndef ADM_BORDER_FACTOR
+#define ADM_BORDER_FACTOR (0.1)
+#endif // !ADM_BORDER_FACTOR
+
+#define DIVS(n, d) ((n) / (d))
+
+static const int16_t dwt2_db2_coeffs_lo[4] = {15826, 27411, 7345, -4240};
+static const int16_t dwt2_db2_coeffs_hi[4] = {-4240, -7345, 27411, -15826};
+
+static const int32_t dwt2_db2_coeffs_lo_sum = 46342;
+static const int32_t dwt2_db2_coeffs_hi_sum = 0;
+
+#ifndef ONE_BY_15
+#define ONE_BY_15 8738
+#endif
+
+#ifndef I4_ONE_BY_15
+#define I4_ONE_BY_15 286331153
+#endif
+
+/* ================= */
+/* Noise floor model */
+/* ================= */
+
+#define VIEW_DIST 3.0f
+
+#define REF_DISPLAY_HEIGHT 1080
+
+/*
+ * The following dwt visibility threshold parameters are taken from
+ * "Visibility of Wavelet Quantization Noise"
+ * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
+ * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
+ * Page 1170, formula (7) and corresponding Table IV
+ * Table IV has 2 entries for Cb and Cr thresholds
+ * Chose those corresponding to subject "sfl" since they are lower
+ * These thresholds were obtained and modeled for the 7-9 biorthogonal wavelet
+ * basis
+ */
+
+/*
+ * The following dwt visibility threshold parameters are taken from
+ * "Visibility of Wavelet Quantization Noise"
+ * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
+ * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
+ * Page 1170, formula (7) and corresponding Table IV
+ * Table IV has 2 entries for Cb and Cr thresholds
+ * Chose those corresponding to subject "sfl" since they are lower
+ * These thresholds were obtained and modeled for the 7-9 biorthogonal wavelet
+ * basis
+ */
+struct dwt_model_params {
+    float a;
+    float k;
+    float f0;
+    float g[4];
+};
+
+// 0 -> Y, 1 -> Cb, 2 -> Cr
+static const struct dwt_model_params dwt_7_9_YCbCr_threshold[3] = {
+    {.a = 0.495, .k = 0.466, .f0 = 0.401, .g = {1.501, 1.0, 0.534, 1.0}},
+    {.a = 1.633, .k = 0.353, .f0 = 0.209, .g = {1.520, 1.0, 0.502, 1.0}},
+    {.a = 0.944, .k = 0.521, .f0 = 0.404, .g = {1.868, 1.0, 0.516, 1.0}}};
+
+/*
+ * The following dwt basis function amplitudes, A(lambda,theta), are taken from
+ * "Visibility of Wavelet Quantization Noise"
+ * by A. B. Watson, G. Y. Yang, J. A. Solomon and J. Villasenor
+ * IEEE Trans. on Image Processing, Vol. 6, No 8, Aug. 1997
+ * Page 1172, Table V
+ * The table has been transposed, i.e. it can be used directly to obtain
+ * A[lambda][theta]
+ * These amplitudes were calculated for the 7-9 biorthogonal wavelet basis
+ */
+static const float dwt_7_9_basis_function_amplitudes[6][4] = {
+    {0.62171, 0.67234, 0.72709, 0.67234},
+    {0.34537, 0.41317, 0.49428, 0.41317},
+    {0.18004, 0.22727, 0.28688, 0.22727},
+    {0.091401, 0.11792, 0.15214, 0.11792},
+    {0.045943, 0.059758, 0.077727, 0.059758},
+    {0.023013, 0.030018, 0.039156, 0.030018}};
+
+#endif /* _FEATURE_ADM_H_ */

--- a/libvmaf/src/feature/x86/adm_avx2.c
+++ b/libvmaf/src/feature/x86/adm_avx2.c
@@ -1,0 +1,277 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "feature/integer_adm.h"
+
+#include <immintrin.h>
+
+void adm_dwt2_8_avx2(const uint8_t *src, const adm_dwt_band_t *dst,
+                     AdmBuffer *buf, int w, int h, int src_stride,
+                     int dst_stride)
+{
+    const int16_t *filter_lo = dwt2_db2_coeffs_lo;
+    const int16_t *filter_hi = dwt2_db2_coeffs_hi;
+
+    const int16_t shift_VP = 8;
+    const int16_t shift_HP = 16;
+    const int32_t add_shift_VP = 128;
+    const int32_t add_shift_HP = 32768;
+    int **ind_y = buf->ind_y;
+    int **ind_x = buf->ind_x;
+
+    int16_t *tmplo = (int16_t *)buf->tmp_ref;
+    int16_t *tmphi = tmplo + w;
+    int32_t accum;
+    int32_t accumv[16] = {0};
+
+    __m256i dwt2_db2_coeffs_lo_sum_const = _mm256_set1_epi32(5931776);
+    __m256i fl0 =
+        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)filter_lo));
+    __m256i fl1 =
+        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(filter_lo + 2)));
+    __m256i fh0 =
+        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)filter_hi));
+    __m256i fh1 =
+        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(filter_hi + 2)));
+    __m256i add_shift_VP_vex = _mm256_set1_epi32(128);
+    __m256i pad_register = _mm256_setzero_si256();
+    __m256i add_shift_HP_vex = _mm256_set1_epi32(32768);
+
+    for (int i = 0; i < (h + 1) / 2; ++i) {
+        /* Vertical pass. */
+
+        for (int j = 0; j < w; j = j + 16) {
+
+            __m256i accum_mu2_lo, accum_mu2_hi, accum_mu1_lo, accum_mu1_hi;
+            accum_mu2_lo = accum_mu2_hi = accum_mu1_lo = accum_mu1_hi =
+                _mm256_setzero_si256();
+            __m256i s0, s1, s2, s3, s4;
+
+            s0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
+                (__m128i *)(src + (ind_y[0][i] * src_stride) + j)));
+            s1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
+                (__m128i *)(src + (ind_y[1][i] * src_stride) + j)));
+            s2 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
+                (__m128i *)(src + (ind_y[2][i] * src_stride) + j)));
+            s3 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
+                (__m128i *)(src + (ind_y[3][i] * src_stride) + j)));
+
+            __m256i s0lo = _mm256_unpacklo_epi16(s0, s1);
+            __m256i s0hi = _mm256_unpackhi_epi16(s0, s1);
+            accum_mu2_lo =
+                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s0lo, fl0));
+            accum_mu2_hi =
+                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s0hi, fl0));
+
+            __m256i s1lo = _mm256_unpacklo_epi16(s2, s3);
+            __m256i s1hi = _mm256_unpackhi_epi16(s2, s3);
+            accum_mu2_lo =
+                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s1lo, fl1));
+            accum_mu2_hi =
+                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s1hi, fl1));
+
+            accum_mu2_lo =
+                _mm256_sub_epi32(accum_mu2_lo, dwt2_db2_coeffs_lo_sum_const);
+            accum_mu2_hi =
+                _mm256_sub_epi32(accum_mu2_hi, dwt2_db2_coeffs_lo_sum_const);
+
+            accum_mu2_lo = _mm256_add_epi32(accum_mu2_lo, add_shift_VP_vex);
+            accum_mu2_lo = _mm256_srli_epi32(accum_mu2_lo, 0x08);
+            accum_mu2_hi = _mm256_add_epi32(accum_mu2_hi, add_shift_VP_vex);
+            accum_mu2_hi = _mm256_srli_epi32(accum_mu2_hi, 0x08);
+            accum_mu2_lo = _mm256_blend_epi16(accum_mu2_lo, pad_register, 0xAA);
+            accum_mu2_hi = _mm256_blend_epi16(accum_mu2_hi, pad_register, 0xAA);
+
+            accum_mu2_hi = _mm256_packus_epi32(accum_mu2_lo, accum_mu2_hi);
+            _mm256_storeu_si256((__m256i *)(tmplo + j), accum_mu2_hi);
+
+            accum_mu1_lo =
+                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s0lo, fh0));
+            accum_mu1_hi =
+                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s0hi, fh0));
+            accum_mu1_lo =
+                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s1lo, fh1));
+            accum_mu1_hi =
+                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s1hi, fh1));
+
+            accum_mu1_lo = _mm256_add_epi32(accum_mu1_lo, add_shift_VP_vex);
+            accum_mu1_lo = _mm256_srli_epi32(accum_mu1_lo, 0x08);
+            accum_mu1_hi = _mm256_add_epi32(accum_mu1_hi, add_shift_VP_vex);
+            accum_mu1_hi = _mm256_srli_epi32(accum_mu1_hi, 0x08);
+            accum_mu1_lo = _mm256_blend_epi16(accum_mu1_lo, pad_register, 0xAA);
+            accum_mu1_hi = _mm256_blend_epi16(accum_mu1_hi, pad_register, 0xAA);
+            accum_mu1_hi = _mm256_packus_epi32(accum_mu1_lo, accum_mu1_hi);
+            _mm256_storeu_si256((__m256i *)(tmphi + j), accum_mu1_hi);
+            // for( int k =0; k<16;k++){
+            //     fprintf(stderr, "actual value hi tmp is %d \n",tmphi[j +k]);
+            // }
+        }
+
+        int j0 = ind_x[0][0];
+        int j1 = ind_x[1][0];
+        int j2 = ind_x[2][0];
+        int j3 = ind_x[3][0];
+
+        int16_t s0 = tmplo[j0];
+        int16_t s1 = tmplo[j1];
+        int16_t s2 = tmplo[j2];
+        int16_t s3 = tmplo[j3];
+
+        accum = 0;
+        accum += (int32_t)filter_lo[0] * s0;
+        accum += (int32_t)filter_lo[1] * s1;
+        accum += (int32_t)filter_lo[2] * s2;
+        accum += (int32_t)filter_lo[3] * s3;
+        dst->band_a[i * dst_stride] = (accum + add_shift_HP) >> shift_HP;
+
+        accum = 0;
+        accum += (int32_t)filter_hi[0] * s0;
+        accum += (int32_t)filter_hi[1] * s1;
+        accum += (int32_t)filter_hi[2] * s2;
+        accum += (int32_t)filter_hi[3] * s3;
+        dst->band_v[i * dst_stride] = (accum + add_shift_HP) >> shift_HP;
+
+        s0 = tmphi[j0];
+        s1 = tmphi[j1];
+        s2 = tmphi[j2];
+        s3 = tmphi[j3];
+
+        accum = 0;
+        accum += (int32_t)filter_lo[0] * s0;
+        accum += (int32_t)filter_lo[1] * s1;
+        accum += (int32_t)filter_lo[2] * s2;
+        accum += (int32_t)filter_lo[3] * s3;
+        dst->band_h[i * dst_stride] = (accum + add_shift_HP) >> shift_HP;
+
+        accum = 0;
+        accum += (int32_t)filter_hi[0] * s0;
+        accum += (int32_t)filter_hi[1] * s1;
+        accum += (int32_t)filter_hi[2] * s2;
+        accum += (int32_t)filter_hi[3] * s3;
+        dst->band_d[i * dst_stride] = (accum + add_shift_HP) >> shift_HP;
+
+        for (int j = 1; j < (w + 1) / 2; j = j + 16) {
+            {
+                __m256i accum_mu2_lo, accum_mu2_hi, accum_mu1_lo, accum_mu1_hi;
+                accum_mu2_lo = accum_mu2_hi = accum_mu1_lo = accum_mu1_hi =
+                    _mm256_setzero_si256();
+
+                __m256i s00, s11, s22, s33, s44;
+
+                s00 = _mm256_loadu_si256((__m256i *)(tmplo + ind_x[0][j]));
+                s22 = _mm256_loadu_si256((__m256i *)(tmplo + ind_x[2][j]));
+                s33 = _mm256_loadu_si256((__m256i *)(tmplo + 16 + ind_x[0][j]));
+                s44 = _mm256_loadu_si256((__m256i *)(tmplo + 16 + ind_x[2][j]));
+
+                accum_mu2_lo =
+                    _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s00, fl0));
+                accum_mu2_hi =
+                    _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s33, fl0));
+                accum_mu2_lo =
+                    _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s22, fl1));
+                accum_mu2_hi =
+                    _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s44, fl1));
+
+                accum_mu2_lo = _mm256_add_epi32(accum_mu2_lo, add_shift_HP_vex);
+                accum_mu2_lo = _mm256_srli_epi32(accum_mu2_lo, 0x10);
+                accum_mu2_hi = _mm256_add_epi32(accum_mu2_hi, add_shift_HP_vex);
+                accum_mu2_hi = _mm256_srli_epi32(accum_mu2_hi, 0x10);
+
+                accum_mu2_hi = _mm256_packus_epi32(accum_mu2_lo, accum_mu2_hi);
+                accum_mu2_hi = _mm256_permute4x64_epi64(accum_mu2_hi, 0xD8);
+                _mm256_storeu_si256(
+                    (__m256i *)(dst->band_a + i * dst_stride + j),
+                    accum_mu2_hi);
+
+                accum_mu1_lo =
+                    _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s00, fh0));
+                accum_mu1_hi =
+                    _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s33, fh0));
+                accum_mu1_lo =
+                    _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s22, fh1));
+                accum_mu1_hi =
+                    _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s44, fh1));
+
+                accum_mu1_lo = _mm256_add_epi32(accum_mu1_lo, add_shift_HP_vex);
+                accum_mu1_lo = _mm256_srli_epi32(accum_mu1_lo, 0x10);
+                accum_mu1_hi = _mm256_add_epi32(accum_mu1_hi, add_shift_HP_vex);
+                accum_mu1_hi = _mm256_srli_epi32(accum_mu1_hi, 0x10);
+
+                accum_mu1_hi = _mm256_packus_epi32(accum_mu1_lo, accum_mu1_hi);
+                accum_mu1_hi = _mm256_permute4x64_epi64(accum_mu1_hi, 0xD8);
+                _mm256_storeu_si256(
+                    (__m256i *)(dst->band_v + i * dst_stride + j),
+                    accum_mu1_hi);
+            }
+
+            {
+                __m256i accum_mu2_lo, accum_mu2_hi, accum_mu1_lo, accum_mu1_hi;
+                accum_mu2_lo = accum_mu2_hi = accum_mu1_lo = accum_mu1_hi =
+                    _mm256_setzero_si256();
+
+                __m256i s00, s11, s22, s33, s44;
+                __m256i add_shift_HP_vex = _mm256_set1_epi32(32768);
+
+                s00 = _mm256_loadu_si256((__m256i *)(tmphi + ind_x[0][j]));
+                s22 = _mm256_loadu_si256((__m256i *)(tmphi + ind_x[2][j]));
+                s33 = _mm256_loadu_si256((__m256i *)(tmphi + 16 + ind_x[0][j]));
+                s44 = _mm256_loadu_si256((__m256i *)(tmphi + 16 + ind_x[2][j]));
+
+                accum_mu2_lo =
+                    _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s00, fl0));
+                accum_mu2_hi =
+                    _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s33, fl0));
+                accum_mu2_lo =
+                    _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s22, fl1));
+                accum_mu2_hi =
+                    _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s44, fl1));
+
+                accum_mu2_lo = _mm256_add_epi32(accum_mu2_lo, add_shift_HP_vex);
+                accum_mu2_lo = _mm256_srli_epi32(accum_mu2_lo, 0x10);
+                accum_mu2_hi = _mm256_add_epi32(accum_mu2_hi, add_shift_HP_vex);
+                accum_mu2_hi = _mm256_srli_epi32(accum_mu2_hi, 0x10);
+
+                accum_mu2_hi = _mm256_packus_epi32(accum_mu2_lo, accum_mu2_hi);
+                accum_mu2_hi = _mm256_permute4x64_epi64(accum_mu2_hi, 0xD8);
+                _mm256_storeu_si256(
+                    (__m256i *)(dst->band_h + i * dst_stride + j),
+                    accum_mu2_hi);
+
+                accum_mu1_lo =
+                    _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s00, fh0));
+                accum_mu1_hi =
+                    _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s33, fh0));
+                accum_mu1_lo =
+                    _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(s22, fh1));
+                accum_mu1_hi =
+                    _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(s44, fh1));
+
+                accum_mu1_lo = _mm256_add_epi32(accum_mu1_lo, add_shift_HP_vex);
+                accum_mu1_lo = _mm256_srli_epi32(accum_mu1_lo, 0x10);
+                accum_mu1_hi = _mm256_add_epi32(accum_mu1_hi, add_shift_HP_vex);
+                accum_mu1_hi = _mm256_srli_epi32(accum_mu1_hi, 0x10);
+
+                accum_mu1_hi = _mm256_packus_epi32(accum_mu1_lo, accum_mu1_hi);
+                accum_mu1_hi = _mm256_permute4x64_epi64(accum_mu1_hi, 0xD8);
+                _mm256_storeu_si256(
+                    (__m256i *)(dst->band_d + i * dst_stride + j),
+                    accum_mu1_hi);
+            }
+        }
+    }
+}

--- a/libvmaf/src/feature/x86/adm_avx2.h
+++ b/libvmaf/src/feature/x86/adm_avx2.h
@@ -16,18 +16,13 @@
  *
  */
 
-#ifndef __VMAF_MEM_H__
-#define __VMAF_MEM_H__
+#ifndef X86_AVX2_ADM_H_
+#define X86_AVX2_ADM_H_
 
-#include <stddef.h>
+#include "feature/integer_adm.h"
 
-#define MAX_ALIGN 32
+void adm_dwt2_8_avx2(const uint8_t *src, const adm_dwt_band_t *dst,
+                     AdmBuffer *buf, int w, int h, int src_stride,
+                     int dst_stride);
 
-#define ALIGN_FLOOR(x) ((x) - (x) % MAX_ALIGN)
-#define ALIGN_CEIL(x) ((x) + ((x) % MAX_ALIGN ? MAX_ALIGN - (x) % MAX_ALIGN : 0))
-
-void *aligned_malloc(size_t size, size_t alignment);
-
-void aligned_free(void *ptr);
-
-#endif /* __VMAF_MEM_H__ */
+#endif /* X86_AVX2_ADM_H_ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -144,6 +144,7 @@ if is_asm_enabled
           feature_src_dir + 'common/convolution_avx.c',
           feature_src_dir + 'x86/motion_avx2.c',
           feature_src_dir + 'x86/vif_avx2.c',
+          feature_src_dir + 'x86/adm_avx2.c',
       ]
 
       x86_avx_static_lib = static_library(


### PR DESCRIPTION
This PR adds AVX2 optimizations to the integer ADM feature extractor. These optimizations are numerically accurate and give somewhere around a 140% speedup on this feature extractor. This PR applies on top of #691.


```
OLD:
VMAF version 7e4c8727
500 frames ⠀⢐ 27.10 FPS

NEW:
VMAF version 7e4c8727
500 frames ⠀⢐ 38.69 FPS
```