### PR TITLE
libvmaf/compute_vmaf: use default psnr

### DIFF
--- a/libvmaf/src/compute_vmaf.c
+++ b/libvmaf/src/compute_vmaf.c
@@ -182,7 +182,7 @@ int compute_vmaf(double* vmaf_score, char* fmt, int width, int height,
     }
 
     if (do_psnr) {
-        err = vmaf_use_feature(vmaf, "float_psnr", NULL);
+        err = vmaf_use_feature(vmaf, "psnr", NULL);
         if (err) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,
                      "problem loading feature extractor: psnr\n");

--- a/libvmaf/src/compute_vmaf.c
+++ b/libvmaf/src/compute_vmaf.c
@@ -182,7 +182,10 @@ int compute_vmaf(double* vmaf_score, char* fmt, int width, int height,
     }
 
     if (do_psnr) {
-        err = vmaf_use_feature(vmaf, "psnr", NULL);
+        VmafFeatureDictionary *d = NULL;
+        vmaf_feature_dictionary_set(&d, "enable_chroma", "false");
+
+        err = vmaf_use_feature(vmaf, "psnr", d);
         if (err) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,
                      "problem loading feature extractor: psnr\n");

--- a/libvmaf/src/feature/alias.c
+++ b/libvmaf/src/feature/alias.c
@@ -104,6 +104,10 @@ static Alias vmafossexec_alias_map[] = {
         .alias = "psnr",
     },
     {
+        .name = "psnr_y",
+        .alias = "psnr",
+    },
+    {
         .name = "float_ssim",
         .alias = "ssim",
     },


### PR DESCRIPTION
This PR updates the `compute_vmaf()` wrapper to use the default PSNR feature extractor. With the default PSNR being used, the library does not need to build with non-default options to enable PSNR computations via `compute_vmaf()`. Should address #787. Also, while this fix is straight forward and reasonable, a reminder that `compute_vmaf()` is considered a deprecated API.