### PR TITLE
libvmaf/feature_collector: add aggregate_vector api

### DIFF
--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -44,6 +44,16 @@ static int aggregate_vector_append(AggregateVector *aggregate_vector,
 {
     if (!aggregate_vector) return -EINVAL;
 
+    for (unsigned i = 0; i < aggregate_vector->cnt; i++) {
+        if (!strcmp(feature_name, aggregate_vector->metric[i].name)) {
+            if (aggregate_vector->metric[i].value == score) {
+                return 0;
+            } else {
+                return -EINVAL;
+            }
+        }
+    }
+
     const unsigned cnt = aggregate_vector->cnt;
     if (cnt >= aggregate_vector->capacity) {
         size_t initial_size =

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -32,8 +32,17 @@ typedef struct {
     unsigned capacity;
 } FeatureVector;
 
+typedef struct {
+    struct {
+        char *name;
+        double value;
+    } *metric;
+    unsigned cnt, capacity;
+} AggregateVector;
+
 typedef struct VmafFeatureCollector {
     FeatureVector **feature_vector;
+    AggregateVector aggregate_vector;
     unsigned cnt, capacity;
     struct { clock_t begin, end; } timer;
     pthread_mutex_t lock;
@@ -48,6 +57,12 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
 int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
                                      char *feature_name, double *score,
                                      unsigned index);
+
+int vmaf_feature_collector_set_aggregate(VmafFeatureCollector *feature_collector,
+                                         char *feature_name, double score);
+
+int vmaf_feature_collector_get_aggregate(VmafFeatureCollector *feature_collector,
+                                         char *feature_name, double *score);
 
 void vmaf_feature_collector_destroy(VmafFeatureCollector *feature_collector);
 

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -104,6 +104,15 @@ int vmaf_write_output_xml(VmafContext *vmaf, VmafFeatureCollector *fc,
     }
     fprintf(outfile, "  </pooled_metrics>\n");
 
+
+    fprintf(outfile, "  <aggregate_metrics ");
+    for (unsigned i = 0; i < fc->aggregate_vector.cnt; i++) {
+        fprintf(outfile, "%s=\"%.6f\" ",
+                fc->aggregate_vector.metric[i].name,
+                fc->aggregate_vector.metric[i].value);
+    }
+    fprintf(outfile, "/>\n");
+
     fprintf(outfile, "</VMAF>\n");
 
     return 0;
@@ -177,7 +186,16 @@ int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
         fprintf(outfile, "      }\n");
         fprintf(outfile, "    }");
     }
-    fprintf(outfile, "\n  ]\n");
+    fprintf(outfile, "\n  ],\n");
+
+    fprintf(outfile, "  \"aggregate_metrics\": {");
+    for (unsigned i = 0; i < fc->aggregate_vector.cnt; i++) {
+        fprintf(outfile, "\n    \"%s\": %.6f",
+                fc->aggregate_vector.metric[i].name,
+                fc->aggregate_vector.metric[i].value);
+        fprintf(outfile, "%s", i < fc->aggregate_vector.cnt - 1 ? "," : "");
+    }
+    fprintf(outfile, "\n  }\n");
 
     fprintf(outfile, "}\n");
     return 0;

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -52,15 +52,16 @@ static char *test_feature_extractor_context_pool()
     err = vmaf_fex_ctx_pool_create(&pool, n_threads);
     mu_assert("problem during vmaf_fex_ctx_pool_create", !err);
 
-    VmafFeatureExtractor *fex = vmaf_get_feature_extractor_by_name("psnr");
+    VmafFeatureExtractor *fex =
+        vmaf_get_feature_extractor_by_name("float_ssim");
     mu_assert("problem during vmaf_get_feature_extractor_by_name", fex);
 
     VmafFeatureExtractorContext *fex_ctx[n_threads];
     for (unsigned i = 0; i < n_threads; i++) {
         err = vmaf_fex_ctx_pool_aquire(pool, fex, NULL, &fex_ctx[i]);
         mu_assert("problem during vmaf_fex_ctx_pool_aquire", !err);
-        mu_assert("fex_ctx[i] should be ssim feature extractor",
-                  !strcmp(fex_ctx[i]->fex->name, "psnr"));
+        mu_assert("fex_ctx[i] should be float_ssim feature extractor",
+                  !strcmp(fex_ctx[i]->fex->name, "float_ssim"));
     }
 
     for (unsigned i = 0; i < n_threads; i++) {


### PR DESCRIPTION
This PR adds an API for aggregate scores to the feature_collector API. An aggregate score is one that is calculated not on a per-frame basis but over the entire length of the video. The immediate use case for this is APSNR, but it could be useful for any sort of temporal pooling method which used pixel based features to determine picture weights (for example). The API for getting and setting is as follows:

```c
int vmaf_feature_collector_set_aggregate(VmafFeatureCollector *feature_collector,
                                         char *feature_name, double score);

int vmaf_feature_collector_get_aggregate(VmafFeatureCollector *feature_collector,
                                         char *feature_name, double *score);
```

Also in this PR is the aggregate metric APSNR which is written out when the option `enable_apsnr=true` is set. Finally, the last commit adds these aggregate metrics to the output XML/JSON. Schema for both of these output formats is shown below:

**XML**
```xml
    ...
    <frame frameNum="498" psnr_y="33.454377" psnr_cb="34.423700" psnr_cr="37.510643" />
    <frame frameNum="499" psnr_y="32.449354" psnr_cb="33.834603" psnr_cr="37.421720" />
  </frames>
  <pooled_metrics>
    <metric name="psnr_y" min="31.626009" max="36.476905" mean="33.084084" harmonic_mean="33.063320" />
    <metric name="psnr_cb" min="33.644718" max="37.281821" mean="34.467196" harmonic_mean="34.458703" />
    <metric name="psnr_cr" min="37.140558" max="39.128122" mean="37.762736" harmonic_mean="37.759060" />
  </pooled_metrics>
  <aggregate_metrics apsnr_y="33.003451" apsnr_cb="34.433354" apsnr_cr="37.746635" />
</VMAF>
```

**JSON**
```json
        ...
        "harmonic_mean": 37.759060
      }
    }
  ],
  "aggregate_metrics": {
    "apsnr_y": 33.003451,
    "apsnr_cb": 34.433354,
    "apsnr_cr": 37.746635
  }
}
```