### PR TITLE
libvmaf/feature: rename features according to float/integer model requirements

### DIFF
--- a/libvmaf/src/feature/alias.c
+++ b/libvmaf/src/feature/alias.c
@@ -26,75 +26,75 @@ typedef struct {
 static Alias alias_map[] = {
     {
         .name = "'VMAF_feature_adm2_score'",
-        .alias = "adm2",
-    },
-    {
-        .name = "'VMAF_integer_feature_adm2_score'",
-        .alias = "integer_adm2",
+        .alias = "float_adm2",
     },
     {
         .name = "'VMAF_feature_adm_scale0_score'",
-        .alias = "adm_scale0",
+        .alias = "float_adm_scale0",
     },
     {
         .name = "'VMAF_feature_adm_scale1_score'",
-        .alias = "adm_scale1",
+        .alias = "float_adm_scale1",
     },
     {
         .name = "'VMAF_feature_adm_scale2_score'",
-        .alias = "adm_scale2",
+        .alias = "float_adm_scale2",
     },
     {
         .name = "'VMAF_feature_adm_scale3_score'",
-        .alias = "adm_scale3",
+        .alias = "float_adm_scale3",
     },
     {
         .name = "'VMAF_feature_motion_score'",
-        .alias = "motion",
+        .alias = "float_motion",
     },
     {
         .name = "'VMAF_feature_motion2_score'",
-        .alias = "motion2",
-    },
-    {
-        .name = "'VMAF_integer_feature_motion_score'",
-        .alias = "integer_motion",
-    },
-    {
-        .name = "'VMAF_integer_feature_motion2_score'",
-        .alias = "integer_motion2",
+        .alias = "float_motion2",
     },
     {
         .name = "'VMAF_feature_vif_scale0_score'",
-        .alias = "vif_scale0",
+        .alias = "float_vif_scale0",
     },
     {
         .name = "'VMAF_feature_vif_scale1_score'",
-        .alias = "vif_scale1",
+        .alias = "float_vif_scale1",
     },
     {
         .name = "'VMAF_feature_vif_scale2_score'",
-        .alias = "vif_scale2",
+        .alias = "float_vif_scale2",
     },
     {
         .name = "'VMAF_feature_vif_scale3_score'",
+        .alias = "float_vif_scale3",
+    },
+    {
+        .name = "VMAF_integer_feature_adm2_score",
+        .alias = "adm2",
+    },
+    {
+        .name = "VMAF_integer_feature_motion_score",
+        .alias = "motion",
+    },
+    {
+        .name = "VMAF_integer_feature_motion2_score",
+        .alias = "motion2",
+    },
+    {
+        .name = "VMAF_integer_feature_vif_scale0_score",
+        .alias = "vif_scale0",
+    },
+    {
+        .name = "VMAF_integer_feature_vif_scale1_score",
+        .alias = "vif_scale1",
+    },
+    {
+        .name = "VMAF_integer_feature_vif_scale2_score",
+        .alias = "vif_scale2",
+    },
+    {
+        .name = "VMAF_integer_feature_vif_scale3_score",
         .alias = "vif_scale3",
-    },
-    {
-        .name = "'VMAF_integer_feature_vif_scale0_score'",
-        .alias = "integer_vif_scale0",
-    },
-    {
-        .name = "'VMAF_integer_feature_vif_scale1_score'",
-        .alias = "integer_vif_scale1",
-    },
-    {
-        .name = "'VMAF_integer_feature_vif_scale2_score'",
-        .alias = "integer_vif_scale2",
-    },
-    {
-        .name = "'VMAF_integer_feature_vif_scale3_score'",
-        .alias = "integer_vif_scale3",
     },
 };
 
@@ -104,16 +104,8 @@ static Alias internal_alias_map[] = {
         .alias = "'VMAF_feature_adm2_score'",
     },
     {
-        .name = "VMAF_integer_feature_adm2_score",
-        .alias = "'VMAF_integer_feature_adm2_score'",
-    },
-    {
         .name = "VMAF_feature_motion2_score",
         .alias = "'VMAF_feature_motion2_score'",
-    },
-    {
-        .name = "VMAF_integer_feature_motion2_score",
-        .alias = "'VMAF_integer_feature_motion2_score'",
     },
     {
         .name = "VMAF_feature_vif_scale0_score",
@@ -130,22 +122,6 @@ static Alias internal_alias_map[] = {
     {
         .name = "VMAF_feature_vif_scale3_score",
         .alias = "'VMAF_feature_vif_scale3_score'",
-    },
-    {
-        .name = "VMAF_integer_feature_vif_scale0_score",
-        .alias = "'VMAF_integer_feature_vif_scale0_score'",
-    },
-    {
-        .name = "VMAF_integer_feature_vif_scale1_score",
-        .alias = "'VMAF_integer_feature_vif_scale1_score'",
-    },
-    {
-        .name = "VMAF_integer_feature_vif_scale2_score",
-        .alias = "'VMAF_integer_feature_vif_scale2_score'",
-    },
-    {
-        .name = "VMAF_integer_feature_vif_scale3_score",
-        .alias = "'VMAF_integer_feature_vif_scale3_score'",
     },
 };
 

--- a/libvmaf/src/feature/alias.c
+++ b/libvmaf/src/feature/alias.c
@@ -81,8 +81,8 @@ static Alias alias_map[] = {
         .alias = "integer_motion2",
     },
     {
-        .name = "integer_VMAF_integer_feature_vif_scale0_score",
-        .alias = "vif_scale0",
+        .name = "VMAF_integer_feature_vif_scale0_score",
+        .alias = "integer_vif_scale0",
     },
     {
         .name = "VMAF_integer_feature_vif_scale1_score",

--- a/libvmaf/src/feature/alias.c
+++ b/libvmaf/src/feature/alias.c
@@ -26,75 +26,75 @@ typedef struct {
 static Alias alias_map[] = {
     {
         .name = "'VMAF_feature_adm2_score'",
-        .alias = "float_adm2",
-    },
-    {
-        .name = "'VMAF_feature_adm_scale0_score'",
-        .alias = "float_adm_scale0",
-    },
-    {
-        .name = "'VMAF_feature_adm_scale1_score'",
-        .alias = "float_adm_scale1",
-    },
-    {
-        .name = "'VMAF_feature_adm_scale2_score'",
-        .alias = "float_adm_scale2",
-    },
-    {
-        .name = "'VMAF_feature_adm_scale3_score'",
-        .alias = "float_adm_scale3",
-    },
-    {
-        .name = "'VMAF_feature_motion_score'",
-        .alias = "float_motion",
-    },
-    {
-        .name = "'VMAF_feature_motion2_score'",
-        .alias = "float_motion2",
-    },
-    {
-        .name = "'VMAF_feature_vif_scale0_score'",
-        .alias = "float_vif_scale0",
-    },
-    {
-        .name = "'VMAF_feature_vif_scale1_score'",
-        .alias = "float_vif_scale1",
-    },
-    {
-        .name = "'VMAF_feature_vif_scale2_score'",
-        .alias = "float_vif_scale2",
-    },
-    {
-        .name = "'VMAF_feature_vif_scale3_score'",
-        .alias = "float_vif_scale3",
-    },
-    {
-        .name = "VMAF_integer_feature_adm2_score",
         .alias = "adm2",
     },
     {
-        .name = "VMAF_integer_feature_motion_score",
+        .name = "'VMAF_feature_adm_scale0_score'",
+        .alias = "adm_scale0",
+    },
+    {
+        .name = "'VMAF_feature_adm_scale1_score'",
+        .alias = "adm_scale1",
+    },
+    {
+        .name = "'VMAF_feature_adm_scale2_score'",
+        .alias = "adm_scale2",
+    },
+    {
+        .name = "'VMAF_feature_adm_scale3_score'",
+        .alias = "adm_scale3",
+    },
+    {
+        .name = "'VMAF_feature_motion_score'",
         .alias = "motion",
     },
     {
-        .name = "VMAF_integer_feature_motion2_score",
+        .name = "'VMAF_feature_motion2_score'",
         .alias = "motion2",
     },
     {
-        .name = "VMAF_integer_feature_vif_scale0_score",
+        .name = "'VMAF_feature_vif_scale0_score'",
+        .alias = "vif_scale0",
+    },
+    {
+        .name = "'VMAF_feature_vif_scale1_score'",
+        .alias = "vif_scale1",
+    },
+    {
+        .name = "'VMAF_feature_vif_scale2_score'",
+        .alias = "vif_scale2",
+    },
+    {
+        .name = "'VMAF_feature_vif_scale3_score'",
+        .alias = "vif_scale3",
+    },
+    {
+        .name = "VMAF_integer_feature_adm2_score",
+        .alias = "integer_adm2",
+    },
+    {
+        .name = "VMAF_integer_feature_motion_score",
+        .alias = "integer_motion",
+    },
+    {
+        .name = "VMAF_integer_feature_motion2_score",
+        .alias = "integer_motion2",
+    },
+    {
+        .name = "integer_VMAF_integer_feature_vif_scale0_score",
         .alias = "vif_scale0",
     },
     {
         .name = "VMAF_integer_feature_vif_scale1_score",
-        .alias = "vif_scale1",
+        .alias = "integer_vif_scale1",
     },
     {
         .name = "VMAF_integer_feature_vif_scale2_score",
-        .alias = "vif_scale2",
+        .alias = "integer_vif_scale2",
     },
     {
         .name = "VMAF_integer_feature_vif_scale3_score",
-        .alias = "vif_scale3",
+        .alias = "integer_vif_scale3",
     },
 };
 

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -2572,43 +2572,43 @@ static int extract(VmafFeatureExtractor *fex,
                                         score, index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "adm_scale0",
+                                        "integer_adm_scale0",
                                         scores[0] / scores[1], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "adm_scale1",
+                                        "integer_adm_scale1",
                                         scores[2] / scores[3], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "adm_scale2",
+                                        "integer_adm_scale2",
                                         scores[4] / scores[5], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "adm_scale3",
+                                        "integer_adm_scale3",
                                         scores[6] / scores[7], index);
 
     if (s->debug) {
-        err |= vmaf_feature_collector_append(feature_collector, "adm",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm",
                                              score, index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_num",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_num",
                                              score_num, index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_den",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_den",
                                              score_den, index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale0",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_num_scale0",
                                              scores[0], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale0",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_den_scale0",
                                              scores[1], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale1",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_num_scale1",
                                              scores[2], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale1",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_den_scale1",
                                              scores[3], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale2",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_num_scale2",
                                              scores[4], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale2",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_den_scale2",
                                              scores[5], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale3",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_num_scale3",
                                              scores[6], index);
-        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale3",
+        err |= vmaf_feature_collector_append(feature_collector, "integer_adm_den_scale3",
                                              scores[7], index);
     }
 
@@ -2631,7 +2631,6 @@ static int close(VmafFeatureExtractor *fex)
 
 static const char *provided_features[] = {
     "VMAF_integer_feature_adm2_score",
-    "adm_scale0", "adm_scale1", "adm_scale2", "adm_scale3",
     NULL
 };
 

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -2568,47 +2568,47 @@ static int extract(VmafFeatureExtractor *fex,
             scores, &s->buf, s->adm_enhn_gain_limit);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "'VMAF_integer_feature_adm2_score'",
+                                        "VMAF_integer_feature_adm2_score",
                                         score, index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "integer_adm_scale0",
+                                        "adm_scale0",
                                         scores[0] / scores[1], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "integer_adm_scale1",
+                                        "adm_scale1",
                                         scores[2] / scores[3], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "integer_adm_scale2",
+                                        "adm_scale2",
                                         scores[4] / scores[5], index);
 
     err |= vmaf_feature_collector_append(feature_collector,
-                                        "integer_adm_scale3",
+                                        "adm_scale3",
                                         scores[6] / scores[7], index);
 
     if (s->debug) {
-        err |= vmaf_feature_collector_append(feature_collector, "integer_adm",
+        err |= vmaf_feature_collector_append(feature_collector, "adm",
                                              score, index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_num",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_num",
                                              score_num, index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_den",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_den",
                                              score_den, index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_num_scale0",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale0",
                                              scores[0], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_den_scale0",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale0",
                                              scores[1], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_num_scale1",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale1",
                                              scores[2], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_den_scale1",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale1",
                                              scores[3], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_num_scale2",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale2",
                                              scores[4], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_den_scale2",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale2",
                                              scores[5], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_num_scale3",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_num_scale3",
                                              scores[6], index);
-        err |= vmaf_feature_collector_append(feature_collector,"integer_adm_den_scale3",
+        err |= vmaf_feature_collector_append(feature_collector, "adm_den_scale3",
                                              scores[7], index);
     }
 
@@ -2630,9 +2630,8 @@ static int close(VmafFeatureExtractor *fex)
 }
 
 static const char *provided_features[] = {
-    "'VMAF_integer_feature_adm2_score'",
-    "integer_adm_scale0", "integer_adm_scale1",
-    "integer_adm_scale2", "integer_adm_scale3",
+    "VMAF_integer_feature_adm2_score",
+    "adm_scale0", "adm_scale1", "adm_scale2", "adm_scale3",
     NULL
 };
 

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -277,11 +277,11 @@ static int extract_force_zero(VmafFeatureExtractor *fex,
     int err = 0;
 
     err = vmaf_feature_collector_append(feature_collector,
-                                         "'VMAF_integer_feature_motion2_score'",
+                                         "VMAF_integer_feature_motion2_score",
                                          0., index);
     if (s->debug) {
         err |= vmaf_feature_collector_append(feature_collector,
-                                            "'VMAF_integer_feature_motion_score'",
+                                            "VMAF_integer_feature_motion_score",
                                             0., index);
     }
     return err;
@@ -333,7 +333,7 @@ static int flush(VmafFeatureExtractor *fex,
     MotionState *s = fex->priv;
     int ret =
         vmaf_feature_collector_append(feature_collector,
-                                      "'VMAF_integer_feature_motion2_score'",
+                                      "VMAF_integer_feature_motion2_score",
                                       s->score, s->index);
     return (ret < 0) ? ret : !ret;
 }
@@ -374,11 +374,11 @@ static int extract(VmafFeatureExtractor *fex,
 
     if (index == 0) {
         err = vmaf_feature_collector_append(feature_collector,
-                                            "'VMAF_integer_feature_motion2_score'",
+                                            "VMAF_integer_feature_motion2_score",
                                             0., index);
         if (s->debug) {
             err |= vmaf_feature_collector_append(feature_collector,
-                                                 "'VMAF_integer_feature_motion_score'",
+                                                 "VMAF_integer_feature_motion_score",
                                                  0., index);
         }
         return err;
@@ -391,7 +391,7 @@ static int extract(VmafFeatureExtractor *fex,
 
     if (s->debug) {
         err |= vmaf_feature_collector_append(feature_collector,
-                                             "'VMAF_integer_feature_motion_score'",
+                                             "VMAF_integer_feature_motion_score",
                                              score, index);
     }
     if (err) return err;
@@ -405,7 +405,7 @@ static int extract(VmafFeatureExtractor *fex,
 
     score2 = score2 < score ? score2 : score;
     err = vmaf_feature_collector_append(feature_collector,
-                                        "'VMAF_integer_feature_motion2_score'",
+                                        "VMAF_integer_feature_motion2_score",
                                         score2, index - 1);
     return err;
 }
@@ -423,7 +423,7 @@ static int close(VmafFeatureExtractor *fex)
 }
 
 static const char *provided_features[] = {
-    "'VMAF_integer_feature_motion_score'", "'VMAF_integer_feature_motion2_score'",
+    "VMAF_integer_feature_motion_score", "VMAF_integer_feature_motion2_score",
     "VMAF_integer_feature_motion2_score",
     NULL
 };

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -424,7 +424,6 @@ static int close(VmafFeatureExtractor *fex)
 
 static const char *provided_features[] = {
     "VMAF_integer_feature_motion_score", "VMAF_integer_feature_motion2_score",
-    "VMAF_integer_feature_motion2_score",
     NULL
 };
 

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -665,16 +665,16 @@ static int extract(VmafFeatureExtractor *fex,
 
     int err = 0;
     err |= vmaf_feature_collector_append(feature_collector,
-                                         "'VMAF_integer_feature_vif_scale0_score'",
+                                         "VMAF_integer_feature_vif_scale0_score",
                                          scores[0] / scores[1], index);
     err |= vmaf_feature_collector_append(feature_collector,
-                                         "'VMAF_integer_feature_vif_scale1_score'",
+                                         "VMAF_integer_feature_vif_scale1_score",
                                          scores[2] / scores[3], index);
     err |= vmaf_feature_collector_append(feature_collector,
-                                         "'VMAF_integer_feature_vif_scale2_score'",
+                                         "VMAF_integer_feature_vif_scale2_score",
                                          scores[4] / scores[5], index);
     err |= vmaf_feature_collector_append(feature_collector,
-                                         "'VMAF_integer_feature_vif_scale3_score'",
+                                         "VMAF_integer_feature_vif_scale3_score",
                                          scores[6] / scores[7], index);
 
     if (s->debug) {
@@ -712,10 +712,10 @@ static int close(VmafFeatureExtractor *fex)
 }
 
 static const char *provided_features[] = {
-    "'VMAF_integer_feature_vif_scale0_score'",
-    "'VMAF_integer_feature_vif_scale1_score'",
-    "'VMAF_integer_feature_vif_scale2_score'",
-    "'VMAF_integer_feature_vif_scale3_score'",
+    "VMAF_integer_feature_vif_scale0_score",
+    "VMAF_integer_feature_vif_scale1_score",
+    "VMAF_integer_feature_vif_scale2_score",
+    "VMAF_integer_feature_vif_scale3_score",
     NULL
 };
 


### PR DESCRIPTION
This PR renames the feature names written by the integer vif/adm/motion feature extractors to match what is published in the new model files. Additionally, features written by the floating point feature extractors are now logged with the `float_` prefix and the integer versions of these features no longer have the `integer_` prefix.