### PR TITLE
libvmaf: use uint64_t for cpumask

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -53,7 +53,7 @@ typedef struct VmafConfiguration {
     enum VmafLogLevel log_level;
     unsigned n_threads;
     unsigned n_subsample;
-    unsigned cpumask;
+    uint64_t cpumask;
 } VmafConfiguration;
 
 typedef struct VmafContext VmafContext;


### PR DESCRIPTION
Updates `VmafConfiguration.cpumask` to use an explicitly sized type: `uint64_t`. Checks one of the final boxes for #591.