### PR TITLE
Use exist_ok=True to remove unnecessary if-statements.

### DIFF
--- a/python/vmaf/config.py
+++ b/python/vmaf/config.py
@@ -15,8 +15,7 @@ VMAF_RESOURCE_ROOT = "https://github.com/Netflix/vmaf_resource/raw/master"
 
 def download_reactively(local_path, remote_path):
     if not os.path.exists(local_path):
-        if not os.path.exists(os.path.dirname(local_path)):
-            os.makedirs(os.path.dirname(local_path))
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
         print(f'download {local_path} from {remote_path}')
         try:
             ssl._create_default_https_context = ssl._create_unverified_context
@@ -213,8 +212,7 @@ class DisplayConfig(object):
         if 'write_to_dir' in kwargs:
             format = kwargs['format'] if 'format' in kwargs else 'png'
             filedir = kwargs['write_to_dir'] if kwargs['write_to_dir'] is not None else VmafConfig.workspace_path('output')
-            if not os.path.exists(filedir):
-                os.makedirs(filedir)
+            os.makedirs(filedir, exist_ok=True)
             for fignum in plt.get_fignums():
                 fig = plt.figure(fignum)
                 fig.savefig(os.path.join(filedir, str(fignum) + '.' + format), format=format)

--- a/python/vmaf/core/train_test_model.py
+++ b/python/vmaf/core/train_test_model.py
@@ -1467,8 +1467,7 @@ class BootstrapMixin(object):
             for i_model, model in enumerate(models):
                 filename_ = self._get_model_i_filename(filename, i_model)
                 filedir = os.path.dirname(filename_)
-                if not os.path.exists(filedir):
-                    os.makedirs(filedir)
+                os.makedirs(filedir, exist_ok=True)
                 model_dict_ = model_dict.copy()
                 model_dict_['model'] = model
                 self._to_file(filename_, param_dict, model_dict_, **more)

--- a/python/vmaf/script/convert_vmaf_model_to_vmaf_no_enhn_gain_model.py
+++ b/python/vmaf/script/convert_vmaf_model_to_vmaf_no_enhn_gain_model.py
@@ -21,8 +21,8 @@ def convert_vmaf_model_to_vmaf_no_enhn_gain_model(vmaf_model_path, output_vmaf_n
             {'vif_enhn_gain_limit': 1.0},  # 'VMAF_feature_vif_scale2_score'
             {'vif_enhn_gain_limit': 1.0},  # 'VMAF_feature_vif_scale3_score'
         ]
-    if not os.path.exists(os.path.dirname(output_vmaf_neg_model_path)):
-        os.makedirs(os.path.dirname(output_vmaf_neg_model_path))
+   
+    os.makedirs(os.path.dirname(output_vmaf_neg_model_path), exist_ok=True)
     with open(output_vmaf_neg_model_path, 'wb') as output_file:
         pickle.dump(vmaf_neg_model, output_file,
                     protocol=1

--- a/python/vmaf/tools/decorator.py
+++ b/python/vmaf/tools/decorator.py
@@ -108,8 +108,7 @@ def persist_to_file(file_name):
             if h not in cache:
                 cache[h] = original_func(*args)
                 file_dir = os.path.dirname(file_name)
-                if not os.path.exists(file_dir):
-                    os.makedirs(file_dir)
+                os.makedirs(file_dir, exist_ok=True)
                 json.dump(cache, open(file_name, 'wt'))
             return cache[h]
 
@@ -129,8 +128,7 @@ def persist_to_dir(dir_name):
             h = hashlib.sha1(str(original_func.__name__) + str(args)).hexdigest()
             file_name = os.path.join(dir_name, h)
             if not os.path.exists(file_name):
-                if not os.path.exists(dir_name):
-                    os.makedirs(dir_name)
+                os.makedirs(dir_name, exist_ok=True)
                 res = original_func(*args)
                 json.dump(res, open(file_name, 'wt'))
             else:

--- a/python/vmaf/tools/misc.py
+++ b/python/vmaf/tools/misc.py
@@ -125,9 +125,7 @@ def get_dir_without_last_slash(path):
 
 def make_parent_dirs_if_nonexist(path):
     dst_dir = get_dir_without_last_slash(path)
-    # create dir if not exist yet
-    if not os.path.exists(dst_dir):
-        os.makedirs(dst_dir)
+    os.makedirs(dst_dir, exist_ok=True)
 
 
 def delete_dir_if_exists(dir):


### PR DESCRIPTION
Adding `exist_ok=True` prevents a `FileExistsError` if the specified directory already exists, removing the need for `if not os.path.exists(<directory>):`.