### PR TITLE
bugfix for multithread

### DIFF
--- a/third_party/libsvm/matlab/libsvmread.c
+++ b/third_party/libsvm/matlab/libsvmread.c
@@ -62,6 +62,7 @@ void read_problem(const char *filename, mxArray *plhs[])
 	char *endptr;
 	mwIndex *ir, *jc;
 	double *labels, *samples;
+    char *saveptr1, *saveptr2;
 	
 	if(fp == NULL)
 	{
@@ -83,11 +84,11 @@ void read_problem(const char *filename, mxArray *plhs[])
 		int index = 0;
 
 		inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
-		strtok(line," \t"); // label
+		strtok_r(line," \t", &saveptr1); // label
 		while (1)
 		{
-			idx = strtok(NULL,":"); // index:value
-			val = strtok(NULL," \t");
+			idx = strtok_r(NULL,":", &saveptr1); // index:value
+			val = strtok_r(NULL," \t", &saveptr1);
 			if(val == NULL)
 				break;
 
@@ -131,7 +132,7 @@ void read_problem(const char *filename, mxArray *plhs[])
 
 		readline(fp);
 
-		label = strtok(line," \t\n");
+		label = strtok_r(line," \t\n", &saveptr2);
 		if(label == NULL)
 		{
 			mexPrintf("Empty line at line %d\n",i+1);
@@ -149,8 +150,8 @@ void read_problem(const char *filename, mxArray *plhs[])
 		// features
 		while(1)
 		{
-			idx = strtok(NULL,":");
-			val = strtok(NULL," \t");
+			idx = strtok_r(NULL,":", &saveptr2);
+			val = strtok_r(NULL," \t", &saveptr2);
 			if(val == NULL)
 				break;
 

--- a/third_party/libsvm/matlab/libsvmread.c
+++ b/third_party/libsvm/matlab/libsvmread.c
@@ -62,7 +62,7 @@ void read_problem(const char *filename, mxArray *plhs[])
 	char *endptr;
 	mwIndex *ir, *jc;
 	double *labels, *samples;
-       char *saveptr1, *saveptr2;
+      char *saveptr1, *saveptr2;
 	
 	if(fp == NULL)
 	{

--- a/third_party/libsvm/matlab/libsvmread.c
+++ b/third_party/libsvm/matlab/libsvmread.c
@@ -62,7 +62,7 @@ void read_problem(const char *filename, mxArray *plhs[])
 	char *endptr;
 	mwIndex *ir, *jc;
 	double *labels, *samples;
-    char *saveptr1, *saveptr2;
+       char *saveptr1, *saveptr2;
 	
 	if(fp == NULL)
 	{

--- a/third_party/libsvm/matlab/svmpredict.c
+++ b/third_party/libsvm/matlab/svmpredict.c
@@ -263,6 +263,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
 	int prob_estimate_flag = 0;
 	struct svm_model *model;
 	info = &mexPrintf;
+    char *saveptr;
 
 	if(nrhs > 4 || nrhs < 3)
 	{
@@ -289,8 +290,8 @@ void mexFunction( int nlhs, mxArray *plhs[],
 
 			// put options in argv[]
 			mxGetString(prhs[3], cmd,  mxGetN(prhs[3]) + 1);
-			if((argv[argc] = strtok(cmd, " ")) != NULL)
-				while((argv[++argc] = strtok(NULL, " ")) != NULL)
+			if((argv[argc] = strtok_r(cmd, " ", &saveptr)) != NULL)
+				while((argv[++argc] = strtok_r(NULL, " ", &saveptr)) != NULL)
 					;
 
 			for(i=1;i<argc;i++)

--- a/third_party/libsvm/matlab/svmpredict.c
+++ b/third_party/libsvm/matlab/svmpredict.c
@@ -263,7 +263,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
 	int prob_estimate_flag = 0;
 	struct svm_model *model;
 	info = &mexPrintf;
-       char *saveptr;
+      char *saveptr;
 
 	if(nrhs > 4 || nrhs < 3)
 	{

--- a/third_party/libsvm/matlab/svmpredict.c
+++ b/third_party/libsvm/matlab/svmpredict.c
@@ -263,7 +263,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
 	int prob_estimate_flag = 0;
 	struct svm_model *model;
 	info = &mexPrintf;
-    char *saveptr;
+       char *saveptr;
 
 	if(nrhs > 4 || nrhs < 3)
 	{

--- a/third_party/libsvm/matlab/svmtrain.c
+++ b/third_party/libsvm/matlab/svmtrain.c
@@ -110,6 +110,7 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 	int i, argc = 1;
 	char cmd[CMD_LEN];
 	char *argv[CMD_LEN/2];
+    char *saveptr;
 	void (*print_func)(const char *) = print_string_matlab;	// default printing to matlab display
 
 	// default values
@@ -137,8 +138,8 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 	{
 		// put options in argv[]
 		mxGetString(prhs[2], cmd, mxGetN(prhs[2]) + 1);
-		if((argv[argc] = strtok(cmd, " ")) != NULL)
-			while((argv[++argc] = strtok(NULL, " ")) != NULL)
+		if((argv[argc] = strtok_r(cmd, " ", &saveptr)) != NULL)
+			while((argv[++argc] = strtok_r(NULL, " ", &saveptr)) != NULL)
 				;
 	}
 

--- a/third_party/libsvm/matlab/svmtrain.c
+++ b/third_party/libsvm/matlab/svmtrain.c
@@ -110,7 +110,7 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 	int i, argc = 1;
 	char cmd[CMD_LEN];
 	char *argv[CMD_LEN/2];
-    char *saveptr;
+       char *saveptr;
 	void (*print_func)(const char *) = print_string_matlab;	// default printing to matlab display
 
 	// default values

--- a/third_party/libsvm/matlab/svmtrain.c
+++ b/third_party/libsvm/matlab/svmtrain.c
@@ -110,7 +110,7 @@ int parse_command_line(int nrhs, const mxArray *prhs[], char *model_file_name)
 	int i, argc = 1;
 	char cmd[CMD_LEN];
 	char *argv[CMD_LEN/2];
-       char *saveptr;
+      char *saveptr;
 	void (*print_func)(const char *) = print_string_matlab;	// default printing to matlab display
 
 	// default values

--- a/third_party/libsvm/svm-predict.c
+++ b/third_party/libsvm/svm-predict.c
@@ -53,6 +53,7 @@ void predict(FILE *input, FILE *output)
 	int nr_class=svm_get_nr_class(model);
 	double *prob_estimates=NULL;
 	int j;
+    char *saveptr;
 
 	if(predict_probability)
 	{
@@ -80,7 +81,7 @@ void predict(FILE *input, FILE *output)
 		char *idx, *val, *label, *endptr;
 		int inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
 
-		label = strtok(line," \t\n");
+		label = strtok_r(line," \t\n", &saveptr);
 		if(label == NULL) // empty line
 			exit_input_error(total+1);
 
@@ -96,8 +97,8 @@ void predict(FILE *input, FILE *output)
 				x = (struct svm_node *) realloc(x,max_nr_attr*sizeof(struct svm_node));
 			}
 
-			idx = strtok(NULL,":");
-			val = strtok(NULL," \t");
+			idx = strtok_r(NULL,":", &saveptr);
+			val = strtok_r(NULL," \t", &saveptr);
 
 			if(val == NULL)
 				break;

--- a/third_party/libsvm/svm-predict.c
+++ b/third_party/libsvm/svm-predict.c
@@ -53,7 +53,7 @@ void predict(FILE *input, FILE *output)
 	int nr_class=svm_get_nr_class(model);
 	double *prob_estimates=NULL;
 	int j;
-    char *saveptr;
+       char *saveptr;
 
 	if(predict_probability)
 	{

--- a/third_party/libsvm/svm-predict.c
+++ b/third_party/libsvm/svm-predict.c
@@ -53,7 +53,7 @@ void predict(FILE *input, FILE *output)
 	int nr_class=svm_get_nr_class(model);
 	double *prob_estimates=NULL;
 	int j;
-       char *saveptr;
+      char *saveptr;
 
 	if(predict_probability)
 	{

--- a/third_party/libsvm/svm-train.c
+++ b/third_party/libsvm/svm-train.c
@@ -281,7 +281,7 @@ void read_problem(const char *filename)
 	FILE *fp = fopen(filename,"r");
 	char *endptr;
 	char *idx, *val, *label;
-       char *saveptr1, *saveptr2;
+      char *saveptr1, *saveptr2;
 
 	if(fp == NULL)
 	{

--- a/third_party/libsvm/svm-train.c
+++ b/third_party/libsvm/svm-train.c
@@ -281,7 +281,7 @@ void read_problem(const char *filename)
 	FILE *fp = fopen(filename,"r");
 	char *endptr;
 	char *idx, *val, *label;
-    char *saveptr1, *saveptr2;
+       char *saveptr1, *saveptr2;
 
 	if(fp == NULL)
 	{

--- a/third_party/libsvm/svm-train.c
+++ b/third_party/libsvm/svm-train.c
@@ -281,6 +281,7 @@ void read_problem(const char *filename)
 	FILE *fp = fopen(filename,"r");
 	char *endptr;
 	char *idx, *val, *label;
+    char *saveptr1, *saveptr2;
 
 	if(fp == NULL)
 	{
@@ -295,12 +296,12 @@ void read_problem(const char *filename)
 	line = Malloc(char,max_line_len);
 	while(readline(fp)!=NULL)
 	{
-		char *p = strtok(line," \t"); // label
+		char *p = strtok_r(line," \t", &saveptr1); // label
 
 		// features
 		while(1)
 		{
-			p = strtok(NULL," \t");
+			p = strtok_r(NULL," \t", &saveptr1);
 			if(p == NULL || *p == '\n') // check '\n' as ' ' may be after the last feature
 				break;
 			++elements;
@@ -321,7 +322,7 @@ void read_problem(const char *filename)
 		inst_max_index = -1; // strtol gives 0 if wrong format, and precomputed kernel has <index> start from 0
 		readline(fp);
 		prob.x[i] = &x_space[j];
-		label = strtok(line," \t\n");
+		label = strtok_r(line," \t\n", &saveptr2);
 		if(label == NULL) // empty line
 			exit_input_error(i+1);
 
@@ -331,8 +332,8 @@ void read_problem(const char *filename)
 
 		while(1)
 		{
-			idx = strtok(NULL,":");
-			val = strtok(NULL," \t");
+			idx = strtok_r(NULL,":", &saveptr2);
+			val = strtok_r(NULL," \t", &saveptr2);
 
 			if(val == NULL)
 				break;

--- a/third_party/libsvm/svm.cpp
+++ b/third_party/libsvm/svm.cpp
@@ -2880,7 +2880,7 @@ svm_model *svm_load_model(const char *model_file_name)
 	max_line_len = 1024;
 	line = Malloc(char,max_line_len);
 	char *p,*endptr,*idx,*val;
-    char *saveptr1, *saveptr2;
+       char *saveptr1, *saveptr2;
 
 	while(readline(fp)!=NULL)
 	{

--- a/third_party/libsvm/svm.cpp
+++ b/third_party/libsvm/svm.cpp
@@ -2880,13 +2880,14 @@ svm_model *svm_load_model(const char *model_file_name)
 	max_line_len = 1024;
 	line = Malloc(char,max_line_len);
 	char *p,*endptr,*idx,*val;
+    char *saveptr1, *saveptr2;
 
 	while(readline(fp)!=NULL)
 	{
-		p = strtok(line,":");
+		p = strtok_r(line,":", &saveptr1);
 		while(1)
 		{
-			p = strtok(NULL,":");
+			p = strtok_r(NULL,":", &saveptr1);
 			if(p == NULL)
 				break;
 			++elements;
@@ -2912,18 +2913,18 @@ svm_model *svm_load_model(const char *model_file_name)
 		readline(fp);
 		model->SV[i] = &x_space[j];
 
-		p = strtok(line, " \t");
+		p = strtok_r(line, " \t", &saveptr2);
 		model->sv_coef[0][i] = strtod(p,&endptr);
 		for(int k=1;k<m;k++)
 		{
-			p = strtok(NULL, " \t");
+			p = strtok_r(NULL, " \t", &saveptr2);
 			model->sv_coef[k][i] = strtod(p,&endptr);
 		}
 
 		while(1)
 		{
-			idx = strtok(NULL, ":");
-			val = strtok(NULL, " \t");
+			idx = strtok_r(NULL, ":", &saveptr2);
+			val = strtok_r(NULL, " \t", &saveptr2);
 
 			if(val == NULL)
 				break;

--- a/third_party/libsvm/svm.cpp
+++ b/third_party/libsvm/svm.cpp
@@ -2880,7 +2880,7 @@ svm_model *svm_load_model(const char *model_file_name)
 	max_line_len = 1024;
 	line = Malloc(char,max_line_len);
 	char *p,*endptr,*idx,*val;
-       char *saveptr1, *saveptr2;
+      char *saveptr1, *saveptr2;
 
 	while(readline(fp)!=NULL)
 	{


### PR DESCRIPTION
The strtok() function's thread safety is MT-Unsafe race:strtok as mentioned in the https://man7.org/linux/man-pages/man3/strtok.3.html

when i call the vmaf function in multithreads, it maybe crash randomly. and the issue is strtok() function, replace the strtok() to strtok_r(), it will be ok.

> The strtok() function uses a static buffer while parsing, so it's not thread safe.  Use strtok_r() if this matters to you.



