### PR TITLE
libvmaf/feature: deprecate daala_ssim

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -23,7 +23,6 @@
 
 #include "feature_extractor.h"
 
-extern VmafFeatureExtractor vmaf_fex_ssim;
 extern VmafFeatureExtractor vmaf_fex_float_ssim;
 extern VmafFeatureExtractor vmaf_fex_psnr;
 extern VmafFeatureExtractor vmaf_fex_psnr_hvs;
@@ -39,7 +38,6 @@ extern VmafFeatureExtractor vmaf_fex_float_ms_ssim;
 extern VmafFeatureExtractor vmaf_fex_float_moment;
 
 static VmafFeatureExtractor *feature_extractor_list[] = {
-    &vmaf_fex_ssim,
     &vmaf_fex_float_ssim,
     &vmaf_fex_psnr,
     &vmaf_fex_psnr_hvs,

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -335,7 +335,6 @@ libvmaf_rc_feature_sources = [
     feature_src_dir + 'float_ms_ssim.c',
     feature_src_dir + 'float_vif.c',
     feature_src_dir + 'integer_vif.c',
-    feature_src_dir + 'integer_ssim.c',
     feature_src_dir + 'float_moment.c',
 ]
 

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -52,7 +52,7 @@ static char *test_feature_extractor_context_pool()
     err = vmaf_fex_ctx_pool_create(&pool, n_threads);
     mu_assert("problem during vmaf_fex_ctx_pool_create", !err);
 
-    VmafFeatureExtractor *fex = vmaf_get_feature_extractor_by_name("ssim");
+    VmafFeatureExtractor *fex = vmaf_get_feature_extractor_by_name("float_ssim");
     mu_assert("problem during vmaf_get_feature_extractor_by_name", fex);
 
     VmafFeatureExtractorContext *fex_ctx[n_threads];
@@ -60,7 +60,7 @@ static char *test_feature_extractor_context_pool()
         err = vmaf_fex_ctx_pool_aquire(pool, fex, NULL, &fex_ctx[i]);
         mu_assert("problem during vmaf_fex_ctx_pool_aquire", !err);
         mu_assert("fex_ctx[i] should be ssim feature extractor",
-                  !strcmp(fex_ctx[i]->fex->name, "ssim"));
+                  !strcmp(fex_ctx[i]->fex->name, "float_ssim"));
     }
 
     for (unsigned i = 0; i < n_threads; i++) {

--- a/python/test/vmafrc_test.py
+++ b/python/test/vmafrc_test.py
@@ -164,7 +164,7 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertEqual(len(results[0]['VMAFRC_motion2_scores']), 48)
         self.assertEqual(len(results[1]['VMAFRC_motion2_scores']), 48)
 
-    def test_run_vmafrc_runner_fixed_psnr_ssim(self):
+    def test_run_vmafrc_runner_fixed_psnr(self):
 
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
 
@@ -175,8 +175,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
             result_store=None,
             optional_dict={
                 'psnr': True,
-                'ssim': True,
-                'ms_ssim': False,  # TODO: enable fixed_ms_ssim
                 'no_prediction': True,
             }
         )
@@ -187,12 +185,10 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_y_score'], 30.755063979166668, places=4)
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_cb_score'], 38.4494410625, places=4)
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_cr_score'], 40.99191027083334, places=4)
-        self.assertAlmostEqual(results[0]['VMAFRC_ssim_score'], 0.8613860416666667, places=4)
 
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_y_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_cb_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_cr_score'], 60.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAFRC_ssim_score'], 1.0, places=4)
 
     def test_run_vmafrc_runner_n_threads(self):
 
@@ -208,8 +204,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
                 'float_ssim': True,
                 'float_ms_ssim': True,
                 'psnr': True,
-                'ssim': True,
-                'ms_ssim': False,  # TODO: enable fixed_ms_ssim
                 'n_threads': 4,
             }
         )
@@ -229,7 +223,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_y_score'], 30.755063979166668, places=4)
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_cb_score'], 38.4494410625, places=4)
         self.assertAlmostEqual(results[0]['VMAFRC_psnr_cr_score'], 40.99191027083334, places=4)
