### PR TITLE
libvmaf: add vmaf_log()

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -29,7 +29,10 @@
 
 enum VmafLogLevel {
     VMAF_LOG_LEVEL_NONE = 0,
-    VMAF_LOG_LEVEL_INFO = 1 << 0,
+    VMAF_LOG_LEVEL_ERROR,
+    VMAF_LOG_LEVEL_WARNING,
+    VMAF_LOG_LEVEL_INFO,
+    VMAF_LOG_LEVEL_DEBUG,
 };
 
 enum VmafOutputFormat {

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -31,6 +31,7 @@
 #include "feature/feature_extractor.h"
 #include "feature/feature_collector.h"
 #include "fex_ctx_vector.h"
+#include "log.h"
 #include "model.h"
 #include "output.h"
 #include "picture.h"
@@ -65,6 +66,8 @@ int vmaf_init(VmafContext **vmaf, VmafConfiguration cfg)
 
     vmaf_init_cpu();
     vmaf_set_cpu_flags_mask(~cfg.cpumask);
+
+    vmaf_set_log_level(cfg.log_level);
 
     err = vmaf_feature_collector_init(&(v->feature_collector));
     if (err) goto free_v;

--- a/libvmaf/src/log.c
+++ b/libvmaf/src/log.c
@@ -1,0 +1,63 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "libvmaf/libvmaf.h"
+
+#include <stdarg.h>
+#include <unistd.h>
+
+static enum VmafLogLevel vmaf_log_level = VMAF_LOG_LEVEL_INFO;
+static int istty = 0;
+
+void vmaf_set_log_level(enum VmafLogLevel level)
+{
+    level = level < VMAF_LOG_LEVEL_NONE ? VMAF_LOG_LEVEL_NONE : level;
+    level = level > VMAF_LOG_LEVEL_DEBUG ? VMAF_LOG_LEVEL_DEBUG : level;
+    vmaf_log_level = level;
+    istty = isatty(fileno(stderr));
+}
+
+static const char *level_str[] = {
+    [VMAF_LOG_LEVEL_ERROR] = "ERROR",
+    [VMAF_LOG_LEVEL_WARNING] = "WARNING",
+    [VMAF_LOG_LEVEL_INFO] = "INFO",
+    [VMAF_LOG_LEVEL_DEBUG] = "DEBUG",
+};
+
+static const char *level_str_color[] = {
+    [VMAF_LOG_LEVEL_ERROR] = "\x1B[31m",
+    [VMAF_LOG_LEVEL_WARNING] = "\x1B[33m",
+    [VMAF_LOG_LEVEL_INFO] = "\x1B[32m",
+    [VMAF_LOG_LEVEL_DEBUG] = "\x1B[34m",
+};
+
+void vmaf_log(enum VmafLogLevel level, const char *fmt, ...)
+{
+    if (level <= VMAF_LOG_LEVEL_NONE) return;
+    if (level > vmaf_log_level) return;
+
+    va_list(args);
+    fprintf(stderr, "%slibvmaf%s %s%s%s ",
+            istty ? "\x1B[35m" : "",
+            istty ? "\x1B[0m" : "",
+            istty ? level_str_color[level] : "",
+            level_str[level],
+            istty ? "\x1B[0m" : "");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+}

--- a/libvmaf/src/log.h
+++ b/libvmaf/src/log.h
@@ -1,0 +1,27 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_SRC_LOG_H__
+#define __VMAF_SRC_LOG_H__
+
+#include "libvmaf/libvmaf.h"
+
+void vmaf_set_log_level(enum VmafLogLevel log_level);
+void vmaf_log(enum VmafLogLevel log_level, const char *fmt, ...);
+
+#endif /* __VMAF_SRC_LOG_H__ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -288,6 +288,7 @@ libvmaf_sources = [
     src_dir + 'ref.c',
     src_dir + 'read_json_model.c',
     src_dir + 'pdjson.c',
+    src_dir + 'log.c',
 ]
 
 if host_machine.system() == 'windows'

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -29,7 +29,7 @@ test_thread_pool = executable('test_thread_pool',
 )
 
 test_model = executable('test_model',
-    ['test.c', 'test_model.c', '../src/dict.c', '../src/svm.cpp', '../src/pdjson.c', '../src/read_json_model.c', json_model_c_sources],
+    ['test.c', 'test_model.c', '../src/dict.c', '../src/svm.cpp', '../src/pdjson.c', '../src/read_json_model.c', '../src/log.c', json_model_c_sources],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src')],
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
@@ -38,7 +38,7 @@ test_model = executable('test_model',
 
 test_predict = executable('test_predict',
     ['test.c', 'test_predict.c', '../src/predict.c', '../src/dict.c',
-     '../src/feature/feature_collector.c', '../src/feature/alias.c', '../src/model.c', '../src/svm.cpp',
+     '../src/feature/feature_collector.c', '../src/feature/alias.c', '../src/model.c', '../src/svm.cpp', '../src/log.c',
      '../src/read_json_model.c', '../src/pdjson.c', json_model_c_sources],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src')],
     c_args : vmaf_cflags_common,

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -22,6 +22,11 @@ test_feature_collector = executable('test_feature_collector',
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/feature/')],
 )
 
+test_log = executable('test_log',
+    ['test.c', 'test_log.c', '../src/log.c'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+)
+
 test_thread_pool = executable('test_thread_pool',
     ['test.c', 'test_thread_pool.c', '../src/thread_pool.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],

--- a/libvmaf/test/test_log.c
+++ b/libvmaf/test/test_log.c
@@ -1,0 +1,45 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <stdint.h>
+
+#include "test.h"
+#include "log.h"
+#include "libvmaf/libvmaf.h"
+
+static char *test_vmaf_log()
+{
+    fprintf(stderr, "\n");
+
+    vmaf_set_log_level(VMAF_LOG_LEVEL_DEBUG);
+    vmaf_log(VMAF_LOG_LEVEL_ERROR, "this is an example %s log\n", "error");
+    vmaf_log(VMAF_LOG_LEVEL_WARNING, "this is an example %s log\n", "warning");
+    vmaf_log(VMAF_LOG_LEVEL_INFO, "this is an example %s log\n", "info");
+    vmaf_log(VMAF_LOG_LEVEL_DEBUG, "this is an example %s log\n", "debug");
+
+    vmaf_log(VMAF_LOG_LEVEL_DEBUG + 1, "this should log nothing\n");
+    vmaf_log(VMAF_LOG_LEVEL_NONE - 1, "this should log nothing\n");
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_vmaf_log);
+    return NULL;
+}


### PR DESCRIPTION
Adds an internal logging api `vmaf_log()`, addresses #365.

Also, another commit to log model loading failures and mention pkl deprecation. 