### PR TITLE
Fix a race condition in vmaf_thread_pool_wait.

### DIFF
--- a/libvmaf/src/thread_pool.c
+++ b/libvmaf/src/thread_pool.c
@@ -156,7 +156,8 @@ int vmaf_thread_pool_wait(VmafThreadPool *pool)
     if (!pool) return -EINVAL;
 
     pthread_mutex_lock(&(pool->queue.lock));
-    while((!pool->stop && pool->n_working) || (pool->stop && pool->n_threads))
+    while((!pool->stop && (pool->n_working || pool->queue.head)) ||
+          (pool->stop && pool->n_threads))
         pthread_cond_wait(&(pool->working), &(pool->queue.lock));
     pthread_mutex_unlock(&(pool->queue.lock));
     return 0;


### PR DESCRIPTION
Fixes #893. 

There may still be work in the queue but n_working=0 before the vmaf_thread_pool_runner loop fetches another job in the queue.  When calling vmaf_thread_pool_wait (and not stopping), we will still want to drain the queue. So only exit the wait loop when n_working = 0 && head == nullptr

