### PR TITLE
vif/x86: set avx2/avx512 filter1d_16 for 12-bit inputs

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -552,14 +552,14 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         s->filter1d_8 = vif_filter1d_8_avx2;
-        if (bpc < 12) s->filter1d_16 = vif_filter1d_16_avx2; //FIXME
+        s->filter1d_16 = vif_filter1d_16_avx2;
         s->filter1d_rd_8 = vif_filter1d_rd_8_avx2;
         s->filter1d_rd_16 = vif_filter1d_rd_16_avx2;
     }
 #if HAVE_AVX512
     if (flags & VMAF_X86_CPU_FLAG_AVX512) {
         s->filter1d_8 = vif_filter1d_8_avx512;
-        if (bpc < 12) s->filter1d_16 = vif_filter1d_16_avx512; //FIXME
+        s->filter1d_16 = vif_filter1d_16_avx512;
         s->filter1d_rd_8 = vif_filter1d_rd_8_avx512;
         s->filter1d_rd_16 = vif_filter1d_rd_16_avx512;
     }


### PR DESCRIPTION
Mismatch was fixed by b82432d86b61833108dfa9afe0d863894749d911.