### PR TITLE
libvmaf/feature: add adm_enhn_gain_limit param to integer adm

### DIFF
--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -54,7 +54,7 @@ static const VmafOption options[] = {
         .min = 1.0,
         .max = DEFAULT_ADM_ENHN_GAIN_LIMIT,
     },
-    { NULL }
+    { 0 }
 };
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -657,7 +657,7 @@ static void adm_decouple(AdmBuffer *buf, int w, int h, int stride,
             int16_t th = dis->band_h[i * stride + j];
             int16_t tv = dis->band_v[i * stride + j];
             int16_t td = dis->band_d[i * stride + j];
-            int16_t tmph, tmpv, tmpd;
+            int16_t rst_h, rst_v, rst_d;
 
             /* Determine if angle between (oh,ov) and (th,tv) is less than 1 degree.
              * Given that u is the angle (oh,ov) and v is the angle (th,tv), this can
@@ -707,42 +707,34 @@ static void adm_decouple(AdmBuffer *buf, int w, int h, int stride,
             int32_t kv = tmp_kv < 0 ? 0 : (tmp_kv > 32768 ? 32768 : tmp_kv);
             int32_t kd = tmp_kd < 0 ? 0 : (tmp_kd > 32768 ? 32768 : tmp_kd);
 
-
-
             /**
              * kh,kv,kd are in Q15 type and oh,ov,od are in Q16 type hence shifted by
              * 15 to make result Q16
              */
-            tmph = ((kh * oh) + 16384) >> 15;
-            tmpv = ((kv * ov) + 16384) >> 15;
-            tmpd = ((kd * od) + 16384) >> 15;
+            rst_h = ((kh * oh) + 16384) >> 15;
+            rst_v = ((kv * ov) + 16384) >> 15;
+            rst_d = ((kd * od) + 16384) >> 15;
 
-            const float tmph_f = ((float)kh / 32768) * ((float)oh / 64);
-            const float tmpv_f = ((float)kv / 32768) * ((float)ov / 64);
-            const float tmpd_f = ((float)kd / 32768) * ((float)od / 64);
+            const float rst_h_f = ((float)kh / 32768) * ((float)oh / 64);
+            const float rst_v_f = ((float)kv / 32768) * ((float)ov / 64);
+            const float rst_d_f = ((float)kd / 32768) * ((float)od / 64);
 
-            if (angle_flag && (tmph_f > 0.))
-                tmph = MIN((tmph * adm_enhn_gain_limit), th);
-            if (angle_flag && (tmph_f < 0.))
-                tmph = MAX((tmph * adm_enhn_gain_limit), th);
+            if (angle_flag && (rst_h_f > 0.)) rst_h = MIN((rst_h * adm_enhn_gain_limit), th);
+            if (angle_flag && (rst_h_f < 0.)) rst_h = MAX((rst_h * adm_enhn_gain_limit), th);
 
-            if (angle_flag && (tmpv_f > 0.))
-                tmpv = MIN(tmpv * adm_enhn_gain_limit, tv);
-            if (angle_flag && (tmpv_f < 0.))
-                tmpv = MAX(tmpv * adm_enhn_gain_limit, tv);
+            if (angle_flag && (rst_v_f > 0.)) rst_v = MIN(rst_v * adm_enhn_gain_limit, tv);
+            if (angle_flag && (rst_v_f < 0.)) rst_v = MAX(rst_v * adm_enhn_gain_limit, tv);
 
-            if (angle_flag && (tmpd_f > 0.))
-                tmpd = MIN(tmpd * adm_enhn_gain_limit, td);
-            if (angle_flag && (tmpd_f < 0.))
-                tmpd = MAX(tmpd * adm_enhn_gain_limit, td);
+            if (angle_flag && (rst_d_f > 0.)) rst_d = MIN(rst_d * adm_enhn_gain_limit, td);
+            if (angle_flag && (rst_d_f < 0.)) rst_d = MAX(rst_d * adm_enhn_gain_limit, td);
 
-            r->band_h[i * stride + j] = tmph;
-            r->band_v[i * stride + j] = tmpv;
-            r->band_d[i * stride + j] = tmpd;
+            r->band_h[i * stride + j] = rst_h;
+            r->band_v[i * stride + j] = rst_v;
+            r->band_d[i * stride + j] = rst_d;
 
-            a->band_h[i * stride + j] = th - tmph;
-            a->band_v[i * stride + j] = tv - tmpv;
-            a->band_d[i * stride + j] = td - tmpd;
+            a->band_h[i * stride + j] = th - rst_h;
+            a->band_v[i * stride + j] = tv - rst_v;
+            a->band_d[i * stride + j] = td - rst_d;
         }
     }
 }
