### PR TITLE
libvmaf: add vmaf_feature_dictionary_free()

### DIFF
--- a/libvmaf/include/libvmaf/feature.h
+++ b/libvmaf/include/libvmaf/feature.h
@@ -24,4 +24,6 @@ typedef struct VmafFeatureDictionary VmafFeatureDictionary;
 int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
                                 const char *val);
 
+int vmaf_feature_dictionary_free(VmafFeatureDictionary **dict);
+
 #endif /* __VMAF_FEATURE_H__ */

--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -110,7 +110,9 @@ int vmaf_use_features_from_model_collection(VmafContext *vmaf,
  * Register specific feature extractor.
  * Useful when a specific/additional feature is required, usually one which
  * is not already provided by a model via `vmaf_use_features_from_model()`.
- * This may be called multiple times.
+ * This may be called multiple times. `VmafContext` will take ownership of the
+ * `VmafFeatureDictionary` (`opts_dict`). Use `vmaf_feature_dictionary_free()`
+ * only in the case of failure.
  *
  * @param vmaf         The VMAF context allocated with `vmaf_init()`.
  *

--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -187,3 +187,8 @@ int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
     return vmaf_dictionary_set((VmafDictionary**)dict, key, val,
                                VMAF_DICT_NORMALIZE_NUMERICAL_VALUES);
 }
+
+int vmaf_feature_dictionary_free(VmafFeatureDictionary **dict)
+{
+    return vmaf_dictionary_free((VmafDictionary**)dict);
+}

--- a/libvmaf/test/test_dict.c
+++ b/libvmaf/test/test_dict.c
@@ -292,11 +292,28 @@ static char *test_vmaf_dictionary_normalize_numerical_val()
     return NULL;
 }
 
+
+static char *test_vmaf_feature_dictionary()
+{
+    int err = 0;
+
+    VmafFeatureDictionary *dict = NULL;
+    err = vmaf_feature_dictionary_set(&dict, "option", "value");
+    mu_assert("problem during vmaf_feature_dictionary_set", !err);
+    mu_assert("dictionary should not be NULL after setting first option", dict);
+    err = vmaf_feature_dictionary_free(&dict);
+    mu_assert("problem during vmaf_feature_dictionary_free", !err);
+    mu_assert("dictionary should be NULL after free", !dict);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_vmaf_dictionary);
     mu_run_test(test_vmaf_dictionary_merge);
     mu_run_test(test_vmaf_dictionary_compare);
     mu_run_test(test_vmaf_dictionary_normalize_numerical_val);
+    mu_run_test(test_vmaf_feature_dictionary);
     return NULL;
 }


### PR DESCRIPTION
A `VmafFeatureDictionary` may need to be free'd using the public api in case of failed calls to `vmaf_feature_dictionary_set()`.

Addresses #873. 