### PR TITLE
libvmaf: add vmaf_feature_collector_append_formatted

### DIFF
--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -18,6 +18,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -282,6 +283,26 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
 unlock:
     feature_collector->timer.end = clock();
     pthread_mutex_unlock(&(feature_collector->lock));
+    return err;
+}
+
+int vmaf_feature_collector_append_formatted(VmafFeatureCollector *feature_collector,
+                                            double score, unsigned index,
+                                            const char *fmt, ...)
+{
+    if (!feature_collector) return -EINVAL;
+    if (!fmt) return -EINVAL;
+
+    int err = 0;
+
+    va_list(args);
+    va_start(args, fmt);
+    char *feature_name = NULL;
+    vasprintf(&feature_name, fmt, args);
+    if (err || !feature_name) return -ENOMEM;
+    err = vmaf_feature_collector_append(feature_collector, feature_name,
+                                        score, index);
+    free(feature_name);
     return err;
 }
 

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -54,6 +54,10 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
                                   const char *feature_name, double score,
                                   unsigned index);
 
+int vmaf_feature_collector_append_formatted(VmafFeatureCollector *feature_collector,
+                                            double score, unsigned index,
+                                            const char *fmt, ...);
+
 int vmaf_feature_collector_append_templated(VmafFeatureCollector *feature_collector,
                                             const char *feature_name,
                                             const char *key, double val,

--- a/libvmaf/test/test_feature_collector.c
+++ b/libvmaf/test/test_feature_collector.c
@@ -156,10 +156,35 @@ static char *test_feature_collector_init_append_get_and_destroy()
     return NULL;
 }
 
+static char *test_feature_collector_append_formatted()
+{
+    int err = 0;
+
+    VmafFeatureCollector *feature_collector;
+    err = vmaf_feature_collector_init(&feature_collector);
+    mu_assert("problem during vmaf_feature_collector_init", !err);
+
+    err = vmaf_feature_collector_append_formatted(feature_collector, 60., 1,
+                                                  "feature_%s_%s_%.2f_%d",
+                                                  "a", "b", 123.456, 88);
+    mu_assert("problem during vmaf_feature_collector_append_formatted", !err);
+
+    double score;
+    err = vmaf_feature_collector_get_score(feature_collector,
+                                           "feature_a_b_123.46_88", &score, 1);
+    mu_assert("problem during vmaf_feature_collector_get_score", !err);
+    mu_assert("vmaf_feature_collector_get_score did not get the expected score",
+              score == 60.);
+
+    vmaf_feature_collector_destroy(feature_collector);
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_feature_vector_init_append_and_destroy);
     mu_run_test(test_feature_collector_init_append_get_and_destroy);
     mu_run_test(test_aggregate_vector_init_append_and_destroy);
+    mu_run_test(test_feature_collector_append_formatted);
     return NULL;
 }


### PR DESCRIPTION
This PR adds a function for writing formatted feature names. See test for example usage.