### PR TITLE
ms_ssim/ssim: add enable_db parameter for reporting of scores in dB

### DIFF
--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -17,6 +17,7 @@
  */
 
 #include <errno.h>
+#include <math.h>
 #include <stddef.h>
 
 #include "feature_collector.h"
@@ -31,6 +32,7 @@ typedef struct MsSsimState {
     float *ref;
     float *dist;
     bool enable_lcs;
+    bool enable_db;
 } MsSsimState;
 
 static const VmafOption options[] = {
@@ -38,6 +40,13 @@ static const VmafOption options[] = {
         .name = "enable_lcs",
         .help = "enable luminance, contrast and structure intermediate output",
         .offset = offsetof(MsSsimState, enable_lcs),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "enable_db",
+        .help = "write MS-SSIM values as dB",
+        .offset = offsetof(MsSsimState, enable_db),
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
     },
@@ -65,6 +74,11 @@ fail:
     return -ENOMEM;
 }
 
+static double convert_to_db(double score)
+{
+    return -10. * log10(1 - score);
+}
+
 static int extract(VmafFeatureExtractor *fex,
                    VmafPicture *ref_pic, VmafPicture *ref_pic_90,
                    VmafPicture *dist_pic, VmafPicture *dist_pic_90,
@@ -84,6 +98,9 @@ static int extract(VmafFeatureExtractor *fex,
                           s->float_stride, s->float_stride,
                           &score, l_scores, c_scores, s_scores);
     if (err) return err;
+
+    if (s->enable_db)
+        score = convert_to_db(score);
 
     err = vmaf_feature_collector_append(feature_collector, "float_ms_ssim",
                                         score, index);

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -247,10 +247,10 @@ static void aom_ctc_proposed(CLISettings *settings, const char *const app)
         parse_feature_config("ciede", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
-        parse_feature_config("float_ssim", app);
+        parse_feature_config("float_ssim=enable_db=true", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
-        parse_feature_config("float_ms_ssim", app);
+        parse_feature_config("float_ms_ssim=enable_db=true", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
         parse_feature_config("psnr_hvs", app);


### PR DESCRIPTION
This PR adds an `enable_db` parameter to both `float_ssim` and `float_ms_ssim` to enable reporting of the SSIM/MS-SSIM scores in dB. Default behavior of reporting linear scores does not change. Usage is as follows:

```sh
--feature float_ssim=enable_db=true
--feature float_ms_ssim=enable_db=true
```