### PR TITLE
Fix the bug: DisplayConfig.show() cannot generate the result picture …

### DIFF
--- a/python/vmaf/config.py
+++ b/python/vmaf/config.py
@@ -209,12 +209,22 @@ class DisplayConfig(object):
     @staticmethod
     def show(**kwargs):
         from vmaf import plt
-        if 'write_to_dir' in kwargs:
-            format = kwargs['format'] if 'format' in kwargs else 'png'
-            filedir = kwargs['write_to_dir'] if kwargs['write_to_dir'] is not None else VmafConfig.workspace_path('output')
-            os.makedirs(filedir, exist_ok=True)
-            for fignum in plt.get_fignums():
-                fig = plt.figure(fignum)
-                fig.savefig(os.path.join(filedir, str(fignum) + '.' + format), format=format)
+        import matplotlib
+
+        if matplotlib.rcParams['backend'] == 'agg':
+            if 'write_to_dir' in kwargs:
+                format = kwargs['format'] if 'format' in kwargs else 'png'
+                filedir = kwargs['write_to_dir'] if kwargs['write_to_dir'] is not None else VmafConfig.workspace_path('output')
+                os.makedirs(filedir, exist_ok=True)
+                for fignum in plt.get_fignums():
+                    fig = plt.figure(fignum)
+                    fig.savefig(os.path.join(filedir, str(fignum) + '.' + format), format=format)
+            else:
+                format = 'png'
+                filedir = VmafConfig.workspace_path('output')
+                os.makedirs(filedir, exist_ok=True)
+                for fignum in plt.get_fignums():
+                    fig = plt.figure(fignum)
+                    fig.savefig(os.path.join(filedir, str(fignum) + '.' + format), format=format)
         else:
             plt.show()


### PR DESCRIPTION
Fix the bug: DisplayConfig.show() cannot generate the result picture when the parameter write_to_dir is missing.

In `python/vmaf/script/run_vmaf_training.py`, the script set the Matplotlib default backends to `non-interactive backends`: Agg.

```
#!/usr/bin/env python3

import matplotlib
matplotlib.use('Agg')
```

But, for `DisplayConfig.show()`, the script will use the interactive backends when the parameter `write_to_dir` is missing. 