### PR TITLE
Optimize CAMBI code in libvmaf

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -443,18 +443,18 @@ static void filter_mode(const VmafPicture *image, int width, int height) {
                     curr[3 * row + col] = data[clamped_row * stride + clamped_col];
                 }
             }
-            buffer[(i%3) * width + j] = mode_selection(curr, hist);
+            buffer[(i % 3) * width + j] = mode_selection(curr, hist);
         }
         if (i >= 2) {
             uint16_t *dest = data + (i - 2) * stride;
-            uint16_t *src = buffer + ((i + 1)%3) * width;
+            uint16_t *src = buffer + ((i + 1) % 3) * width;
             memcpy(dest, src, width * sizeof(uint16_t));
         }
     }
     // Copy last two rows
     for (int i = height - 2; i < height; i++) {
         uint16_t *dest = data + i * stride;
-        uint16_t *src = buffer + (i%3) * width;
+        uint16_t *src = buffer + (i % 3) * width;
         memcpy(dest, src, width * sizeof(uint16_t));
     }
 

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -53,7 +53,7 @@ static const int g_all_diffs[NUM_ALL_DIFFS] = {-4, -3, -2, -1, 0, 1, 2, 3, 4};
 static const uint16_t g_c_value_histogram_offset = 4; // = -g_all_diffs[0]
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
-
+#define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 
 #define PICS_BUFFER_SIZE 4
 
@@ -398,56 +398,54 @@ static void decimate(VmafPicture *image, unsigned width, unsigned height)
             data[i * stride + j] = data[(i<<1) * stride + (j<<1)];
 }
 
