### PR TITLE
Corrected default model_path location.

### DIFF
--- a/resource/doc/ffmpeg.md
+++ b/resource/doc/ffmpeg.md
@@ -14,7 +14,7 @@ We provide a few examples how you can construct the FFmpeg command line and use 
 
 Below is an example on how you can run FFmpeg+libvmaf on a pair of YUV files. First, download the reference video [`src01_hrc00_576x324.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/src01_hrc00_576x324.yuv) and the distorted video [`src01_hrc01_576x324.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/src01_hrc01_576x324.yuv). `-r 24` sets the frame rate (note that it needs to be before `-i`), and `PTS-STARTPTS` synchronizes the PTS (presentation timestamp) of the two videos (this is crucial if one of your videos does not start at PTS 0, for example, if you cut your video out of a long video stream). It is important to set the frame rate and the PTS right, since FFmpeg filters synchronize based on timestamps instead of frames.
 
-The `log_path` is set to standard output `/dev/stdout`. It uses the `model_path` at location `/usr/local/share/model/vmaf_float_v0.6.1.json` (which is the default and can be omitted).
+The `log_path` is set to standard output `/dev/stdout`. It uses the `model_path` at location `/usr/local/share/model/vmaf_v0.6.1.pkl` (which is the default and can be omitted).
 
 ```shell script
 ffmpeg -video_size 576x324 -r 24 -pixel_format yuv420p -i src01_hrc00_576x324.yuv \


### PR DESCRIPTION
When using libvmaf with FFmpeg, if you do not use the `model_path` option, you get the error:
 `problem loading model file: /usr/local/share/model/vmaf_v0.6.1.pkl`

 Therefore, the default location of `model_path` is `/usr/local/share/model/vmaf_v0.6.1.pkl`, not `/usr/local/share/model/vmaf_float_v0.6.1.json`.

I confirmed this by going to FFmpeg's GitHub repository and looking the code for the libvmaf filter: https://github.com/FFmpeg/FFmpeg/blob/069d2b4a50a6eb2f925f36884e6b9bd9a1e54670/libavfilter/vf_libvmaf.c#L75