### PR TITLE
build: add top include dir to .pc file

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -332,5 +332,5 @@ pkg_mod.generate(libraries: libvmaf,
     name: 'libvmaf',
     filebase: 'libvmaf',
     description: 'VMAF, Video Multimethod Assessment Fusion',
-    subdirs: 'libvmaf'
+    subdirs: [ '.', 'libvmaf']
 )


### PR DESCRIPTION
Fixes: #903

This patch fixes headers lookup included w/ libvmaf subfolder prefix:
  #include <libvmaf/libvmaf.h>
Basically, libvmaf.h includes headers in this way as well.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>