### PR TITLE
libvmaf/motion: add motion_force_zero to integer motion fex

### DIFF
--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -49,13 +49,13 @@ static const VmafOption options[] = {
         .default_val.b = false,
     },
     {
-            .name = "motion_force_zero",
-            .help = "forcing motion score to zero",
-            .offset = offsetof(MotionState, motion_force_zero),
-            .type = VMAF_OPT_TYPE_BOOL,
-            .default_val.b = false,
+        .name = "motion_force_zero",
+        .help = "forcing motion score to zero",
+        .offset = offsetof(MotionState, motion_force_zero),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
     },
-    { NULL }
+    { 0 }
 };
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,


### PR DESCRIPTION
This PR adds the `motion_force_zero` parameter to the integer motion feature extractor. Possible enhancement and probably a more flexible approach might be adding a parameter to force the motion score to any floating-point value. That may or may not be useful.

```
./build/tools/vmaf_rc \
    --reference ./y4ms/ducks.y4m \
    --distorted ./y4ms/ducks_dist.y4m \
    --feature float_motion=motion_force_zero=true \
    --feature motion=motion_force_zero=true \
    --no_prediction \
    --output motion.xml
```