### PR TITLE
libvmaf: final documentation pass before v2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Refer to the [FAQ](FAQ.md) page.
 
 The software package offers a number of ways to interact with the VMAF implementation.
 
-  - The [C executable `vmaf`](libvmaf/tools/README.md) has a complete algorithm implementation, such that one can easily deploy VMAF in a production environment. Additionally, the `vmaf` tool provides a number of auxillary metrics such as PSNR, SSIM and MS-SSIM.
-  - The [C library `libvmaf`](libvmaf/README.md) provides an interface to incorporate VMAF into your C code, and tools to integrate other feature extractors into the library.
+  - The command-line tool [`vmaf`](libvmaf/tools/README.md) provides a complete algorithm implementation, such that one can easily deploy VMAF in a production environment. Additionally, the `vmaf` tool provides a number of auxillary metrics such as PSNR, SSIM and MS-SSIM.
+  - The [C library `libvmaf`](libvmaf/README.md) provides an interface to incorporate VMAF into your code, and tools to integrate other feature extractors into the library.
   - The [Python library](resource/doc/VMAF_Python_library.md) offers a full array of wrapper classes and scripts for software testing, VMAF model training and validation, dataset processing, data visualization, etc.
   - VMAF is now included as a filter in FFmpeg, and can be configured using: `./configure --enable-libvmaf`. Refer to the [Using VMAF with FFmpeg](resource/doc/ffmpeg.md) page.
   - [VMAF Dockerfile](Dockerfile) generates a docker image from the [Python library](resource/doc/VMAF_Python_library.md). Refer to [this](resource/doc/docker.md) document for detailed usages.

--- a/libvmaf/README.md
+++ b/libvmaf/README.md
@@ -1,6 +1,4 @@
-# C library - `libvmaf`
-
-`libvmaf` is a C library that provides a complete VMAF implementation and an API to incorporate VMAF into your C code. Today FFmpeg incorporates VMAF [as a filter](../resource/doc/ffmpeg.md). `libvmaf` also provides tools to integrate a third-party feature extractors (for example: PSNR-HVS) into the library through the `VmafFeatureExtractor` API.
+# `libvmaf`
 
 ## Prerequisites
 
@@ -23,7 +21,7 @@ You need to invoke `[package-manager]` depending on which system you are on: `ap
 
 ## Compile
 
-Under the `libvmaf` directory, run:
+Run:
 
 ```
 meson build --buildtype release
@@ -84,12 +82,13 @@ ninja -vC build doc/html
 
 `libvmaf` now has a number of VMAF models built-in. This means that no external VMAF model files are required, since the models are compiled into and read directly from the library. If you do not wish to compile the built-in models into your build, you may disable them with `-Dbuilt_in_models=false`. Previous versions of this library required a `.pkl` model file. Since libvmaf v2.0.0, these `.pkl` model files have been depreciated in favor of `.json` model files. If you have a previously trained `.pkl` model you would like to convert to `.json`, this [Python conversion script](../python/vmaf/script/convert_model_from_pkl_to_json.py) is available. 
 
-## Incorporate VMAF into Your C Code
+## `vmaf`
 
-Follow the steps below to incorporate VMAF into your C code. For complete API documentation, see [libvmaf.h](include/libvmaf/libvmaf.h). For an example of using the API to create the `vmaf` command line tool, see [vmaf.c](tools/vmaf.c).
+A command line tool called `vmaf` is included as part of the build/installation. See the `vmaf` [README.md](tools/README.md) for details. An older command line tool (`vmafossexec`) is still part of the build but is not part of the installation. `vmafossexec` will be removed in a future version of this library.
 
+## API Walkthrough
 
-First, create a `VmafContext` with `vmaf_init()`. `VmafContext` is an opaque type, and `VmafConfiguration` is a options struct used to initialize the context. Be sure to clean up the `VmafContext` with `vmaf_close()` when you are done with it.
+Create a `VmafContext` with `vmaf_init()`. `VmafContext` is an opaque type, and `VmafConfiguration` is a options struct used to initialize the context. Be sure to clean up the `VmafContext` with `vmaf_close()` when you are done with it.
 
 ```c
 int vmaf_init(VmafContext **vmaf, VmafConfiguration cfg);
@@ -144,11 +143,13 @@ int vmaf_score_pooled(VmafContext *vmaf, VmafModel *model,
                       unsigned index_low, unsigned index_high);
 ```
 
