### PR TITLE
Update --aom_ctc v1.0 to clip infinite dB values.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,22 +57,6 @@ jobs:
       - name: Test vmaf
         run: meson test -C libvmaf/build --num-processes $(nproc)
 
-      - name: Clone FFmpeg
-        uses: actions/checkout@v2
-        with:
-          repository: FFmpeg/FFmpeg
-          path: ffmpeg
-
-      - name: Build FFmpeg
-        run: |
-          sed -i 's;Libs.private.*;& -lstdc++;' "$MINGW_PREFIX/lib/pkgconfig/libvmaf.pc"
-          cd ffmpeg
-          ./configure --prefix=$MINGW_PREFIX --pkg-config-flags="--static" --enable-libvmaf --enable-pthreads --disable-w32threads --cc="$CC" --cxx="$CXX" || {
-            less ffbuild/config.log
-            exit 1
-          }
-          make --quiet -j $(nproc) install
-
       - name: Get binary path & Current Release
         id: get_info
         run: |

--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -1,5 +1,5 @@
 project('libvmaf', ['c', 'cpp'],
-    version : '2.1.0',
+    version : '2.1.1',
     default_options : ['c_std=c11',
                        'cpp_std=c++11',
                        'warning_level=2',
@@ -8,7 +8,7 @@ project('libvmaf', ['c', 'cpp'],
                       ],
     meson_version: '>= 0.47.0')
 
-vmaf_soname_version       = '1.1.0'
+vmaf_soname_version       = '1.1.1'
 vmaf_api_version_array    = vmaf_soname_version.split('.')
 vmaf_api_version_major    = vmaf_api_version_array[0]
 vmaf_api_version_minor    = vmaf_api_version_array[1]

--- a/libvmaf/src/feature/float_ms_ssim.c
+++ b/libvmaf/src/feature/float_ms_ssim.c
@@ -33,6 +33,8 @@ typedef struct MsSsimState {
     float *dist;
     bool enable_lcs;
     bool enable_db;
+    bool clip_db;
+    double max_db;
 } MsSsimState;
 
 static const VmafOption options[] = {
@@ -50,16 +52,31 @@ static const VmafOption options[] = {
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
     },
+    {
+        .name = "clip_db",
+        .help = "clip dB scores",
+        .offset = offsetof(MsSsimState, clip_db),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
     { 0 }
 };
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
-    (void) bpc;
     (void) pix_fmt;
 
     MsSsimState *s = fex->priv;
+
+    const unsigned peak = (1 << bpc) - 1;
+    if (s->clip_db) {
+        const double mse = 0.5 / (w * h);
+        s->max_db = ceil(10. * log10(peak * peak / mse));
+    } else {
+        s->max_db = INFINITY;
+    }
+
     s->float_stride = ALIGN_CEIL(w * sizeof(float));
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
@@ -74,9 +91,11 @@ fail:
     return -ENOMEM;
 }
 
-static double convert_to_db(double score)
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+static double convert_to_db(double score, double max_db)
 {
-    return -10. * log10(1 - score);
+    return MIN(-10. * log10(1 - score), max_db);
 }
 
 static int extract(VmafFeatureExtractor *fex,
@@ -100,7 +119,7 @@ static int extract(VmafFeatureExtractor *fex,
     if (err) return err;
 
     if (s->enable_db)
-        score = convert_to_db(score);
+        score = convert_to_db(score, s->max_db);
 
     err = vmaf_feature_collector_append(feature_collector, "float_ms_ssim",
                                         score, index);

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -17,6 +17,7 @@
  */
 
 #include <errno.h>
+#include <float.h>
 #include <math.h>
 #include <stddef.h>
 #include <string.h>
@@ -31,6 +32,8 @@ typedef struct PsnrState {
     bool enable_apsnr;
     bool reduced_hbd_peak;
     uint32_t peak;
+    double psnr_max[3];
+    double min_sse;
     struct {
         uint64_t sse[3];
         uint64_t n_pixels[3];
@@ -66,6 +69,15 @@ static const VmafOption options[] = {
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
     },
+    {
+        .name = "min_sse",
+        .help = "constrain the minimum possible sse",
+        .offset = offsetof(PsnrState, min_sse),
+        .type = VMAF_OPT_TYPE_DOUBLE,
+        .default_val.d = 0.0,
+        .min = 0.0,
+        .max = DBL_MAX,
+    },
     { 0 }
 };
 
@@ -73,13 +85,21 @@ static const VmafOption options[] = {
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
-    (void) pix_fmt;
-    (void) bpc;
-    (void) w;
-    (void) h;
-
     PsnrState *s = fex->priv;
     s->peak = s->reduced_hbd_peak ? 255 * 1 << (bpc - 8) : (1 << bpc) - 1;
+
+    for (unsigned i = 0; i < 3; i++) {
+        if (s->min_sse != 0.0) {
+            const int ss_hor = pix_fmt != VMAF_PIX_FMT_YUV444P;
+            const int ss_ver = pix_fmt == VMAF_PIX_FMT_YUV420P;
+            const double mse = s->min_sse / 
+                (((i && ss_hor) ? w / 2 : w) * ((i && ss_ver) ? h / 2 : h));
+            s->psnr_max[i] = ceil(10. * log10(s->peak * s->peak / mse));
+        } else {
+            s->psnr_max[i] = (6 * bpc) + 12;
+        }
+    }
+
     return 0;
 }
 
@@ -94,7 +114,6 @@ static int psnr(VmafPicture *ref_pic, VmafPicture *dist_pic,
                 PsnrState *s)
 {
     const uint8_t peak = 255; // (1 << ref_pic->bpc) - 1;
-    const double psnr_max = 60.; // (6 * ref_pic->bpc) + 12;
     const unsigned n = s->enable_chroma ? 3 : 1;
 
     int err = 0;
@@ -122,7 +141,7 @@ static int psnr(VmafPicture *ref_pic, VmafPicture *dist_pic,
 
         const double mse = ((double) sse) / (ref_pic->w[p] * ref_pic->h[p]);
         const double psnr =
-            MIN(10. * log10(peak * peak / MAX(mse, 1e-16)), psnr_max);
+            MIN(10. * log10(peak * peak / MAX(mse, 1e-16)), s->psnr_max[p]);
 
         err |= vmaf_feature_collector_append(feature_collector, psnr_name[p],
                                              psnr, index);
@@ -139,7 +158,6 @@ static int psnr_hbd(VmafPicture *ref_pic, VmafPicture *dist_pic,
                     unsigned index, VmafFeatureCollector *feature_collector,
                     PsnrState *s)
 {
-    const double psnr_max = (6 * ref_pic->bpc) + 12;
     const unsigned n = s->enable_chroma ? 3 : 1;
 
     int err = 0;
@@ -165,7 +183,8 @@ static int psnr_hbd(VmafPicture *ref_pic, VmafPicture *dist_pic,
 
         const double mse = ((double) sse) / (ref_pic->w[p] * ref_pic->h[p]);
         const double psnr =
-            MIN(10. * log10(s->peak * s->peak / MAX(mse, 1e-16)), psnr_max);
+            MIN(10. * log10(s->peak * s->peak / MAX(mse, 1e-16)),
+                s->psnr_max[p]);
 
         err |= vmaf_feature_collector_append(feature_collector, psnr_name[p],
                                              psnr, index);
@@ -209,12 +228,20 @@ static int flush(VmafFeatureExtractor *fex,
     int err = 0;
     if (s->enable_apsnr) {
         for (unsigned i = 0; i < 3; i++) {
+
             double apsnr = 10 * (log10(s->peak * s->peak) +
                                  log10(s->apsnr.n_pixels[i]) -
                                  log10(s->apsnr.sse[i]));
+
+            double max_apsnr =
+                ceil(10 * log10(s->peak * s->peak *
+                                s->apsnr.n_pixels[i] *
+                                2));
+
             err |=
                 vmaf_feature_collector_set_aggregate(feature_collector,
-                                                     apsnr_name[i], apsnr);
+                                                     apsnr_name[i],
+                                                     MIN(apsnr, max_apsnr));
         }
     }
 

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -269,16 +269,16 @@ static void aom_ctc_v1_0(CLISettings *settings, const char *const app)
 
     settings->feature_cfg[settings->feature_cnt++] =
         parse_feature_config("psnr=reduced_hbd_peak=true:"
-                             "enable_apsnr=true", app);
+                             "enable_apsnr=true:min_sse=0.5", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
         parse_feature_config("ciede", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
-        parse_feature_config("float_ssim=enable_db=true", app);
+        parse_feature_config("float_ssim=enable_db=true:clip_db=true", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
-        parse_feature_config("float_ms_ssim=enable_db=true", app);
+        parse_feature_config("float_ms_ssim=enable_db=true:clip_db=true", app);
 
     settings->feature_cfg[settings->feature_cnt++] =
         parse_feature_config("psnr_hvs", app);

--- a/resource/doc/aom_ctc.md
+++ b/resource/doc/aom_ctc.md
@@ -35,6 +35,12 @@ There are also a few optional command-line settings you may find useful.
 
 # AOM CTC Version History
 * v1.0: `--aom_ctc v1.0`
+  * 2021-01-13
+  * Fix for lossless comparisons, dB clipping for PSNR/APSNR/SSIM/MS-SSIM according to the AOM CTC.
+  * Release: [libvmaf v2.1.1](https://github.com/Netflix/vmaf/releases/tag/v2.1.1)
+  * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.1.1)
+
+* v1.0: `--aom_ctc v1.0`
   * 2020-12-22
   * Initial CTC release, `--aom_ctc proposed` deprecated.
   * Release: [libvmaf v2.1.0](https://github.com/Netflix/vmaf/releases/tag/v2.1.0)


### PR DESCRIPTION
This PR adds the following feature extractor options:

* `psnr`: `min_sse`
* `float_ssim` : `clip_db`
*  `float_ms_ssim`: `clip_db`

Along with these feature extractor options, `--aom_ctc v1.0` has been updated to clip PSNR/SSIM dB values according to the AOM CTC. Rationale for this is to avoid infinite values in the case of lossless comparisons.

Also in this PR is a commit to avoid building FFmpeg in our Windows Github Actions build. There is something in the CI environment which has changed which is causing this to fail. Rather than debug this now, I'm just turning it off. We have a separate CI job to build FFmpeg on Ubuntu and that is still active and passing.