### PR TITLE
libvmaf: add 4k models to list of built-in models

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -108,6 +108,7 @@ if built_in_models_enabled
             'vmaf_v0.6.1.json',
             'vmaf_b_v0.6.3.json',
             'vmaf_v0.6.1neg.json',
+            'vmaf_4k_v0.6.1.json',
         ]
 
         if float_enabled
@@ -115,6 +116,7 @@ if built_in_models_enabled
               'vmaf_float_v0.6.1neg.json',
               'vmaf_float_v0.6.1.json',
               'vmaf_float_b_v0.6.3.json',
+              'vmaf_float_4k_v0.6.1.json',
             ]
         endif
 

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -54,6 +54,11 @@ static const VmafBuiltInModel built_in_models[] = {
         .data = &src_vmaf_float_b_v0_6_3_json,
         .data_len = &src_vmaf_float_b_v0_6_3_json_len,
     },
+    {
+        .version = "vmaf_float_4k_v0.6.1",
+        .data = &src_vmaf_float_b_v0_6_3_json,
+        .data_len = &src_vmaf_float_b_v0_6_3_json_len,
+    },
 #endif
     {
         .version = "vmaf_v0.6.1",
@@ -67,6 +72,11 @@ static const VmafBuiltInModel built_in_models[] = {
     },
     {
         .version = "vmaf_v0.6.1neg",
+        .data = &src_vmaf_v0_6_1neg_json,
+        .data_len = &src_vmaf_v0_6_1neg_json_len,
+    },
+    {
+        .version = "vmaf_4k_v0.6.1",
         .data = &src_vmaf_v0_6_1neg_json,
         .data_len = &src_vmaf_v0_6_1neg_json_len,
     },

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -27,6 +27,8 @@ extern const char src_vmaf_float_v0_6_1_json;
 extern const int src_vmaf_float_v0_6_1_json_len;
 extern const char src_vmaf_float_b_v0_6_3_json;
 extern const int src_vmaf_float_b_v0_6_3_json_len;
+extern const char src_vmaf_float_4k_v0_6_1_json;
+extern const int src_vmaf_float_4k_v0_6_1_json_len;
 #endif
 extern const char src_vmaf_v0_6_1_json;
 extern const int src_vmaf_v0_6_1_json_len;
@@ -34,6 +36,8 @@ extern const char src_vmaf_b_v0_6_3_json;
 extern const int src_vmaf_b_v0_6_3_json_len;
 extern const char src_vmaf_v0_6_1neg_json;
 extern const int src_vmaf_v0_6_1neg_json_len;
+extern const char src_vmaf_4k_v0_6_1_json;
+extern const int src_vmaf_4k_v0_6_1_json_len;
 #endif
 
 static const VmafBuiltInModel built_in_models[] = {


### PR DESCRIPTION
This PR adds the 4k models to the list of compiled-in models. Addresses #744.