### PR TITLE
Add test cases to CAMBI filter_mode unit test

### DIFF
--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -226,6 +226,17 @@ static char *test_filter_mode()
     mu_assert("filter_mode: two ones (3,3) check", output_data[3 * output_stride + 3]==1);
     mu_assert("filter_mode: two ones (2,3) check", output_data[2 * output_stride + 3]==1);
 
+    data[0 * stride + 0] = 2;
+    data[0 * stride + 1] = 1;
+    filter_mode(&image, &filtered_image, w, h);
+    mu_assert("filter_mode: two in the corner check", output_data[0 * output_stride + 0]==2);
+    data[1 * stride + 0] = 1;
+    filter_mode(&image, &filtered_image, w, h);
+    mu_assert("filter_mode: two in the corner and adjacent ones check", output_data[0 * output_stride + 0]==1);
+    data[2 * stride + 0] = 2;
+    filter_mode(&image, &filtered_image, w, h);
+    mu_assert("filter_mode: two in corner and edge check", output_data[1 * output_stride + 0]==2);
+
     return NULL;
 }
 


### PR DESCRIPTION
The function that we're testing is a 3x3 mode filter with mirroring for the edges and which should take the smaller element in case of a tie in frequency.

The unit test for this function was only checking for elements in the middle of the matrix, but elements on the edge and corners can be problematic due to the mirroring. 

The previous test case was this one:

| 0 | 0 | 0 | 0 | 0 |
|---|---|---|---|---|
| 0 | 0 | 0 | 0 | 0 |
| 0 | 0 | 1 | 1 | 0 |
| 0 | 0 | 1 | 1 | 1 |
| 0 | 0 | 0 | 0 | 0 |

Added the following test cases:

------------

Input:

| 2 | 1 | 0 | 0 | 0 |
|---|---|---|---|---|
| 0 | 0 | 0 | 0 | 0 |
| 0 | 0 | 1 | 1 | 0 |
| 0 | 0 | 1 | 1 | 1 |
| 0 | 0 | 0 | 0 | 0 |

Expected output:

| 2 | 0 | 0 | 0 | 0 |
|---|---|---|---|---|
| 0 | 0 | 0 | 0 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 0 | 0 |

This should have a 2 in the top-left corner because the 2 gets mirrored into 4 squares, so there are 4 twos, 2 ones and 3 zeroes.

------------

Input:

| 2 | 1 | 0 | 0 | 0 |
|---|---|---|---|---|
| 1 | 0 | 0 | 0 | 0 |
| 0 | 0 | 1 | 1 | 0 |
| 0 | 0 | 1 | 1 | 1 |
| 0 | 0 | 0 | 0 | 0 |

Expected output:

| 1 | 0 | 0 | 0 | 0 |
|---|---|---|---|---|
| 0 | 0 | 0 | 0 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 0 | 0 |

This should have a 1 in the top-left corner because now there are 4 twos and 4 ones, and we choose the smaller one in case of a tie.

------------

Input:

| 2 | 1 | 0 | 0 | 0 |
|---|---|---|---|---|
| 1 | 0 | 0 | 0 | 0 |
| 2 | 0 | 1 | 1 | 0 |
| 0 | 0 | 1 | 1 | 1 |
| 0 | 0 | 0 | 0 | 0 |

Expected output:

| 1 | 0 | 0 | 0 | 0 |
|---|---|---|---|---|
| 2 | 0 | 0 | 0 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 1 | 0 |
| 0 | 0 | 0 | 0 | 0 |

This should have a 2 in the (1, 0) position because it has 4 neighbours that are twos, and only 3 that are ones.

------------

