### PR TITLE
add vmaf feature param which uses motion2 instead of motion

### DIFF
--- a/resource/feature_param/vmaf_feature_v6.py
+++ b/resource/feature_param/vmaf_feature_v6.py
@@ -1,0 +1,5 @@
+feature_dict = {
+
+    'VMAF_feature': ['vif_scale0', 'vif_scale1', 'vif_scale2', 'vif_scale3', 'adm2', 'motion2', ],
+
+}


### PR DESCRIPTION
The default (0.6.1) model uses `motion2` instead of motion, and yet the latest feature param file for vmaf is v3 which uses `motion`.  This adds a `vmaf_feature_v6.py` model which uses the same features as the baseline model to make it easier to start with the correct baseline for subsequent model explorations.