### PR TITLE
Remove ALLOW_UNSECURE on CI

### DIFF
--- a/.github/workflows/ffmpeg.yml
+++ b/.github/workflows/ffmpeg.yml
@@ -25,9 +25,7 @@ jobs:
       CXX: ${{ matrix.CXX }}
     steps:
       - name: Setup python
-        uses: actions/setup-python@v1.2.0
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install meson and ninja
@@ -52,8 +50,6 @@ jobs:
           brew upgrade
           brew install -q ninja nasm
       - uses: actions/checkout@v2
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Build vmaf
         run: |
           meson setup libvmaf libvmaf/build --buildtype release

--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -30,9 +30,7 @@ jobs:
       CXX: ${{ matrix.CXX }}
     steps:
       - name: Setup python
-        uses: actions/setup-python@v1.2.0
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install meson and ninja
@@ -75,8 +73,6 @@ jobs:
           ccache --version
 
       - uses: actions/checkout@v2
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - name: Run meson
         run: |
           #sudo chown -R runner: $HOME/.ccache


### PR DESCRIPTION
Remove the need for ACTIONS_ALLOW_UNSECURE_COMMANDS, checkout never needed it and setup-python v2 does not use set-env anymore.

Closes #715 