### PR TITLE
adm_dwt2_8_avx2: avoid mismatch when width is not mod8

### DIFF
--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -2500,7 +2500,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 #if ARCH_X86
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
-        s->dwt2_8 = adm_dwt2_8_avx2;
+        if (!(w % 8)) s->dwt2_8 = adm_dwt2_8_avx2;
     }
 #endif
 


### PR DESCRIPTION
`adm_dwt2_8_avx2` shows a mismatch for inputs with non mod8 widths. Likely due to the multi-scale subsampling process. For now we will detect such cases and avoid enabling the AVX2 path, in the future we will see about a proper fix.