-static FORCE_INLINE inline uint16_t mode_selection(const VmafPicture *image, unsigned *block_rows,
-                                                   unsigned *block_cols, const unsigned block_size)
+static FORCE_INLINE inline uint16_t mode_selection(uint16_t *elems, uint8_t *hist)
 {
-    uint16_t *data = image->data[0];
-    ptrdiff_t stride = image->stride[0]>>1;
-
     unsigned max_counts = 0;
     uint16_t max_mode = 1024;
-    for (unsigned col=0; col<block_size; col++) {
-        for (unsigned row=0; row<block_size; row++) {
-            uint16_t value = data[block_rows[row] * stride + block_cols[col]];
-            unsigned counts = 0;
-            if (value == max_mode)
-                continue;
-
-            for (unsigned c=0; c<block_size; c++)
-                for (unsigned r=0; r<block_size; r++)
-                    counts += (data[block_rows[r] * stride + block_cols[c]]==value);
-
-            if (counts > max_counts || (counts == max_counts && value < max_mode)) {
-                max_counts = counts;
-                max_mode = value;
-            }
+    // Set the 9 entries to 0
+    for (int i = 0; i < 9; i++) {
+        hist[elems[i]] = 0;
+    }
+    // Increment the 9 entries and find the mode
+    for (int i = 0; i < 9; i++) {
+        uint16_t value = elems[i];
+        hist[value]++;
+        uint8_t count = hist[value];
+        if (count >= 5) {
+            return value;
+        }
+        if (count > max_counts || (count == max_counts && value < max_mode)) {
+            max_counts = count;
+            max_mode = value;
         }
     }
-
     return max_mode;
 }
 
 static void filter_mode(const VmafPicture *image, VmafPicture *filtered_image,
-                        unsigned width, unsigned height)
+                        int width, int height)
 {
-    const unsigned block_size = 3;
-    unsigned block_rows[block_size], block_cols[block_size];
-
+    uint8_t *hist = malloc(1024 * sizeof(uint8_t));
+    uint16_t *data = image->data[0];
+    ptrdiff_t stride = image->stride[0]>>1;    
     uint16_t *filtered_data = filtered_image->data[0];
-    ptrdiff_t stride = filtered_image->stride[0]>>1;
-
-    for (unsigned i=0; i<height; i++) {
-        block_rows[0] = (i==0) ? 0 : i-1;
-        block_rows[1] = i;
-        block_rows[2] = (i==height-1) ? i : i+1;
-        for (unsigned j=0; j<width; j++) {
-            block_cols[0] = (j==0) ? j : j-1;
-            block_cols[1] = j;
-            block_cols[2] = (j==width-1) ? j : j+1;
-            filtered_data[i * stride + j] =
-                mode_selection(image, block_rows, block_cols, block_size);
+    ptrdiff_t out_stride = filtered_image->stride[0]>>1;
+    uint16_t curr[9];
+    for (int i=0; i<height; i++) {
+        for (int j=0; j<width; j++) {
+            // Get the 9 elements into an array for cache coherence
+            for (int row = 0; row < 3; row++) {
+                for (int col = 0; col < 3; col++) {
+                    int clamped_row = CLAMP(i + row - 1, 0, height - 1);
+                    int clamped_col = CLAMP(j + col - 1, 0, width - 1);
+                    curr[3 * row + col] = data[clamped_row * stride + clamped_col];
+                }
+            }
+            filtered_data[i * out_stride + j] = mode_selection(curr, hist);
         }
     }
+
+    free(hist);
 }
 
 static FORCE_INLINE inline uint16_t get_mask_index(unsigned input_width, unsigned input_height,

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -466,24 +466,23 @@ static void get_zero_derivative(const VmafPicture *pic, VmafPicture *zero_deriva
     uint16_t *data = pic->data[0];
     uint16_t *output_data = zero_derivative->data[0];
     ptrdiff_t stride = pic->stride[0]>>1;
-    uint16_t hor_derivative, ver_derivative;
 
     for (unsigned i=0; i<height-1; i++) {
         for (unsigned j=0; j<width-1; j++) {
-            hor_derivative = data[i * stride + j] - data[i * stride + j+1];
-            ver_derivative = data[i * stride + j] - data[(i+1) * stride + j];
-            output_data[i * stride + j] = (hor_derivative==0 && ver_derivative==0);
+            output_data[i * stride + j] = 
+                (data[i * stride + j] == data[i * stride + j+1] 
+                && data[i * stride + j] == data[(i+1) * stride + j]);
         }
         // Last column
         unsigned j = width-1;
-        ver_derivative = data[i * stride + j] - data[(i+1) * stride + j];
-        output_data[i * stride + j] = (ver_derivative==0);
+        output_data[i * stride + j] = 
+            (data[i * stride + j] == data[(i+1) * stride + j]);
     }
     // Last row
     unsigned i = height-1;
     for (unsigned j=0; j<width-1; j++) {
-        hor_derivative = data[i * stride + j] - data[i * stride + j+1];
-        output_data[i * stride + j] = (hor_derivative==0);
+        output_data[i * stride + j] = 
+            (data[i * stride + j] == data[i * stride + j+1]);
     }
     output_data[(height-1) * stride + (width-1)] = 1;
 }

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -303,22 +303,25 @@ static char *test_calculate_c_values()
     unsigned width = 4, height = 4;
     uint16_t tvi_for_diff[4] = {178, 305, 432, 559};
     uint16_t window_size = 3;
+    uint16_t histograms[4*1032];
 
     get_sample_image(&input, 0);
     get_sample_image(&mask, 8);
-    calculate_c_values(&input, &mask, combined_c_values,
+    calculate_c_values(&input, &mask, combined_c_values, histograms,
                        window_size, tvi_for_diff, width, height);
 
-    for (unsigned i=0; i<16; i++)
+    for (unsigned i=0; i<16; i++) {
         mu_assert("calculate_c_values error ws=3",
             almost_equal(combined_c_values[i], expected_values[i]));
+    }
 
     VmafPicture input_8x8, mask_8x8;
     float combined_c_values_8x8[64];
     get_sample_image_8x8(&input_8x8, 0);
     get_sample_image_8x8(&mask_8x8, 1);
     window_size = 9;
-    calculate_c_values(&input_8x8, &mask_8x8, combined_c_values_8x8,
+    uint16_t histograms_8x8[8*1032];
+    calculate_c_values(&input_8x8, &mask_8x8, combined_c_values_8x8, histograms_8x8,
                        window_size, tvi_for_diff, 8, 8);
 
     double sum = 0;
@@ -352,19 +355,17 @@ static char *test_c_value_pixel()
     uint16_t num_diffs = 2;
     float c_value;
 
-    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds);
+    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds, 0, 1);
     mu_assert("c_value_all_diffs for value=2, weights=2,3", almost_equal(c_value, 2.6666667));
-
 
     diff_weights[0] = 4;
     diff_weights[1] = 5;
-    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds);
+    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds, 0, 1);
     mu_assert("c_value_all_diffs for value=2, weights=4,5", almost_equal(c_value, 6.6666667));
 
     value = 4;
-    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds);
+    c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds, 0, 1);
     mu_assert("c_value_all_diffs for value=4, weights=4,5", almost_equal(c_value, 0));
