### PR TITLE
Add extern C for C++ Usage

### DIFF
--- a/libvmaf/include/libvmaf/feature.h
+++ b/libvmaf/include/libvmaf/feature.h
@@ -19,11 +19,19 @@
 #ifndef __VMAF_FEATURE_H__
 #define __VMAF_FEATURE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct VmafFeatureDictionary VmafFeatureDictionary;
 
 int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
                                 const char *val);
 
 int vmaf_feature_dictionary_free(VmafFeatureDictionary **dict);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __VMAF_FEATURE_H__ */

--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -27,6 +27,10 @@
 #include "libvmaf/picture.h"
 #include "libvmaf/feature.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum VmafLogLevel {
     VMAF_LOG_LEVEL_NONE = 0,
     VMAF_LOG_LEVEL_ERROR,
@@ -322,5 +326,9 @@ int vmaf_write_output(VmafContext *vmaf, const char *output_path,
  * Get libvmaf version.
  */
 const char *vmaf_version(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __VMAF_H__ */

--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -23,6 +23,10 @@
 
 #include "feature.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct VmafModel VmafModel;
 
 enum VmafModelFlags {
@@ -82,5 +86,9 @@ int vmaf_model_collection_feature_overload(VmafModel *model,
                                            VmafFeatureDictionary *opts_dict);
 
 void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __VMAF_MODEL_H__ */

--- a/libvmaf/include/libvmaf/picture.h
+++ b/libvmaf/include/libvmaf/picture.h
@@ -21,6 +21,10 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum VmafPixelFormat {
     VMAF_PIX_FMT_UNKNOWN,
     VMAF_PIX_FMT_YUV420P,
@@ -43,5 +47,9 @@ int vmaf_picture_alloc(VmafPicture *pic, enum VmafPixelFormat pix_fmt,
                        unsigned bpc, unsigned w, unsigned h);
 
 int vmaf_picture_unref(VmafPicture *pic);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __VMAF_PICTURE_H__ */


### PR DESCRIPTION
I was trying to use libvmaf in my c++ project, and ran into the same issue as this: https://github.com/Netflix/vmaf/issues/858.

By adding extern "C" to the following header files, I was able to resolve my issue and compile with g++.