### PR TITLE
include_dirs do not appear to be getting passed properly on OS X 

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,8 @@ def get_version():
         pass
     return "0.0-dev"
 
+ext_module = cythonize(['vmaf/core/adm_dwt2_cy.pyx'])
+ext_module[0].include_dirs = [numpy.get_include(), '../libvmaf/src']
 
 setup(
     name="vmaf",
@@ -66,6 +68,5 @@ setup(
             'run_vmafossexec_subsampling=vmaf.script.run_vmafossexec_subsampling:main',
         ],
     },
-    ext_modules=cythonize(['vmaf/core/adm_dwt2_cy.pyx']),
-    include_dirs=[numpy.get_include(), '../libvmaf/src']
+    ext_modules=ext_module,
 )


### PR DESCRIPTION
I'm unable to build latest VMAF on OS X, using Python 3.9.0 from homebrew (although the same problem repro'd with 3.7.5), and another coworker had the exact same problem on another machine.

The error is `unable to find "numpy/arrayobject.h"` in Cython, even though numpy is correctly installed, and `numpy.get_include()` returns the correct path (where I verified the headers exist).

For some reason `include_dirs` in setup.py is not being passed down. After thinking I'm losing my mind I did some searching and I see that other projects are experiencing the same problem, see for example https://github.com/hmmlearn/hmmlearn/issues/43 and the various other issues linking to it.

So I used the same workaround, instead manually setting the include dirs on the ext_module, and that seems to work just fine. No idea why `include_dirs` is not being respected properly though. It feels somewhat dirty but this is the only way I was able to get unblocked with building on OS X.