### PR TITLE
Add FPS field to JSON output

### DIFF
--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -563,7 +563,7 @@ int vmaf_write_output(VmafContext *vmaf, const char *output_path,
         break;
     case VMAF_OUTPUT_FORMAT_JSON:
         ret = vmaf_write_output_json(vmaf, vmaf->feature_collector, outfile,
-                                     vmaf->cfg.n_subsample);
+                                     vmaf->cfg.n_subsample, fps);
         break;
     case VMAF_OUTPUT_FORMAT_CSV:
         ret = vmaf_write_output_csv(vmaf->feature_collector, outfile,

--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -120,10 +120,11 @@ int vmaf_write_output_xml(VmafContext *vmaf, VmafFeatureCollector *fc,
 }
 
 int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
-                           FILE *outfile, unsigned subsample)
+                           FILE *outfile, unsigned subsample, double fps)
 {
     fprintf(outfile, "{\n");
     fprintf(outfile, "  \"version\": \"%s\",\n", vmaf_version());
+    fprintf(outfile, "  \"fps\": %.2f,\n", fps);
 
     unsigned n_frames = 0;
     fprintf(outfile, "  \"frames\": [");
@@ -228,6 +229,7 @@ int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
     }
     fprintf(outfile, "\n  }\n");
     fprintf(outfile, "}\n");
+    
     return 0;
 }
 

--- a/libvmaf/src/output.h
+++ b/libvmaf/src/output.h
@@ -24,7 +24,7 @@ int vmaf_write_output_xml(VmafContext *vmaf, VmafFeatureCollector *fc, FILE *out
                           double fps);
 
 int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
-                           FILE *outfile, unsigned subsample);
+                           FILE *outfile, unsigned subsample, double fps);
 
 int vmaf_write_output_csv(VmafFeatureCollector *fc, FILE *outfile,
                            unsigned subsample);


### PR DESCRIPTION
The XML output contains a field with the FPS:
```
  <fyi fps="11.12" />
```

This PR adds this field to the JSON output, which didn't have it previously.

```
{
  "version": "21ecc2a7",
  "fps": 11.36,
  "frames": [
    {
       ...
    }
  ]
}
```

Command to reproduce:
```
vmaf --pixel_format 420 --bitdepth 8 -d yuvs/HoC1__av1-yuv420p-ffmpeg__960_540__qp32_vmaf86.64_psnr41.49_kbps706.25_fps25_r.yuv -r yuvs/HoC1__av1-yuv420p-ffmpeg__960_540__qp32_vmaf86.64_psnr41.49_kbps706.25_fps25_r.yuv --width 960 --height 540 --output out.json --json --feature cambi
```

To test it, I tried parsing the output with the `json` module in Python, and it parsed correctly.
