### PR TITLE
Compilation fix on FreeBSD

### DIFF
--- a/libvmaf/src/cpu_info.c
+++ b/libvmaf/src/cpu_info.c
@@ -10,6 +10,9 @@
 #elif MACOS
 #include <sys/param.h>
 #include <sys/sysctl.h>
+#elif __FreeBSD__
+#include <sys/types.h>
+#include <sys/sysctl.h>
 #else
 #include <unistd.h>
 #endif
@@ -33,6 +36,11 @@ int getNumCores() {
         if(count < 1) { count = 1; }
     }
     return count;
+#elif __FreeBSD__
+    int ncpu;
+    size_t sz = sizeof(int);
+    sysctlbyname("hw.ncpu", &ncpu, &sz, 0,0);
+    return(ncpu);
 #else
     return sysconf(_SC_NPROCESSORS_ONLN);
 #endif

--- a/libvmaf/src/feature/ciede.c
+++ b/libvmaf/src/feature/ciede.c
@@ -42,6 +42,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#ifdef __FreeBSD__
+/* Required to get M_PI from math.h */
+#define __BSD_VISIBLE 1
+#endif
+
 #include <errno.h>
 #include <math.h>
 #include <stddef.h>


### PR DESCRIPTION
Didn't compile on FreeBSD, since _SC_NPROCESSORS_ONLN  is undefined there. Instead, use the hw.ncpu sysctl.