### PR TITLE
ci/windows: also upload vmaf_rc artifact

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
         run: echo "name=CCACHE_DIR::$PWD/.ccache" >> $GITHUB_ENV
 
       - name: Configure vmaf
-        run: meson setup libvmaf libvmaf/build --buildtype release --default-library static --prefix "$MINGW_PREFIX"
+        run: meson setup libvmaf libvmaf/build --buildtype release --default-library static --prefix "$MINGW_PREFIX" -Dinstall_rc=true
       - name: Build vmaf
         run: meson install -C libvmaf/build
 
@@ -92,6 +92,8 @@ jobs:
         run: |
           ldd "$MINGW_PREFIX/bin/vmafossexec.exe" || true
           echo "::set-output name=path::$(cygpath -m "$(command -v vmafossexec)")"
+          ldd "$MINGW_PREFIX/bin/vmaf_rc.exe" || true
+          echo "::set-output name=vmaf_rc_path::$(cygpath -m "$(command -v vmaf_rc)")"
           echo "::set-output name=upload_url::$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")"
 
       - name: Upload vmafossexec
@@ -108,4 +110,19 @@ jobs:
           upload_url: ${{ steps.get_info.outputs.upload_url }}
           asset_path: ${{ steps.get_info.outputs.path }}
           asset_name: vmafossexec.exe
+          asset_content_type: application/vnd.microsoft.portable-executable
+      - name: Upload vmaf_rc
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.msystem }}-vmaf_rc
+          path: ${{ steps.get_info.outputs.vmaf_rc_path }}
+      - name: Upload vmaf_rc
+        if: steps.get_info.outputs.upload_url != 'null' && matrix.msystem == 'MINGW64'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_info.outputs.upload_url }}
+          asset_path: ${{ steps.get_info.outputs.vmaf_rc_path }}
+          asset_name: vmaf_rc.exe
           asset_content_type: application/vnd.microsoft.portable-executable

--- a/libvmaf/meson_options.txt
+++ b/libvmaf/meson_options.txt
@@ -17,3 +17,8 @@ option('enable_avx512',
     type: 'boolean',
     value: false,
     description: 'Build AVX-512 asm files, requires nasm 2.14')
+
+option('install_rc',
+    type: 'boolean',
+    value: false,
+    description: 'Add rc libs/bins to list of installed files')

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -334,7 +334,7 @@ libvmaf_rc = both_libraries(
         libvmaf_rc_feature_static_lib.extract_all_objects(),
         libvmaf_rc_cpu_static_lib.extract_all_objects(),
     ],
-    install: false,
+    install: get_option('install_rc'),
 )
 
 pkg_mod = import('pkgconfig')

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -21,7 +21,7 @@ vmaf_rc = executable(
     dependencies: [stdatomic_dependency],
     c_args : [vmaf_cflags_common, compat_cflags],
     link_with : libvmaf_rc.get_static_lib(),
-    install : false,
+    install : get_option('install_rc'),
 )
 
 vmaf_feature = executable(


### PR DESCRIPTION
This PR uploads the vmaf_rc.exe artifact on each Windows CI build. There are people are asking for builds, this is an easy way to provide them.