@@ -797,7 +789,7 @@ static void adm_decouple_s123(AdmBuffer *buf, int w, int h, int stride,
             int32_t th = dis->band_h[i * stride + j];
             int32_t tv = dis->band_v[i * stride + j];
             int32_t td = dis->band_d[i * stride + j];
-            int32_t tmph, tmpv, tmpd;
+            int32_t rst_h, rst_v, rst_d;
 
             /* Determine if angle between (oh,ov) and (th,tv) is less than 1 degree.
              * Given that u is the angle (oh,ov) and v is the angle (th,tv), this can
@@ -871,36 +863,30 @@ static void adm_decouple_s123(AdmBuffer *buf, int w, int h, int stride,
             int64_t kv = tmp_kv < 0 ? 0 : (tmp_kv > 32768 ? 32768 : tmp_kv);
             int64_t kd = tmp_kd < 0 ? 0 : (tmp_kd > 32768 ? 32768 : tmp_kd);
 
-            tmph = ((kh * oh) + 16384) >> 15;
-            tmpv = ((kv * ov) + 16384) >> 15;
-            tmpd = ((kd * od) + 16384) >> 15;
+            rst_h = ((kh * oh) + 16384) >> 15;
+            rst_v = ((kv * ov) + 16384) >> 15;
+            rst_d = ((kd * od) + 16384) >> 15;
 
-            const float tmph_f = ((float)kh / 32768) * ((float)oh / 64);
-            const float tmpv_f = ((float)kv / 32768) * ((float)ov / 64);
-            const float tmpd_f = ((float)kd / 32768) * ((float)od / 64);
+            const float rst_h_f = ((float)kh / 32768) * ((float)oh / 64);
+            const float rst_v_f = ((float)kv / 32768) * ((float)ov / 64);
+            const float rst_d_f = ((float)kd / 32768) * ((float)od / 64);
 
-            if (angle_flag && (tmph_f > 0.))
-                tmph = MIN((tmph * adm_enhn_gain_limit), th);
-            if (angle_flag && (tmph_f < 0.))
-                tmph = MAX((tmph * adm_enhn_gain_limit), th);
+            if (angle_flag && (rst_h_f > 0.)) rst_h = MIN((rst_h * adm_enhn_gain_limit), th);
+            if (angle_flag && (rst_h_f < 0.)) rst_h = MAX((rst_h * adm_enhn_gain_limit), th);
 
-            if (angle_flag && (tmpv_f > 0.))
-                tmpv = MIN(tmpv * adm_enhn_gain_limit, tv);
-            if (angle_flag && (tmpv_f < 0.))
-                tmpv = MAX(tmpv * adm_enhn_gain_limit, tv);
+            if (angle_flag && (rst_v_f > 0.)) rst_v = MIN(rst_v * adm_enhn_gain_limit, tv);
+            if (angle_flag && (rst_v_f < 0.)) rst_v = MAX(rst_v * adm_enhn_gain_limit, tv);
 
-            if (angle_flag && (tmpd_f > 0.))
-                tmpd = MIN(tmpd * adm_enhn_gain_limit, td);
-            if (angle_flag && (tmpd_f < 0.))
-                tmpd = MAX(tmpd * adm_enhn_gain_limit, td);
+            if (angle_flag && (rst_d_f > 0.)) rst_d = MIN(rst_d * adm_enhn_gain_limit, td);
+            if (angle_flag && (rst_d_f < 0.)) rst_d = MAX(rst_d * adm_enhn_gain_limit, td);
 
-            r->band_h[i * stride + j] = tmph;
-            r->band_v[i * stride + j] = tmpv;
-            r->band_d[i * stride + j] = tmpd;
+            r->band_h[i * stride + j] = rst_h;
+            r->band_v[i * stride + j] = rst_v;
+            r->band_d[i * stride + j] = rst_d;
 
-            a->band_h[i * stride + j] = th - tmph;
-            a->band_v[i * stride + j] = tv - tmpv;
-            a->band_d[i * stride + j] = td - tmpd;
+            a->band_h[i * stride + j] = th - rst_h;
+            a->band_v[i * stride + j] = tv - rst_v;
+            a->band_d[i * stride + j] = td - rst_d;
         }
     }
 }

--- a/libvmaf/src/feature/integer_adm.h
+++ b/libvmaf/src/feature/integer_adm.h
@@ -1,7 +1,6 @@
 #ifndef FEATURE_ADM_H_
 #define FEATURE_ADM_H_
 
-#include "adm_options.h"
 #include "mem.h"
 #include "stdio.h"
 #include <errno.h>

--- a/python/test/vmafrc_feature_extractor_test.py
+++ b/python/test/vmafrc_feature_extractor_test.py
@@ -322,7 +322,7 @@ class FeatureExtractorTest(unittest.TestCase):
         )
         self.fextractor.run()
         results = self.fextractor.results
-        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.934578625, places=4)
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9345057916666667, places=4)
         self.assertAlmostEqual(results[1]['integer_ADM_feature_adm2_score'], 1.000002, places=6)
 
     def test_run_integer_adm_fextractor_12bit(self):
@@ -334,7 +334,7 @@ class FeatureExtractorTest(unittest.TestCase):
         )
         self.fextractor.run()
         results = self.fextractor.results
-        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9518436666666666, places=4)
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9517706666666667, places=4)
         self.assertAlmostEqual(results[1]['integer_ADM_feature_adm2_score'], 1.000002, places=6)
 
     def test_run_integer_adm_fextractor_akiyo_multiply(self):
@@ -352,7 +352,7 @@ class FeatureExtractorTest(unittest.TestCase):
         )
         self.fextractor.run()
         results = self.fextractor.results
-        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.116705, places=6)  # float 1.116686
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.1167, places=6)  # float 1.116686
 
     def test_run_integer_adm_fextractor_akiyo_multiply_enhn_gain_limit_1(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -370,7 +370,7 @@ class FeatureExtractorTest(unittest.TestCase):
         )
         self.fextractor.run()
         results = self.fextractor.results
-        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9574308606115118, places=6)  # float 0.9574308606115118
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.957433, places=6)  # float 0.9574308606115118
 
     def test_run_integer_adm_fextractor_akiyo_multiply_enhn_gain_limit_1d2(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -388,7 +388,7 @@ class FeatureExtractorTest(unittest.TestCase):
         )
         self.fextractor.run()
         results = self.fextractor.results
-        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.116595, places=6)  # float 1.116595
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.116609, places=6)  # float 1.116595
 
 
 if __name__ == '__main__':

--- a/python/test/vmafrc_feature_extractor_test.py
+++ b/python/test/vmafrc_feature_extractor_test.py
@@ -59,6 +59,19 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['integer_motion_feature_motion2_score'], 3.895345229166667, places=8)
         self.assertAlmostEqual(results[1]['integer_motion_feature_motion2_score'], 3.895345229166667, places=8)
 
+    def test_run_integer_motion_fextractor_forcing_zero(self):
+        ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = IntegerMotionFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'motion_force_zero': True}
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_motion_feature_motion2_score'], 0.0, places=8)
+        self.assertAlmostEqual(results[1]['integer_motion_feature_motion2_score'], 0.0, places=8)
+
     def test_run_integer_motion_fextractor_12bit(self):
         ref_path, dis_path, asset, asset_original = set_default_576_324_12bit_videos_for_testing()
         self.fextractor = IntegerMotionFeatureExtractor(

--- a/python/test/vmafrc_feature_extractor_test.py
+++ b/python/test/vmafrc_feature_extractor_test.py
@@ -337,5 +337,59 @@ class FeatureExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9518436666666666, places=4)
         self.assertAlmostEqual(results[1]['integer_ADM_feature_adm2_score'], 1.000002, places=6)
 
+    def test_run_integer_adm_fextractor_akiyo_multiply(self):
+        ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        dis_path = VmafConfig.test_resource_path("yuv", "disp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        asset = Asset(dataset="test", content_id=0, asset_id=0,
+                      workdir_root=VmafConfig.workdir_path(),
+                      ref_path=ref_path,
+                      dis_path=dis_path,
+                      asset_dict={'width': 352, 'height': 288})
+        self.fextractor = IntegerAdmFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.116705, places=6)  # float 1.116686
+
+    def test_run_integer_adm_fextractor_akiyo_multiply_enhn_gain_limit_1(self):
+        ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        dis_path = VmafConfig.test_resource_path("yuv", "disp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        asset = Asset(dataset="test", content_id=0, asset_id=0,
+                      workdir_root=VmafConfig.workdir_path(),
+                      ref_path=ref_path,
+                      dis_path=dis_path,
+                      asset_dict={'width': 352, 'height': 288})
+        self.fextractor = IntegerAdmFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'adm_enhn_gain_limit': 1.0}
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 0.9574308606115118, places=6)  # float 0.9574308606115118
+
+    def test_run_integer_adm_fextractor_akiyo_multiply_enhn_gain_limit_1d2(self):
+        ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        dis_path = VmafConfig.test_resource_path("yuv", "disp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
+        asset = Asset(dataset="test", content_id=0, asset_id=0,
+                      workdir_root=VmafConfig.workdir_path(),
+                      ref_path=ref_path,
+                      dis_path=dis_path,
+                      asset_dict={'width': 352, 'height': 288})
+        self.fextractor = IntegerAdmFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'adm_enhn_gain_limit': 1.2}
+        )
+        self.fextractor.run()
+        results = self.fextractor.results
+        self.assertAlmostEqual(results[0]['integer_ADM_feature_adm2_score'], 1.116595, places=6)  # float 1.116595
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/vmaf/core/vmafrc_feature_extractor.py
+++ b/python/vmaf/core/vmafrc_feature_extractor.py
@@ -188,7 +188,8 @@ class IntegerPsnrFeatureExtractor(VmafrcFeatureExtractorMixin, FeatureExtractor)
 class IntegerAdmFeatureExtractor(VmafrcFeatureExtractorMixin, FeatureExtractor):
 
     TYPE = "integer_ADM_feature"
-    VERSION = "1.0"
+    # VERSION = "1.0"
+    VERSION = "1.1"  # vectorization; small numerical diff introduced by adm_enhn_gain_limit
 
     ATOM_FEATURES = ['adm2']
 

--- a/python/vmaf/core/vmafrc_feature_extractor.py
+++ b/python/vmaf/core/vmafrc_feature_extractor.py
@@ -56,7 +56,8 @@ class IntegerMotionFeatureExtractor(VmafrcFeatureExtractorMixin, FeatureExtracto
         h=quality_height
         logger = self.logger
 
-        ExternalProgramCaller.call_vmafrc_single_feature('motion', yuv_type, ref_path, dis_path, w, h, log_file_path, logger)
+        ExternalProgramCaller.call_vmafrc_single_feature('motion', yuv_type, ref_path, dis_path, w, h,
+                                                         log_file_path, logger, options=self.optional_dict)
 
 
 class FloatVifFeatureExtractor(VmafrcFeatureExtractorMixin, FeatureExtractor):

--- a/python/vmaf/core/vmafrc_feature_extractor.py
+++ b/python/vmaf/core/vmafrc_feature_extractor.py
@@ -210,4 +210,5 @@ class IntegerAdmFeatureExtractor(VmafrcFeatureExtractorMixin, FeatureExtractor):
         h=quality_height
         logger = self.logger
 
-        ExternalProgramCaller.call_vmafrc_single_feature('adm', yuv_type, ref_path, dis_path, w, h, log_file_path, logger)
+        ExternalProgramCaller.call_vmafrc_single_feature('adm', yuv_type, ref_path, dis_path, w, h,
+                                                         log_file_path, logger, options=self.optional_dict)


### PR DESCRIPTION
This PR adds the vif_enhn_gain_limit parameter to the integer vif feature extractor.

```
./build/tools/vmaf_rc \
    --reference ./y4ms/ducks.y4m \
    --distorted ./y4ms/ducks_dist.y4m \
    --feature float_adm=adm_enhn_gain_limit=1.0 \
    --feature adm=adm_enhn_gain_limit=1.0 \
    --no_prediction \
    --output adm.xml
```