-        self.assertAlmostEqual(results[0]['VMAFRC_ssim_score'], 0.8613860416666667, places=4)
 
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale0_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_vif_scale1_score'], 0.9999998541666666, places=4)
@@ -243,7 +236,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_y_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_cb_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_psnr_cr_score'], 60.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAFRC_ssim_score'], 1.0, places=4)
 
         self.assertAlmostEqual(results[0]['VMAFRC_score'], 76.66890489583334, places=4)
         self.assertAlmostEqual(results[1]['VMAFRC_score'], 99.94641666666666, places=4)
@@ -588,8 +580,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
                 'float_ssim': True,
                 'float_ms_ssim': True,
                 'psnr': True,
-                'ssim': True,
-                'ms_ssim': False,
             }
         )
         self.runner.run(parallelize=True)
@@ -618,7 +608,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_y_score'], results[0]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cb_score'], 38.4494410625, places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cr_score'], 40.99191027083334, places=4)
-        self.assertAlmostEqual(results_rc[0]['VMAFRC_ssim_score'], 0.8613860416666667, places=5)
 
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale0_score'], results[1]['VMAFOSSEXEC_vif_scale0_score'], places=5)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale1_score'], results[1]['VMAFOSSEXEC_vif_scale1_score'], places=5)
@@ -632,7 +621,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_y_score'], results[1]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cb_score'], 60.0, places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cr_score'], 60.0, places=4)
-        self.assertAlmostEqual(results_rc[1]['VMAFRC_ssim_score'], 1.0, places=5)
 
         self.assertAlmostEqual(results_rc[0]['VMAFRC_score'], results[0]['VMAFOSSEXEC_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_score'], results[1]['VMAFOSSEXEC_score'], places=4)
@@ -665,8 +653,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
                 'float_ssim': True,
                 'float_ms_ssim': True,
                 'psnr': True,
-                'ssim': True,
-                'ms_ssim': False,
             }
         )
         self.runner.run(parallelize=True)
@@ -695,7 +681,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_y_score'], results[0]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cb_score'], 50.2879106, places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cr_score'], 49.740259, places=4)
-        self.assertAlmostEqual(results_rc[0]['VMAFRC_ssim_score'], 0.9957616000000001, places=5)
 
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale0_score'], results[1]['VMAFOSSEXEC_vif_scale0_score'], places=5)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale1_score'], results[1]['VMAFOSSEXEC_vif_scale1_score'], places=5)
@@ -709,7 +694,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_y_score'], results[1]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cb_score'], 72.0, places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cr_score'], 72.0, places=4)
-        self.assertAlmostEqual(results_rc[1]['VMAFRC_ssim_score'], 1.0, places=5)
 
         self.assertAlmostEqual(results_rc[0]['VMAFRC_score'], results[0]['VMAFOSSEXEC_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_score'], results[1]['VMAFOSSEXEC_score'], places=4)
@@ -728,8 +712,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
                 'float_ssim': True,
                 'float_ms_ssim': True,
                 'psnr': True,
-                'ssim': True,
-                'ms_ssim': False,
             }
         )
         self.runner.run(parallelize=True)
@@ -758,7 +740,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_y_score'], results[0]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cb_score'], 38.7698320625, places=4)
         self.assertAlmostEqual(results_rc[0]['VMAFRC_psnr_cr_score'], 41.284188416666666, places=4)
-        self.assertAlmostEqual(results_rc[0]['VMAFRC_ssim_score'], 0.8616883333333334, places=5)
 
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale0_score'], results[1]['VMAFOSSEXEC_vif_scale0_score'], places=5)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_vif_scale1_score'], results[1]['VMAFOSSEXEC_vif_scale1_score'], places=5)
@@ -772,7 +753,6 @@ class VmafrcQualityRunnerTest(unittest.TestCase):
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_y_score'], results[1]['VMAFOSSEXEC_psnr_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cb_score'], 72.0, places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_psnr_cr_score'], 72.0, places=4)
-        self.assertAlmostEqual(results_rc[1]['VMAFRC_ssim_score'], 1.0, places=5)
 
         self.assertAlmostEqual(results_rc[0]['VMAFRC_score'], results[0]['VMAFOSSEXEC_score'], places=4)
         self.assertAlmostEqual(results_rc[1]['VMAFRC_score'], results[1]['VMAFOSSEXEC_score'], places=4)


### PR DESCRIPTION
This PR deprecates the ported version of daala ssim in libvmaf. `float_ssim` has always been the primary ssim implementation, with daala ssim only being ported as an auxiliary implementation. This is being deprecated to avoid any confusion about which ssim feature extractor should be used.