### PR TITLE
libvmaf: fail with monochrome VmafPicture in color aware feature extractors

### DIFF
--- a/libvmaf/src/feature/ciede.c
+++ b/libvmaf/src/feature/ciede.c
@@ -100,6 +100,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     CiedeState *s = fex->priv;
     int err = 0;
 
+    if (pix_fmt == VMAF_PIX_FMT_YUV400P)
+        return -EINVAL;
+
     if (pix_fmt == VMAF_PIX_FMT_YUV444P)
         return 0;
 

--- a/libvmaf/src/feature/integer_psnr.c
+++ b/libvmaf/src/feature/integer_psnr.c
@@ -88,6 +88,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     PsnrState *s = fex->priv;
     s->peak = s->reduced_hbd_peak ? 255 * 1 << (bpc - 8) : (1 << bpc) - 1;
 
+    if (pix_fmt == VMAF_PIX_FMT_YUV400P)
+        s->enable_chroma = false;
+
     for (unsigned i = 0; i < 3; i++) {
         if (s->min_sse != 0.0) {
             const int ss_hor = pix_fmt != VMAF_PIX_FMT_YUV444P;

--- a/libvmaf/src/feature/third_party/xiph/psnr_hvs.c
+++ b/libvmaf/src/feature/third_party/xiph/psnr_hvs.c
@@ -341,6 +341,20 @@ static double convert_score_db(double _score, double _weight)
     return 10 * (-1 * log10(_weight * _score));
 }
 
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
+{
+    (void) fex;
+    (void) bpc;
+    (void) w;
+    (void) h;
+
+    if (pix_fmt == VMAF_PIX_FMT_YUV400P)
+        return -EINVAL;
+    else
+        return 0;
+}
+
 static int extract(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
                    VmafPicture *ref_pic_90, VmafPicture *dist_pic,
                    VmafPicture *dist_pic_90, unsigned index,
@@ -379,6 +393,7 @@ static const char *provided_features[] = {
 
 VmafFeatureExtractor vmaf_fex_psnr_hvs = {
     .name = "psnr_hvs",
+    .init = init,
     .extract = extract,
     .provided_features = provided_features,
 };


### PR DESCRIPTION
The new `VmafPicture` type `VMAF_PIX_FMT_YUV400P` is a public type which affects feature extractors which could previously safely assume chroma planes in all pictures. This commit will check and fail for monochrome pictures in `psnr_hvs` and `cidede`. It will force `enable_chroma = false` for the `psnr` feature extractor. The check is only needed once in the `.init()` callback since a consistent picture type check is already taking place. This should address #863.