### PR TITLE
libvmaf: use const char* in API, clean up compilation warnings

### DIFF
--- a/libvmaf/include/libvmaf/feature.h
+++ b/libvmaf/include/libvmaf/feature.h
@@ -21,6 +21,7 @@
 
 typedef struct VmafFeatureDictionary VmafFeatureDictionary;
 
-int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val);
+int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
+                                const char *val);
 
 #endif /* __VMAF_FEATURE_H__ */

--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -139,7 +139,7 @@ int vmaf_use_feature(VmafContext *vmaf, const char *feature_name,
  *
  * @return 0 on success, or < 0 (a negative errno code) on error.
  */
-int vmaf_import_feature_score(VmafContext *vmaf, char *feature_name,
+int vmaf_import_feature_score(VmafContext *vmaf, const char *feature_name,
                               double value, unsigned index);
 
 /**

--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -31,7 +31,7 @@ enum VmafModelFlags {
 };
 
 typedef struct VmafModelConfig {
-    char *name;
+    const char *name;
     uint64_t flags;
 } VmafModelConfig;
 

--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -1,6 +1,6 @@
 project('libvmaf', ['c', 'cpp'],
     version : '2.0.0',
-    default_options : ['c_std=c99',
+    default_options : ['c_std=c11',
                        'cpp_std=c++11',
                        'warning_level=2',
                        'buildtype=release',

--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -151,7 +151,8 @@ fail:
 }
 
 
-int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, char *key, char *val)
+int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
+                                const char *val)
 {
     return vmaf_dictionary_set((VmafDictionary**)dict, key, val, 0);
 }

--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -40,7 +40,7 @@ static int aggregate_vector_init(AggregateVector *aggregate_vector)
 }
 
 static int aggregate_vector_append(AggregateVector *aggregate_vector,
-                                   char *feature_name, double score)
+                                   const char *feature_name, double score)
 {
     if (!aggregate_vector) return -EINVAL;
 
@@ -89,7 +89,7 @@ static void aggregate_vector_destroy(AggregateVector *aggregate_vector)
 }
 
 int vmaf_feature_collector_set_aggregate(VmafFeatureCollector *feature_collector,
-                                         char *feature_name, double score)
+                                         const char *feature_name, double score)
 {
     if (!feature_collector) return -EINVAL;
     if (!feature_name) return -EINVAL;
@@ -102,7 +102,8 @@ int vmaf_feature_collector_set_aggregate(VmafFeatureCollector *feature_collector
 }
 
 int vmaf_feature_collector_get_aggregate(VmafFeatureCollector *feature_collector,
-                                         char *feature_name, double *score)
+                                         const char *feature_name,
+                                         double *score)
 {
     if (!feature_collector) return -EINVAL;
     if (!feature_name) return -EINVAL;
@@ -219,7 +220,7 @@ fail:
 }
 
 static FeatureVector *find_feature_vector(VmafFeatureCollector *fc,
-                                          char *feature_name)
+                                          const char *feature_name)
 {
     FeatureVector *feature_vector = NULL;
     for (unsigned i = 0; i < fc->cnt; i++) {
@@ -233,7 +234,7 @@ static FeatureVector *find_feature_vector(VmafFeatureCollector *fc,
 }
 
 int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
-                                  char *feature_name, double score,
+                                  const char *feature_name, double score,
                                   unsigned picture_index)
 {
     if (!feature_collector) return -EINVAL;
@@ -279,7 +280,7 @@ unlock:
 }
 
 int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
-                                     char *feature_name, double *score,
+                                     const char *feature_name, double *score,
                                      unsigned index)
 {
     if (!feature_collector) return -EINVAL;

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -51,18 +51,20 @@ typedef struct VmafFeatureCollector {
 int vmaf_feature_collector_init(VmafFeatureCollector **const feature_collector);
 
 int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
-                                  char *feature_name, double score,
+                                  const char *feature_name, double score,
                                   unsigned index);
 
 int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
-                                     char *feature_name, double *score,
+                                     const char *feature_name, double *score,
                                      unsigned index);
 
 int vmaf_feature_collector_set_aggregate(VmafFeatureCollector *feature_collector,
-                                         char *feature_name, double score);
+                                         const char *feature_name,
+                                         double score);
 
 int vmaf_feature_collector_get_aggregate(VmafFeatureCollector *feature_collector,
-                                         char *feature_name, double *score);
+                                         const char *feature_name,
+                                         double *score);
 
 void vmaf_feature_collector_destroy(VmafFeatureCollector *feature_collector);
 

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -61,7 +61,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     NULL
 };
 
-VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(char *name)
+VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(const char *name)
 {
     if (!name) return NULL;
 
@@ -73,7 +73,7 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(char *name)
     return NULL;
 }
 
-VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name)
+VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(const char *name)
 {
     if (!name) return NULL;
 

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -91,10 +91,10 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(const char *nam
 
 int vmaf_fex_ctx_parse_options(VmafFeatureExtractorContext *fex_ctx)
 {
-    VmafOption *opt = NULL;
+    const VmafOption *opt = NULL;
     for (unsigned i = 0; (opt = &fex_ctx->fex->options[i]); i++) {
         if (!opt->name) break;
-        VmafDictionaryEntry *entry =
+        const VmafDictionaryEntry *entry =
             vmaf_dictionary_get(&fex_ctx->opts_dict, opt->name, 0);
         int err = vmaf_option_set(opt, fex_ctx->fex->priv,
                                   entry ? entry->val : NULL);
@@ -291,7 +291,7 @@ int vmaf_fex_ctx_pool_aquire(VmafFeatureExtractorContextPool *pool,
     while (atomic_load(&entry->capacity) == atomic_load(&entry->in_use))
         pthread_cond_wait(&(entry->full), &(pool->lock));
 
-    for (unsigned i = 0; i < atomic_load(&entry->capacity); i++) {
+    for (int i = 0; i < atomic_load(&entry->capacity); i++) {
         VmafFeatureExtractorContext *f = entry->ctx_list[i].fex_ctx;
         if (!f) {
             VmafDictionary *d = NULL;
@@ -337,7 +337,7 @@ int vmaf_fex_ctx_pool_release(VmafFeatureExtractorContextPool *pool,
         goto unlock;
     }
 
-    for (unsigned i = 0; i < atomic_load(&entry->capacity); i++) {
+    for (int i = 0; i < atomic_load(&entry->capacity); i++) {
         if (fex_ctx == entry->ctx_list[i].fex_ctx) {
             entry->ctx_list[i].in_use = false;
             atomic_fetch_sub(&entry->in_use, 1);
@@ -363,7 +363,7 @@ int vmaf_fex_ctx_pool_flush(VmafFeatureExtractorContextPool *pool,
         VmafFeatureExtractor *fex = pool->fex_list[i].fex;
         if (!(fex->flags & VMAF_FEATURE_EXTRACTOR_TEMPORAL))
             continue;
-        for (unsigned j = 0; j < atomic_load(&pool->fex_list[i].capacity); j++) {
+        for (int j = 0; j < atomic_load(&pool->fex_list[i].capacity); j++) {
             VmafFeatureExtractorContext *fex_ctx =
                 pool->fex_list[i].ctx_list[j].fex_ctx;
             if (!fex_ctx) continue;
@@ -383,7 +383,7 @@ int vmaf_fex_ctx_pool_destroy(VmafFeatureExtractorContextPool *pool)
 
     for (unsigned i = 0; i < pool->length; i++) {
         if (!pool->fex_list[i].ctx_list) continue;
-        for (unsigned j = 0; j < atomic_load(&pool->fex_list[i].capacity); j++) {
+        for (int j = 0; j < atomic_load(&pool->fex_list[i].capacity); j++) {
             VmafFeatureExtractorContext *fex_ctx =
                 pool->fex_list[i].ctx_list[j].fex_ctx;
             if (!fex_ctx) continue;

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -86,8 +86,8 @@ typedef struct VmafFeatureExtractor {
     const char **provided_features; ///< Provided feature list, NULL terminated.
 } VmafFeatureExtractor;
 
-VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(char *name);
-VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(char *name);
+VmafFeatureExtractor *vmaf_get_feature_extractor_by_name(const char *name);
+VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(const char *name);
 
 enum VmafFeatureExtractorContextFlags {
     VMAF_FEATURE_EXTRACTOR_CONTEXT_DO_NOT_OVERWRITE = 1 << 0,

--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -41,12 +41,15 @@ static const VmafOption options[] = {
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
     },
-    { NULL }
+    { 0 }
 };
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
+    (void) bpc;
+    (void) pix_fmt;
+
     MsSsimState *s = fex->priv;
     s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);

--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -41,12 +41,15 @@ static const VmafOption options[] = {
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
     },
-    { NULL }
+    { 0 }
 };
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
+    (void) pix_fmt;
+    (void) bpc;
+
     SsimState *s = fex->priv;
     s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -106,7 +106,7 @@ int vmaf_close(VmafContext *vmaf)
     return 0;
 }
 
-int vmaf_import_feature_score(VmafContext *vmaf, char *feature_name,
+int vmaf_import_feature_score(VmafContext *vmaf, const char *feature_name,
                               double value, unsigned index)
 {
     if (!vmaf) return -EINVAL;

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -225,7 +225,6 @@ libvmaf_feature_sources = [
     feature_src_dir + 'feature_collector.c',
     feature_src_dir + 'integer_motion.c',
     feature_src_dir + 'integer_vif.c',
-    feature_src_dir + 'integer_ssim.c',
     feature_src_dir + 'ciede.c',
     feature_src_dir + 'common/alignment.c',
 

--- a/libvmaf/src/opt.c
+++ b/libvmaf/src/opt.c
@@ -62,7 +62,7 @@ static int set_option_double(double *dst, double default_val, const char *val,
     return 0;
 }
 
-int vmaf_option_set(VmafOption *opt, void *obj, const char *val)
+int vmaf_option_set(const VmafOption *opt, void *obj, const char *val)
 {
     if (!obj) return -EINVAL;
     if (!opt) return -EINVAL;

--- a/libvmaf/src/opt.h
+++ b/libvmaf/src/opt.h
@@ -41,6 +41,6 @@ typedef struct VmafOption {
     double min, max;
 } VmafOption;
 
-int vmaf_option_set(VmafOption *opt, void *obj, const char *val);
+int vmaf_option_set(const VmafOption *opt, void *obj, const char *val);
 
 #endif /* __VMAF_SRC_OPT_H__ */

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -28,7 +28,7 @@
 #include "predict.h"
 #include "svm.h"
 
-static int normalize(VmafModel *model, double slope, double intercept,
+static int normalize(const VmafModel *model, double slope, double intercept,
                      double *feature_score)
 {
     switch (model->norm_type) {
@@ -44,7 +44,7 @@ static int normalize(VmafModel *model, double slope, double intercept,
     return 0;
 }
 
-static int denormalize(VmafModel *model, double *prediction)
+static int denormalize(const VmafModel *model, double *prediction)
 {
     switch (model->norm_type) {
     case(VMAF_MODEL_NORMALIZATION_TYPE_NONE):
@@ -60,7 +60,7 @@ static int denormalize(VmafModel *model, double *prediction)
 }
 
 
-static int transform(VmafModel *model, double *prediction,
+static int transform(const VmafModel *model, double *prediction,
                      enum VmafModelFlags flags)
 {
     if (!model->score_transform.enabled)
@@ -86,7 +86,7 @@ static int transform(VmafModel *model, double *prediction,
     return 0;
 }
 
-static int clip(VmafModel *model, double *prediction,
+static int clip(const VmafModel *model, double *prediction,
                 enum VmafModelFlags flags)
 {
     if (!model->score_clip.enabled)

--- a/libvmaf/src/svm.cpp
+++ b/libvmaf/src/svm.cpp
@@ -3113,19 +3113,19 @@ private:
 	void parse_support_vectors() {
 		// prepare sv coefficient structure
 		model->sv_coef = Malloc(double *, model->nr_class - 1);
-		for(size_t i = 0; i < model->nr_class - 1; ++i) {
+		for(int i = 0; i < model->nr_class - 1; ++i) {
 			model->sv_coef[i] = Malloc(double, model->l);
 		}
 
 		std::string line_buffer;
 		svm_node node_buffer;
 		std::vector<svm_node> sv_buffer;
-		for(size_t i = 0; i < model->l; ++i) {
+		for(int i = 0; i < model->l; ++i) {
 			exceptAssert(model_source.read_line(line_buffer), "Failed to read SVs");
 			std::istringstream line(line_buffer);
 
 			// parse sv coefficients
-			for(size_t c = 0; c < model->nr_class - 1; ++c) {
+			for(int c = 0; c < model->nr_class - 1; ++c) {
 				exceptAssert(line >> model->sv_coef[c][i], "Failed to parse SV coefficient");
 			}
 

--- a/libvmaf/test/test.c
+++ b/libvmaf/test/test.c
@@ -21,7 +21,7 @@
 
 int mu_tests_run;
 
-int main(int argc, char *argv[])
+int main(void)
 {
     char *msg = run_tests();
 

--- a/libvmaf/tools/main.cpp
+++ b/libvmaf/tools/main.cpp
@@ -48,6 +48,7 @@ static bool cmdOptionExists(char** begin, char** end, const std::string& option)
 
 static void print_usage(int argc, char *argv[])
 {
+    (void) argc;
     fprintf(stderr, "Usage: %s fmt width height ref_path dis_path model_path [--log log_path] [--log-fmt log_fmt] [--thread n_thread] [--subsample n_subsample] [--disable-clip] [--disable-avx] [--psnr] [--ssim] [--ms-ssim] [--phone-model] [--pool pool_method] [--ci]\n", argv[0]);
     fprintf(stderr, "fmt:\n\tyuv420p\n\tyuv422p\n\tyuv444p\n\tyuv420p10le\n\tyuv422p10le\n\tyuv444p10le\n\tyuv420p12le\n\tyuv422p12le\n\tyuv444p12le\n\tyuv420p16le\n\tyuv422p16le\n\tyuv444p16le\n\n");
     fprintf(stderr, "log_fmt:\n\txml (default)\n\tjson\n\tcsv\n\n");

--- a/libvmaf/tools/read_frame.c
+++ b/libvmaf/tools/read_frame.c
@@ -27,36 +27,6 @@
 /**
  * Note: stride is in terms of bytes
  */
-static int read_image(FILE *rfile, void *buf, int width, int height, int stride, int elem_size)
-{
-	char *byte_ptr = buf;
-	int i;
-	int ret = 1;
-
-	if (width <= 0 || height <= 0 || elem_size <= 0)
-	{
-		goto fail_or_end;
-	}
-
-	for (i = 0; i < height; ++i)
-	{
-		if (fread(byte_ptr, elem_size, width, rfile) != (size_t)width)
-		{
-			goto fail_or_end;
-		}
-
-		byte_ptr += stride;
-	}
-
-	ret = 0;
-
-fail_or_end:
-	return ret;
-}
-
-/**
- * Note: stride is in terms of bytes
- */
 static int read_image_b(FILE * rfile, float *buf, float off, int width, int height, int stride)
 {
 	char *byte_ptr = (char *)buf;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -276,8 +276,7 @@ int main(int argc, char *argv[])
         if (ret1 && ret2) {
             break;
         } else if (ret1 < 0 || ret2 < 0) {
-            fprintf(stderr, "\nproblem while reading pictures\n",
-                    c.path_ref, c.path_dist);
+            fprintf(stderr, "\nproblem while reading pictures\n");
             break;
         } else if (ret1) {
             fprintf(stderr, "\n\"%s\" ended before \"%s\".\n",


### PR DESCRIPTION
One last tweak before the release. Use `const char *` throughout the libvmaf API where appropriate. Also in this PR are some commits which clean up several compilation warnings in libvmaf.