### PR TITLE
libvmaf/test: clean up all test allocations

### DIFF
--- a/libvmaf/src/fex_ctx_vector.c
+++ b/libvmaf/src/fex_ctx_vector.c
@@ -47,6 +47,7 @@ int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
                 /* if do not overwrite, check opts_dict consistency */
                 if (!rfe->fex_ctx[i]->opts_dict && !fex_ctx->opts_dict) {
                     /* skip if both opts_dict are NULL */
+                    vmaf_feature_extractor_context_destroy(fex_ctx);
                     return 0;
                 } else if (!rfe->fex_ctx[i]->opts_dict || !fex_ctx->opts_dict) {
                     /* error if one dict is NULL and the other is not.
@@ -54,16 +55,19 @@ int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
                      * equal to the default value of the NULL dict's. But this is not fixable
                      * in the current framework unless the default values of fex's options
                      * are exposed in the current layer. FIXME */
+                    vmaf_feature_extractor_context_destroy(fex_ctx);
                     return -ENOMEM;
                 }
                 VmafDictionary *d =
                         vmaf_dictionary_merge(&rfe->fex_ctx[i]->opts_dict,
                                               &fex_ctx->opts_dict, VMAF_DICT_DO_NOT_OVERWRITE);
                 if (!d) {
+                    vmaf_feature_extractor_context_destroy(fex_ctx);
                     return -ENOMEM;
                 }
                 else {
                     vmaf_dictionary_free(&d);
+                    vmaf_feature_extractor_context_destroy(fex_ctx);
                     return 0;
                 }
             } else {

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -116,6 +116,15 @@ static char *test_feature_extractor_flush()
                                            &score, 1);
     mu_assert("problem during vmaf_feature_collector_get_score", !err);
 
+    err = vmaf_feature_extractor_context_close(fex_ctx);
+    mu_assert("problem during vmaf_feature_extractor_context_close", !err);
+    err = vmaf_feature_extractor_context_destroy(fex_ctx);
+    mu_assert("problem during vmaf_feature_extractor_context_destroy", !err);
+
+    vmaf_feature_collector_destroy(vfc);
+    vmaf_picture_unref(&ref);
+    vmaf_picture_unref(&dist);
+
     return NULL;
 }
 
@@ -154,8 +163,14 @@ static char *test_feature_extractor_initialization_options()
     err = vmaf_feature_collector_get_score(vfc, "psnr_cb", &score, 0);
     mu_assert("chroma PSNR was not disabled via option", err);
 
-    err = vmaf_dictionary_free(&opts_dict);
-    mu_assert("problem during vmaf_dictionary_free", !err);
+    err = vmaf_feature_extractor_context_close(fex_ctx);
+    mu_assert("problem during vmaf_feature_extractor_context_close", !err);
+    err = vmaf_feature_extractor_context_destroy(fex_ctx);
+    mu_assert("problem during vmaf_feature_extractor_context_destroy", !err);
+
+    vmaf_feature_collector_destroy(vfc);
+    vmaf_picture_unref(&ref);
+    vmaf_picture_unref(&dist);
 
     return NULL;
 }

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -263,6 +263,7 @@ static char *test_model_set_flags()
               !model3->feature[4].opts_dict);
     mu_assert("feature[5].opts_dict must be NULL.\n",
               !model3->feature[5].opts_dict);
+    vmaf_model_destroy(model3);
 
     VmafModel  *model4;
     VmafModelConfig  cfg4 = { 0 };
@@ -309,6 +310,7 @@ static char *test_model_set_flags()
     mu_assert("feature[5].opts_dict[\"vif_enhn_gain_limit\"] must have value 1.0.\n",
               strcmp(entry->val, "1.0")==0);
 
+    vmaf_model_destroy(model4);
     return NULL;
 }
 

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -362,9 +362,11 @@ int main(int argc, char *argv[])
 
     for (unsigned i = 0; i < c.model_cnt; i++)
         vmaf_model_destroy(model[i]);
+    free(model);
 
     for (unsigned i = 0; i < model_collection_cnt; i++)
         vmaf_model_collection_destroy(model_collection[i]);
+    free(model_collection);
 
     video_input_close(&vid_ref);
     video_input_close(&vid_dist);


### PR DESCRIPTION
Cleans up all memory in `libvmaf` tests which was previously not `free`'d. It's good to keep these leakless since it's just more lsan noise if we don't.