### PR TITLE
vmaf: add --aom_ctc flag and `proposed` preset

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -25,15 +25,15 @@
 #include "feature_extractor.h"
 
 #if VMAF_FLOAT_FEATURES
-extern VmafFeatureExtractor vmaf_fex_float_ssim;
 extern VmafFeatureExtractor vmaf_fex_float_psnr;
 extern VmafFeatureExtractor vmaf_fex_float_ansnr;
 extern VmafFeatureExtractor vmaf_fex_float_adm;
 extern VmafFeatureExtractor vmaf_fex_float_motion;
-extern VmafFeatureExtractor vmaf_fex_float_ms_ssim;
 extern VmafFeatureExtractor vmaf_fex_float_moment;
 extern VmafFeatureExtractor vmaf_fex_float_vif;
 #endif
+extern VmafFeatureExtractor vmaf_fex_float_ssim;
+extern VmafFeatureExtractor vmaf_fex_float_ms_ssim;
 extern VmafFeatureExtractor vmaf_fex_ciede;
 extern VmafFeatureExtractor vmaf_fex_psnr;
 extern VmafFeatureExtractor vmaf_fex_psnr_hvs;
@@ -43,15 +43,15 @@ extern VmafFeatureExtractor vmaf_fex_integer_vif;
 
 static VmafFeatureExtractor *feature_extractor_list[] = {
 #if VMAF_FLOAT_FEATURES
-    &vmaf_fex_float_ssim,
     &vmaf_fex_float_psnr,
     &vmaf_fex_float_ansnr,
     &vmaf_fex_float_adm,
     &vmaf_fex_float_vif,
     &vmaf_fex_float_motion,
-    &vmaf_fex_float_ms_ssim,
     &vmaf_fex_float_moment,
 #endif
+    &vmaf_fex_float_ms_ssim,
+    &vmaf_fex_float_ssim,
     &vmaf_fex_ciede,
     &vmaf_fex_psnr,
     &vmaf_fex_psnr_hvs,

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -229,6 +229,15 @@ libvmaf_feature_sources = [
     feature_src_dir + 'integer_ssim.c',
     feature_src_dir + 'ciede.c',
     feature_src_dir + 'common/alignment.c',
+
+    feature_src_dir + 'float_ssim.c',
+    feature_src_dir + 'float_ms_ssim.c',
+    feature_src_dir + 'ssim.c',
+    feature_src_dir + 'ms_ssim.c',
+    feature_src_dir + 'iqa/decimate.c',
+    feature_src_dir + 'iqa/ssim_tools.c',
+    feature_src_dir + 'iqa/math_utils.c',
+    feature_src_dir + 'iqa/convolve.c',
 ]
 
 if float_enabled
@@ -237,8 +246,6 @@ if float_enabled
         feature_src_dir + 'float_psnr.c',
         feature_src_dir + 'float_ansnr.c',
         feature_src_dir + 'float_motion.c',
-        feature_src_dir + 'float_ssim.c',
-        feature_src_dir + 'float_ms_ssim.c',
         feature_src_dir + 'float_vif.c',
         feature_src_dir + 'float_moment.c',
 
@@ -253,15 +260,9 @@ if float_enabled
         feature_src_dir + 'motion.c',
         feature_src_dir + 'psnr.c',
         feature_src_dir + 'psnr_tools.c',
-        feature_src_dir + 'ssim.c',
-        feature_src_dir + 'ms_ssim.c',
         feature_src_dir + 'moment.c',
         feature_src_dir + 'all.c',
         feature_src_dir + 'common/blur_array.c',
-        feature_src_dir + 'iqa/math_utils.c',
-        feature_src_dir + 'iqa/convolve.c',
-        feature_src_dir + 'iqa/decimate.c',
-        feature_src_dir + 'iqa/ssim_tools.c',
     ]
 endif
 


### PR DESCRIPTION
This PR adds a `--aom_ctc` flag the `vmaf` tool, as well as one preset `proposed`. Usage is as follows. This flag will preload the correct vmaf model as well as all the auxiliary metrics as required by the AOM CTC. If this proposal is accepted in AOM, we would have versioned presets (i.e. `--aom_ctc v1.0`). Presets discourage errors and should hopefully avoid having to specify an extended set of arguments.

```sh
./build/tools/vmaf  \
    --reference ./y4ms/test8.y4m \
    --distorted ./y4ms/test8dist.y4m \
    --aom_ctc proposed \
    --output output.xml
```

Also in this PR is a commit which is laying the initial groundwork for the APSNR metric. This metric is unique in that it is not calculated per-frame and then pooled, it is calculated over all the pixels in the video. There needs to be some framework updates to accommodate this category of metric. 