### PR TITLE
vmaf_read_pictures: feature extractor flush update

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.rc.h
+++ b/libvmaf/include/libvmaf/libvmaf.rc.h
@@ -149,6 +149,9 @@ int vmaf_import_feature_score(VmafContext *vmaf, char *feature_name,
  * `VmafContext` will take ownership of both `VmafPicture`s (`ref` and `dist`)
  * and `vmaf_picture_unref()`.
  *
+ * When you're done reading pictures call this function again with both `ref`
+ * and `dist` set to NULL to flush all feature extractors.
+ *
  * @param vmaf  The VMAF context allocated with `vmaf_init()`.
  *
  * @param ref   Reference picture.

--- a/libvmaf/src/compute_vmaf.c
+++ b/libvmaf/src/compute_vmaf.c
@@ -248,6 +248,12 @@ int compute_vmaf(double* vmaf_score, char* fmt, int width, int height,
         }
     }
 
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    if (err) {
+        fprintf(stderr, "problem flushing context\n");
+        return err;
+    }
+
      if (enable_conf_interval) {
          VmafModelCollectionScore model_collection_score;
          err = vmaf_score_pooled_model_collection(vmaf, model_collection,

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -142,7 +142,7 @@ int vmaf_feature_extractor_context_init(VmafFeatureExtractorContext *fex_ctx,
     if (fex_ctx->is_initialized) return -EINVAL;
     if (!pix_fmt) return -EINVAL;
 
-    if (!fex_ctx->is_initialized) {
+    if (fex_ctx->fex->init && !fex_ctx->is_initialized) {
         int err = fex_ctx->fex->init(fex_ctx->fex, pix_fmt, bpc, w, h);
         if (err) return err;
     }
@@ -163,7 +163,8 @@ int vmaf_feature_extractor_context_extract(VmafFeatureExtractorContext *fex_ctx,
     if (!vfc) return -EINVAL;
     if (!fex_ctx->fex->extract) return -EINVAL;
 
-    if (fex_ctx->fex->init && !fex_ctx->is_initialized) {
+
+    if (!fex_ctx->is_initialized) {
         int err =
             vmaf_feature_extractor_context_init(fex_ctx, ref->pix_fmt, ref->bpc,
                                                 ref->w[0], ref->h[0]);

--- a/libvmaf/src/feature/float_motion.c
+++ b/libvmaf/src/feature/float_motion.c
@@ -90,9 +90,14 @@ static int flush(VmafFeatureExtractor *fex,
                  VmafFeatureCollector *feature_collector)
 {
     MotionState *s = fex->priv;
-    int ret = vmaf_feature_collector_append(feature_collector,
+    int ret = 0;
+
+    if (s->index > 0) {
+        ret = vmaf_feature_collector_append(feature_collector,
                                             "'VMAF_feature_motion2_score'",
                                             s->score, s->index);
+    }
+
     return (ret < 0) ? ret : !ret;
 }
 

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -331,10 +331,14 @@ static int flush(VmafFeatureExtractor *fex,
                  VmafFeatureCollector *feature_collector)
 {
     MotionState *s = fex->priv;
-    int ret =
-        vmaf_feature_collector_append(feature_collector,
-                                      "VMAF_integer_feature_motion2_score",
-                                      s->score, s->index);
+    int ret = 0;
+
+    if (s->index > 0) {
+        ret = vmaf_feature_collector_append(feature_collector,
+                                            "VMAF_integer_feature_motion2_score",
+                                            s->score, s->index);
+    }
+
     return (ret < 0) ? ret : !ret;
 }
 

--- a/libvmaf/src/libvmaf.rc.c
+++ b/libvmaf/src/libvmaf.rc.c
@@ -348,8 +348,15 @@ int vmaf_score_at_index(VmafContext *vmaf, VmafModel *model, double *score,
     if (!model) return -EINVAL;
     if (!score) return -EINVAL;
 
-    return vmaf_predict_score_at_index(model, vmaf->feature_collector, index,
-                                       score, true, 0);
+    int err =
+        vmaf_feature_collector_get_score(vmaf->feature_collector, model->name,
+                                         score, index);
+    if (err) {
+        err = vmaf_predict_score_at_index(model, vmaf->feature_collector, index,
+                                          score, true, 0);
+    }
+
+    return err;
 }
 
 int vmaf_score_at_index_model_collection(VmafContext *vmaf,

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -309,6 +309,12 @@ int main(int argc, char *argv[])
     }
     fprintf(stderr, "\n");
 
+    err |= vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    if (err) {
+        fprintf(stderr, "problem flushing context\n");
+        return err;
+    }
+
     for (unsigned i = 0; i < c.model_cnt; i++) {
         double vmaf_score;
         err = vmaf_score_pooled(vmaf, model[i], VMAF_POOL_METHOD_MEAN,


### PR DESCRIPTION
This PR adds a buffer flush mechanism to `vmaf_read_pictures()`. When you're done reading pictures call this function again with both `ref` and `dist` set to NULL to flush all feature extractors. In this framework, there can be feature extractors with temporal dependencies. When input pictures are finished a feature extractor may still have its own internal buffer which still needs to be drained. Currently,`motion` is the only feature extractor with the `VMAF_FEATURE_EXTRACTOR_TEMPORAL` flag. This API usage of passing `NULL, NULL` to flush buffers is similar to most encoding libraries.

Previously there were a few functions designed to be called after the `vmaf_read_pictures()` loop:

- `vmaf_feature_score_pooled()`
- `vmaf_score_pooled()`
- `vmaf_score_pooled_model_collection()`
- `vmaf_write_output()`

These functions used to automatically flush the feature extractors. The side effect of this was that once the flush took place, all future calls to `vmaf_read_pictures()` were invalid. In short, this means that any of the above functions could not be called "in-loop" more than once. With this change, this is no longer a constraint.

One thing to keep in mind is that VMAF has a temporal aspect, the `motion` feature extractor requires a future frame (**n+1**) in order to calculate the score of the current frame (**n**). This means the aforementioned functions will fail if called "in the loop" using picture index **n** because the motion score has not been written for that picture index yet. In the same situation, using index **n -1** will work just fine. In order to address this, we will be adding a new API in the future: `vmaf_read_reference_picture()`. Which will be a way to extract reference-only features like `motion`. With this API, generating the VMAF score of picture index **n** in-loop will be possible. Another thing that will become possible with this API will be usage in the context of OOO picture coding. 

Fixes #712.