### PR TITLE
Actions/windows: use the new syntax for setting environment variables

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
           # Disabled 32-bit job due to vmaf score mismatch
           #- msystem: MINGW32
           #  MINGW_PACKAGE_PREFIX: mingw-w64-i686
-          #  CFLAGS: -msse
+          #  CFLAGS: -msse2 -mfpmath=sse -mstackrealign
           - msystem: MINGW64
             MINGW_PACKAGE_PREFIX: mingw-w64-x86_64
     env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
           path-type: inherit
 
       - name: Set ccache dir
-        run: echo "::set-env name=CCACHE_DIR::$PWD/.ccache"
+        run: echo "name=CCACHE_DIR::$PWD/.ccache" >> $GITHUB_ENV
 
       - name: Configure vmaf
         run: meson setup libvmaf libvmaf/build --buildtype release --default-library static --prefix "$MINGW_PREFIX"


### PR DESCRIPTION
Also changes the flags "used" for the 32-bit jobs, still disabled since the output is `93.656205` instead of `93.656203`