-
     return NULL;
 }
 

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -133,20 +133,6 @@ static char *test_anti_dithering_filter()
     return NULL;
 }
 
-static char *test_copy_10b_luma()
-{
-    VmafPicture pic, copy_pic, expected;
-    get_sample_image(&pic, 0);
-    get_sample_image(&copy_pic, 0);
-    get_sample_image(&expected, 0);
-
-    copy_10b_luma(&pic, &copy_pic);
-    bool equal = pic_data_equality(&copy_pic, &expected);
-    mu_assert("convert_to_10b: wrong 10b luma copy", equal);
-
-    return NULL;
-}
-
 /* Banding detection functions */
 static char *test_decimate()
 {
@@ -317,19 +303,6 @@ static char *test_calculate_c_values()
     for (unsigned i=0; i<64; i++)
         sum += combined_c_values_8x8[i];
     mu_assert("combined_c_values 8x8 error", almost_equal(sum, 195.382527));
-
-    return NULL;
-}
-
-static char *test_pic_add_offset()
-{
-    VmafPicture image, expected;
-    get_sample_image(&image, 6);
-    get_sample_image(&expected, 7);
-
-    uint16_t const offset = 5;
-    pic_add_offset(&image, offset, 3, 2);
-    mu_assert("pic_add_offset output pic wrong", pic_data_equality(&expected, &image));
 
     return NULL;
 }
@@ -576,7 +549,6 @@ char *run_tests()
 {
     /* Preprocessing functions */
     mu_run_test(test_anti_dithering_filter);
-    mu_run_test(test_copy_10b_luma);
     mu_run_test(test_decimate_generic);
 
     /* Banding detection functions */
@@ -587,7 +559,6 @@ char *run_tests()
     mu_run_test(test_get_spatial_mask_for_index);
 
     mu_run_test(test_calculate_c_values);
-    mu_run_test(test_pic_add_offset);
     mu_run_test(test_c_value_pixel);
 
     mu_run_test(test_spatial_pooling);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -240,20 +240,6 @@ static char *test_filter_mode()
     return NULL;
 }
 
