### PR TITLE
meson: use library() and fix external builds

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -4,6 +4,7 @@ project('libvmaf', ['c', 'cpp'],
                        'cpp_std=c++11',
                        'warning_level=2',
                        'buildtype=release',
+                       'default_library=both',
                       ],
     meson_version: '>= 0.47.0')
 

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -122,7 +122,11 @@ if built_in_models_enabled
             json_model_c_sources += custom_target(
                   model_file,
                   output : '@PLAINNAME@.c',
-                  input : model_dir + model_file,
+                  input : configure_file(
+                    input : model_dir + model_file,
+                    output : model_file,
+                    copy: true
+                  ),
                   command : [xxd, '--include', '@INPUT@', '@OUTPUT@'],
             )
         endforeach

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -297,7 +297,7 @@ else
     vmaf_soversion = vmaf_api_version_major
 endif
 
-libvmaf = both_libraries(
+libvmaf = library(
     'vmaf',
     [libvmaf_sources, rev_target, json_model_c_sources],
     include_directories : [libvmaf_inc, vmaf_include],

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -21,19 +21,19 @@ typedef struct VmafBuiltInModel {
 
 #if VMAF_BUILT_IN_MODELS
 #if VMAF_FLOAT_FEATURES
-extern const char ___src_______model_vmaf_float_v0_6_1neg_json;
-extern const int ___src_______model_vmaf_float_v0_6_1neg_json_len;
-extern const char ___src_______model_vmaf_float_v0_6_1_json;
-extern const int ___src_______model_vmaf_float_v0_6_1_json_len;
-extern const char ___src_______model_vmaf_float_b_v0_6_3_json;
-extern const int ___src_______model_vmaf_float_b_v0_6_3_json_len;
+extern const char src_vmaf_float_v0_6_1neg_json;
+extern const int src_vmaf_float_v0_6_1neg_json_len;
+extern const char src_vmaf_float_v0_6_1_json;
+extern const int src_vmaf_float_v0_6_1_json_len;
+extern const char src_vmaf_float_b_v0_6_3_json;
+extern const int src_vmaf_float_b_v0_6_3_json_len;
 #endif
-extern const char ___src_______model_vmaf_v0_6_1_json;
-extern const int ___src_______model_vmaf_v0_6_1_json_len;
-extern const char ___src_______model_vmaf_b_v0_6_3_json;
-extern const int ___src_______model_vmaf_b_v0_6_3_json_len;
-extern const char ___src_______model_vmaf_v0_6_1neg_json;
-extern const int ___src_______model_vmaf_v0_6_1neg_json_len;
+extern const char src_vmaf_v0_6_1_json;
+extern const int src_vmaf_v0_6_1_json_len;
+extern const char src_vmaf_b_v0_6_3_json;
+extern const int src_vmaf_b_v0_6_3_json_len;
+extern const char src_vmaf_v0_6_1neg_json;
+extern const int src_vmaf_v0_6_1neg_json_len;
 #endif
 
 static const VmafBuiltInModel built_in_models[] = {
@@ -41,34 +41,34 @@ static const VmafBuiltInModel built_in_models[] = {
 #if VMAF_FLOAT_FEATURES
     {
         .version = "vmaf_float_v0.6.1neg",
-        .data = &___src_______model_vmaf_float_v0_6_1neg_json,
-        .data_len = &___src_______model_vmaf_float_v0_6_1neg_json_len,
+        .data = &src_vmaf_float_v0_6_1neg_json,
+        .data_len = &src_vmaf_float_v0_6_1neg_json_len,
     },
     {
         .version = "vmaf_float_v0.6.1",
-        .data = &___src_______model_vmaf_float_v0_6_1_json,
-        .data_len = &___src_______model_vmaf_float_v0_6_1_json_len,
+        .data = &src_vmaf_float_v0_6_1_json,
+        .data_len = &src_vmaf_float_v0_6_1_json_len,
     },
     {
         .version = "vmaf_float_b_v0.6.3",
-        .data = &___src_______model_vmaf_float_b_v0_6_3_json,
-        .data_len = &___src_______model_vmaf_float_b_v0_6_3_json_len,
+        .data = &src_vmaf_float_b_v0_6_3_json,
+        .data_len = &src_vmaf_float_b_v0_6_3_json_len,
     },
 #endif
     {
         .version = "vmaf_v0.6.1",
-        .data = &___src_______model_vmaf_v0_6_1_json,
-        .data_len = &___src_______model_vmaf_v0_6_1_json_len,
+        .data = &src_vmaf_v0_6_1_json,
+        .data_len = &src_vmaf_v0_6_1_json_len,
     },
     {
         .version = "vmaf_b_v0.6.3",
-        .data = &___src_______model_vmaf_b_v0_6_3_json,
-        .data_len = &___src_______model_vmaf_b_v0_6_3_json_len,
+        .data = &src_vmaf_b_v0_6_3_json,
+        .data_len = &src_vmaf_b_v0_6_3_json_len,
     },
     {
         .version = "vmaf_v0.6.1neg",
-        .data = &___src_______model_vmaf_v0_6_1neg_json,
-        .data_len = &___src_______model_vmaf_v0_6_1neg_json_len,
+        .data = &src_vmaf_v0_6_1neg_json,
+        .data_len = &src_vmaf_v0_6_1neg_json_len,
     },
 #endif
     { 0 }

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -7,7 +7,7 @@ test_inc = include_directories('.')
 test_context = executable('test_context',
     ['test.c', 'test_context.c'],
     include_directories : [libvmaf_inc, test_inc],
-    link_with : libvmaf.get_static_lib(),
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     dependencies:[stdatomic_dependency],
 )
 

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -10,7 +10,7 @@ vmafossexec = executable(
     dependencies: [stdatomic_dependency],
     c_args : vmaf_cflags_common,
     cpp_args : vmaf_cflags_common,
-    link_with : libvmaf.get_static_lib(),
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     install : false,
 )
 
@@ -20,6 +20,6 @@ vmaf = executable(
     include_directories : [libvmaf_inc, vmaf_include],
     dependencies: [stdatomic_dependency],
     c_args : [vmaf_cflags_common, compat_cflags],
-    link_with : libvmaf.get_static_lib(),
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     install : true,
 )


### PR DESCRIPTION
Use `library()` so the `--default-library`  flag will have an effect, fixes #557 and an issue in #613

also fixes #752