### PR TITLE
Revert "Add support for yuv400p VmafPicture type (#861)"

### DIFF
--- a/libvmaf/include/libvmaf/picture.h
+++ b/libvmaf/include/libvmaf/picture.h
@@ -26,7 +26,6 @@ enum VmafPixelFormat {
     VMAF_PIX_FMT_YUV420P,
     VMAF_PIX_FMT_YUV422P,
     VMAF_PIX_FMT_YUV444P,
-    VMAF_PIX_FMT_YUV400P,
 };
 
 typedef struct VmafRef VmafRef;

--- a/libvmaf/src/picture.c
+++ b/libvmaf/src/picture.c
@@ -43,9 +43,6 @@ int vmaf_picture_alloc(VmafPicture *pic, enum VmafPixelFormat pix_fmt,
     pic->w[1] = pic->w[2] = w >> ss_hor;
     pic->h[0] = h;
     pic->h[1] = pic->h[2] = h >> ss_ver;
-    if (pic->pix_fmt == VMAF_PIX_FMT_YUV400P)
-        pic->w[1] = pic->w[2] = pic->h[1] = pic->h[2] = 0;
-
     const int aligned_y = (pic->w[0] + DATA_ALIGN - 1) & ~(DATA_ALIGN - 1);
     const int aligned_c = (pic->w[1] + DATA_ALIGN - 1) & ~(DATA_ALIGN - 1);
     const int hbd = pic->bpc > 8;
@@ -61,8 +58,6 @@ int vmaf_picture_alloc(VmafPicture *pic, enum VmafPixelFormat pix_fmt,
     pic->data[0] = data;
     pic->data[1] = data + y_sz;
     pic->data[2] = data + y_sz + uv_sz;
-    if (pic->pix_fmt == VMAF_PIX_FMT_YUV400P)
-        pic->data[1] = pic->data[2] = NULL;
 
     int err = vmaf_ref_init(&pic->ref);
     if (err) goto free_data;


### PR DESCRIPTION
There are no guards to protect against passing a monochrome picture to any of the chroma supporting feature extractors. Reverting bbeddc02e5f171a10ff8cfdfb6d23e290f169366 until there is a fix for #863.