-static char *test_get_zero_derivative()
-{
-    VmafPicture pic, expected, zero_derivative;
-    get_sample_image(&pic, 3);
-    get_sample_image(&zero_derivative, 3);
-    get_sample_image(&expected, 4);
-
-    get_zero_derivative(&pic, &zero_derivative, 4, 4);
-    bool equal = pic_data_equality(&expected, &zero_derivative);
-    mu_assert("zero derivative output pic wrong", equal);
-
-    return NULL;
-}
-
 static char *test_get_mask_index()
 {
     uint16_t index = get_mask_index(1980, 1080, 7);
@@ -270,26 +256,29 @@ static char *test_get_spatial_mask_for_index()
     VmafPicture image, mask;
     uint16_t filter_size = 3;
     unsigned width = 4, height = 4;
+    // dp_width = width + 2 * (filter_size >> 2) + 1
+    // dp_height = 2 * (filter_size >> 2) + 2
+    uint32_t mask_dp[7*4];
 
     get_sample_image(&image, 3);
     get_sample_image(&mask, 3);
 
-    get_spatial_mask_for_index(&image, &mask, 2, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=2, image=3", data_pic_sum(&mask)==0);
-    get_spatial_mask_for_index(&image, &mask, 1, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=1, image=3", data_pic_sum(&mask)==2);
-    get_spatial_mask_for_index(&image, &mask, 0, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=0, image=3", data_pic_sum(&mask)==11);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 2, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=2, image=3", data_pic_sum(&mask)==14);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 1, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=1, image=3", data_pic_sum(&mask)==16);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 0, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=0, image=3", data_pic_sum(&mask)==16);
 
     get_sample_image(&image, 4);
     get_sample_image(&image, 4);
 
-    get_spatial_mask_for_index(&image, &mask, 5, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=5, image=4", data_pic_sum(&mask)==2);
-    get_spatial_mask_for_index(&image, &mask, 4, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=4, image=4", data_pic_sum(&mask)==7);
-    get_spatial_mask_for_index(&image, &mask, 3, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=3, image=4", data_pic_sum(&mask)==9);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 3, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=3, image=4", data_pic_sum(&mask)==0);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 2, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=2, image=4", data_pic_sum(&mask)==6);
+    get_spatial_mask_for_index(&image, &mask, mask_dp, 1, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=1, image=4", data_pic_sum(&mask)==9);
 
     return NULL;
 }
@@ -593,8 +582,7 @@ char *run_tests()
     /* Banding detection functions */
     mu_run_test(test_decimate);
     mu_run_test(test_filter_mode);
-    mu_run_test(test_get_zero_derivative);
-
+    
     mu_run_test(test_get_mask_index);
     mu_run_test(test_get_spatial_mask_for_index);
 

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -198,30 +198,35 @@ static char *test_filter_mode()
 
     uint16_t *data = image.data[0];
     ptrdiff_t stride = image.stride[0]>>1;
-    uint16_t *output_data = filtered_image.data[0];
+    uint16_t *filtered_data = filtered_image.data[0];
     ptrdiff_t output_stride = filtered_image.stride[0]>>1;
 
     data[2 * stride + 2] = 1; data[3 * stride + 2] = 1;
     data[2 * stride + 3] = 1; data[3 * stride + 3] = 1;
-    filter_mode(&image, &filtered_image, w, h);
+    memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
+    filter_mode(&filtered_image, w, h);
     mu_assert("filter_mode: all zeros", data_pic_sum(&filtered_image)==0);
 
     data[3 * stride + 4] = 1;
-    filter_mode(&image, &filtered_image, w, h);
+    memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
+    filter_mode(&filtered_image, w, h);
     mu_assert("filter_mode: two ones sum check", data_pic_sum(&filtered_image)==2);
-    mu_assert("filter_mode: two ones (3,3) check", output_data[3 * output_stride + 3]==1);
-    mu_assert("filter_mode: two ones (2,3) check", output_data[2 * output_stride + 3]==1);
+    mu_assert("filter_mode: two ones (3,3) check", filtered_data[3 * output_stride + 3]==1);
+    mu_assert("filter_mode: two ones (2,3) check", filtered_data[2 * output_stride + 3]==1);
 
     data[0 * stride + 0] = 2;
     data[0 * stride + 1] = 1;
-    filter_mode(&image, &filtered_image, w, h);
-    mu_assert("filter_mode: two in the corner check", output_data[0 * output_stride + 0]==2);
+    memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
+    filter_mode(&filtered_image, w, h);
+    mu_assert("filter_mode: two in the corner check", filtered_data[0 * output_stride + 0]==2);
     data[1 * stride + 0] = 1;
-    filter_mode(&image, &filtered_image, w, h);
-    mu_assert("filter_mode: two in the corner and adjacent ones check", output_data[0 * output_stride + 0]==1);
+    memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
+    filter_mode(&filtered_image, w, h);
+    mu_assert("filter_mode: two in the corner and adjacent ones check", filtered_data[0 * output_stride + 0]==1);
     data[2 * stride + 0] = 2;
-    filter_mode(&image, &filtered_image, w, h);
-    mu_assert("filter_mode: two in corner and edge check", output_data[1 * output_stride + 0]==2);
+    memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
+    filter_mode(&filtered_image, w, h);
+    mu_assert("filter_mode: two in corner and edge check", filtered_data[1 * output_stride + 0]==2);
 
     return NULL;
 }

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -275,11 +275,21 @@ static char *test_get_spatial_mask_for_index()
     get_sample_image(&mask, 3);
 
     get_spatial_mask_for_index(&image, &mask, 2, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=2", data_pic_sum(&mask)==0);
+    mu_assert("spatial_mask_for_index wrong mask for index=2, image=3", data_pic_sum(&mask)==0);
     get_spatial_mask_for_index(&image, &mask, 1, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=1", data_pic_sum(&mask)==2);
+    mu_assert("spatial_mask_for_index wrong mask for index=1, image=3", data_pic_sum(&mask)==2);
     get_spatial_mask_for_index(&image, &mask, 0, filter_size, width, height);
-    mu_assert("spatial_mask_for_index wrong mask for index=0", data_pic_sum(&mask)==11);
+    mu_assert("spatial_mask_for_index wrong mask for index=0, image=3", data_pic_sum(&mask)==11);
+
+    get_sample_image(&image, 4);
+    get_sample_image(&image, 4);
+
+    get_spatial_mask_for_index(&image, &mask, 5, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=5, image=4", data_pic_sum(&mask)==2);
+    get_spatial_mask_for_index(&image, &mask, 4, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=4, image=4", data_pic_sum(&mask)==7);
+    get_spatial_mask_for_index(&image, &mask, 3, filter_size, width, height);
+    mu_assert("spatial_mask_for_index wrong mask for index=3, image=4", data_pic_sum(&mask)==9);
 
     return NULL;
 }

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -174,6 +174,14 @@ static char *test_decimate_generic()
     mu_assert("decimate generic 10b wrong pixel value (1,0)", data[stride]==2);
     mu_assert("decimate generic 10b wrong pixel value (1,1)", data[1+stride]==100);
 
+    VmafPicture out_pic_4x4;
+    err = vmaf_picture_alloc(&out_pic_4x4, VMAF_PIX_FMT_YUV400P, 10, 4, 4);
+    (void)err;
+
+    decimate_generic_10b(&pic, &out_pic_4x4);
+
+    mu_assert("decimate generic 10b wrong for same dimensions", pic_data_equality(&pic, &out_pic_4x4));
+
     VmafPicture pic_8b;
     get_sample_image_8b(&pic_8b);
 


### PR DESCRIPTION
* Optimize `filter_mode` using a histogram to avoid quadratic time on each box
* Optimize `calculate_c_values` for better memory access patterns
* Optimize `get_spatial_mask_for_index` using DP square sums algorithm
* Eliminate need for `zero_derivative` image buffer by computing in-place
* Eliminate need for `filtered_image` buffer by filtering in-place
* Format `cambi.c` file for consistent style and spacing
* Add unit test cases on some functions
* Results:
  * Speedup ranging between x1.6 (on low resolutions) and x4.5 (on 4k resolution)
  * Memory usage down from 150MB to 125MB in 4k resolution
  * CAMBI score remains unchanged (compared to `master`)