### PR TITLE
y4m_input: do not resample chroma for 420mpeg2 input

### DIFF
--- a/libvmaf/tools/y4m_input.c
+++ b/libvmaf/tools/y4m_input.c
@@ -593,7 +593,8 @@ static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
   }
   _y4m->depth=8;
   if(strcmp(_y4m->chroma_type,"420")==0||
-   strcmp(_y4m->chroma_type,"420jpeg")==0){
+   strcmp(_y4m->chroma_type,"420jpeg")==0||
+   strcmp(_y4m->chroma_type,"420mpeg2")==0){
     _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=2;
     _y4m->dst_buf_read_sz=_y4m->pic_w*_y4m->pic_h
      +2*((_y4m->pic_w+1)/2)*((_y4m->pic_h+1)/2);
@@ -617,14 +618,6 @@ static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
     /*Natively supported: no conversion required.*/
     _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
     _y4m->convert=y4m_convert_null;
-  }
-  else if(strcmp(_y4m->chroma_type,"420mpeg2")==0){
-    _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=2;
-    _y4m->dst_buf_read_sz=_y4m->pic_w*_y4m->pic_h;
-    /*Chroma filter required: read into the aux buf first.*/
-    _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=
-     2*((_y4m->pic_w+1)/2)*((_y4m->pic_h+1)/2);
-    _y4m->convert=y4m_convert_42xmpeg2_42xjpeg;
   }
   else if(strcmp(_y4m->chroma_type,"420paldv")==0){
     _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=2;


### PR DESCRIPTION
The daala y4m reader is patched to align with AOM handling of 420mpeg2:
https://aomedia.googlesource.com/aom/+/2656f676d3fcdef83d1155cd91b1bfb7f657b486