### PR TITLE
fix formatting in ListStats doctests, fix warning in Python 3.8+

### DIFF
--- a/python/vmaf/core/executor.py
+++ b/python/vmaf/core/executor.py
@@ -498,7 +498,7 @@ class Executor(TypeVersionEnabled):
 
         filter_cmds = []
         for key in Asset.ORDERED_FILTER_LIST:
-            if key is not 'crop' and key is not 'pad':
+            if key != 'crop' and key != 'pad':
                 filter_cmds.append(self._get_filter_cmd(asset, key, 'ref'))
 
         vf_cmd = ','.join(filter(lambda s: s!='', [select_cmd, crop_cmd, pad_cmd, scale_cmd] + filter_cmds))
@@ -551,7 +551,7 @@ class Executor(TypeVersionEnabled):
 
         filter_cmds = []
         for key in Asset.ORDERED_FILTER_LIST:
-            if key is not 'crop' and key is not 'pad':
+            if key != 'crop' and key != 'pad':
                 filter_cmds.append(self._get_filter_cmd(asset, key, 'dis'))
 
         vf_cmd = ','.join(filter(lambda s: s!='', [select_cmd, crop_cmd, pad_cmd, scale_cmd] + filter_cmds))

--- a/python/vmaf/tools/stats.py
+++ b/python/vmaf/tools/stats.py
@@ -7,52 +7,34 @@ import numpy as np
 class ListStats(object):
     """
     >>> test_list = [1, 2, 3, 4, 5, 11, 12, 13, 14, 15]
-    >>> ListStats.total_variation(test_list)
-    1.5555555555555556
+    >>> "%0.4f" % ListStats.total_variation(test_list)
+    '1.5556'
     >>> np.mean(test_list)
     8.0
     >>> np.median(test_list)
     8.0
     >>> ListStats.lp_norm(test_list, 1.0)
     8.0
-    >>> ListStats.lp_norm(test_list, 3.0)
-    10.507175744985801
-    >>> ListStats.perc5(test_list)
-    1.4500000000000002
-    >>> ListStats.perc20(test_list)
-    2.8000000000000003
+    >>> "%0.4f" % ListStats.lp_norm(test_list, 3.0)
+    '10.5072'
+    >>> "%0.2f" % ListStats.perc1(test_list)
+    '1.09'
+    >>> "%0.2f" % ListStats.perc5(test_list)
+    '1.45'
+    >>> "%0.2f" % ListStats.perc10(test_list)
+    '1.90'
+    >>> "%0.2f" % ListStats.perc20(test_list)
+    '2.80'
     >>> ListStats.nonemean([None, None, 1, 2])
     1.5
     >>> ListStats.nonemean([3, 4, 1, 2])
     2.5
     >>> ListStats.nonemean([None, None, None])
     nan
-    """
-
-    """
-    The following tests don't render numbers with same precision in py2 vs py3:
-    >> ListStats.print_stats(test_list)
-    Min: 1, Max: 15, Median: 8.0, Mean: 8.0, Variance: 27.0, Total_variation: 1.55555555556
-    >> ListStats.print_moving_average_stats(test_list, 3)
-    Min: 2.67984333217, Max: 13.6798433322, Median: 4.64565264023, Mean: 6.61976499826, Variance: 18.625918874, Total_variation: 1.22222222222
-    
-    The following tests need review
-    >> ListStats.moving_average(test_list, 2)
-    array([  2.26894142,   2.26894142,   2.26894142,   3.26894142,
-             4.26894142,   6.61364853,  11.26894142,  12.26894142,
-            13.26894142,  14.26894142])
-    >> ListStats.moving_average(test_list, 5)
-    array([  4.08330969,   4.08330969,   4.08330969,   4.08330969,
-             4.08330969,   4.08330969,   5.81552983,   7.7557191 ,
-             9.96294602,  12.51305607])
-    >> ListStats.harmonic_mean(test_list)
-    4.5222635212015483
-    >> ListStats.lp_norm(test_list, 2.0)
-    9.5393920141694561
-    >> ListStats.perc1(test_list)
-    1.0900000000000001
-    >> ListStats.perc10(test_list)
-    1.8999999999999999
+    >>> "%0.4f" % ListStats.harmonic_mean(test_list)
+    '4.5223'
+    >>> "%0.4f" % ListStats.lp_norm(test_list, 2.0)
+    '9.5394'
     """
 
     @staticmethod


### PR DESCRIPTION
`is not` with a literal now throws SyntaxWarning in Python 3.8 or newer. This replaces those usages with `!=`. Also the float formatting in the doctests of `ListStats` can result in failures due to slight differences. This replaces their usage with float formatting so we can specify the necessary precision.

Also the doc tests were split into 2, with the bottom part not actually running. I salvaged some of those tests by moving them to the doctest block above and removed the ones that I believe were intended to be disabled. 