-## Write a New Feature Extractor
+For complete API documentation, see [libvmaf.h](include/libvmaf/libvmaf.h). For an example of using the API to create the `vmaf` command line tool, see [vmaf.c](tools/vmaf.c).
+
+## Contributing a new VmafFeatureExtractor
 
 To write a new feature extractor, please first familiarize yourself with the [VmafFeatureExtractor API](https://github.com/Netflix/vmaf/blob/master/libvmaf/src/feature/feature_extractor.h#L36-L87) documentation.
 
-Create a new `VmafFeatureExtractor` and add it to the build as well as the `feature_extractor_list[]`. See [this diff](https://github.com/Netflix/vmaf/commit/fd3c79697c7e06586aa5b9cda8db0d9aedfd70c5) for an example to create a floating-point MS-SSIM feature extractor. Once you do this your feature extractor may be registered and used inside of `libvmaf` via `vmaf_use_feature()` or `vmaf_use_features_from_model()`. To invoke this feature extractor directly from the command line with `vmaf` use the `--feature` flag.
+Create a new `VmafFeatureExtractor` and add it to the build as well as the `feature_extractor_list[]`. See [this diff](https://github.com/Netflix/vmaf/commit/fd3c79697c7e06586aa5b9cda8db0d9aedfd70c5) for an example. Once you do this your feature extractor may be registered and used inside of `libvmaf` via `vmaf_use_feature()` or `vmaf_use_features_from_model()`. To invoke this feature extractor directly from the command line with `vmaf` use the `--feature` flag.
 
 `VmafFeatureExtractor` is a feature extraction class with just a few callbacks. If you have preallocations and/or precomputations to make, it is best to do this in the `.init()` callback and store the output in `.priv`.  This is a place for custom data which is available for all subsequent callbacks. If you allocate anything in `.init()` be sure to clean it up in the `.close()` callback.
 

--- a/libvmaf/tools/README.md
+++ b/libvmaf/tools/README.md
@@ -1,8 +1,6 @@
-# C Executable - `vmaf`
+# `vmaf`
 
 `vmaf` is a command line tool which supports VMAF feature extraction and prediction. The tool takes a pair of input videos as well as a trained VMAF model and writes an output log containing per-frame and pooled VMAF scores. Input videos can be either `.y4m` or `.yuv` and output logs are available in a number of formats: `.xml`, `.json`, `.csv`, `.sub`.
-
-An older command line tool (`vmafossexec`) is still part of the build but is not part of the [installation](../README.md#install). `vmafossexec` will be removed in a future version of this library.
 
 ## Compile
 
@@ -11,7 +9,7 @@ Refer to the [`libvmaf`](../README.md) Compile section.
 ## Usage
 
 ```
-Usage: libvmaf/build/tools/vmaf [options]
+Usage: vmaf [options]
 
 Supported options:
  --reference/-r $path:      path to reference .y4m or .yuv
@@ -80,7 +78,7 @@ A number of addtional metrics are supported. Enable these metrics with the `--fe
 The following example shows a comparison using a pair of yuv inputs ([`src01_hrc00_576x324.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/src01_hrc00_576x324.yuv), [`src01_hrc01_576x324.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/src01_hrc01_576x324.yuv)). In addition to VMAF, the `psnr` metric is also computed and logged.
 
 ```shell script
-libvmaf/build/tools/vmaf \
+./build/tools/vmaf \
     --reference src01_hrc00_576x324.yuv \
     --distorted src01_hrc01_576x324.yuv \
     --width 576 --height 324 --pixel_format 420 --bitdepth 8 \


### PR DESCRIPTION
This PR is a final documentation pass before the `libvmaf` v2.0.0.

- Avoids external references, written as if the `libvmaf` directory was its own self-contained tree.
- Since the library should be linkable via C++, FFI, etc. the "incorporate VMAF into your C code" sections have been modified to discuss the API in a general context.
- Avoid mentions of the `ffmpeg` filter from the `libvmaf` tree, discuss `libvmaf` only.