### PR TITLE
Add max_contrast parameter

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -36,6 +36,9 @@
 /* Visibilty threshold for luminance ΔL < tvi_threshold*L_mean for BT.1886 */
 #define DEFAULT_CAMBI_TVI (0.019)
 
+/* Max log contrast luma levels */
+#define DEFAULT_MAX_LOG_CONTRAST (2)
+
 #define CAMBI_MIN_WIDTH (320)
 #define CAMBI_MAX_WIDTH (4096)
 #define CAMBI_4K_WIDTH (3840)
@@ -44,13 +47,13 @@
 #define NUM_SCALES 5
 static const int g_scale_weights[NUM_SCALES] = {16, 8, 4, 2, 1};
 
-#define NUM_DIFFS 4
-static const int g_diffs_to_consider[NUM_DIFFS] = {1, 2, 3, 4};
-static const int g_diffs_weights[NUM_DIFFS] = {1, 2, 3, 4};
+/* Suprathreshold contrast response */
+static const int g_contrast_weights[32] = {1, 2, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8,
+                                           8, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9};
 
-#define NUM_ALL_DIFFS (2 * NUM_DIFFS + 1)
-static const int g_all_diffs[NUM_ALL_DIFFS] = {-4, -3, -2, -1, 0, 1, 2, 3, 4};
-static const uint16_t g_c_value_histogram_offset = 4; // = -g_all_diffs[0]
+static uint16_t *g_diffs_to_consider;
+static int *g_diffs_weights;
+static int *g_all_diffs;
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
@@ -75,10 +78,11 @@ typedef struct CambiState {
     VmafPicture pics[PICS_BUFFER_SIZE];
     unsigned enc_width;
     unsigned enc_height;
-    uint16_t tvi_for_diff[NUM_DIFFS];
+    uint16_t *tvi_for_diff;
     uint16_t window_size;
     double topk;
     double tvi_threshold;
+    uint16_t max_log_contrast;
     float *c_values;
     uint16_t *c_values_histograms;
     uint32_t *mask_dp;
@@ -131,6 +135,16 @@ static const VmafOption options[] = {
         .default_val.d = DEFAULT_CAMBI_TVI,
         .min = 0.0001,
         .max = 1.0,
+    },
+    {
+        .name = "max_log_contrast",
+        .help = "Max contrast luma level at 10-bits, set to  2^max_log_contrast \
+                 \t 0 to 5: Default 2 is recommended for banding from compression",
+        .offset = offsetof(CambiState, max_log_contrast),
+        .type = VMAF_OPT_TYPE_INT,
+        .default_val.i = DEFAULT_MAX_LOG_CONTRAST,
+        .min = 0,
+        .max = 5,
     },
     { 0 }
 };
@@ -242,6 +256,22 @@ static FORCE_INLINE inline void adjust_window_size(uint16_t *window_size, unsign
     (*window_size) = ((*window_size) * input_width) / CAMBI_4K_WIDTH;
 }
 
+void  set_contrast_arrays(const uint16_t num_diffs, uint16_t **diffs_to_consider,
+                          int **diffs_weights, int **all_diffs)
+{
+    *diffs_to_consider = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
+    *diffs_weights = aligned_malloc(ALIGN_CEIL(sizeof(int)) * num_diffs, 32);
+    *all_diffs = aligned_malloc(ALIGN_CEIL(sizeof(int)) * (2*num_diffs+1), 32);
+
+    for (int d=0; d<num_diffs; d++) {
+        (*diffs_to_consider)[d] = d+1;
+        (*diffs_weights)[d] = g_contrast_weights[d];
+    }
+
+    for (int d=-num_diffs; d<=num_diffs; d++)
+        (*all_diffs)[d+num_diffs] = d;
+}
+
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h) {
     (void)pix_fmt;
@@ -263,17 +293,22 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     for (unsigned i = 0; i < PICS_BUFFER_SIZE; i++)
         err |= vmaf_picture_alloc(&s->pics[i], VMAF_PIX_FMT_YUV400P, 10, w, h);
 
-    for (int d = 0; d < NUM_DIFFS; d++) {
+    const int num_diffs = 1<<s->max_log_contrast;
+
+    set_contrast_arrays(num_diffs, &g_diffs_to_consider, &g_diffs_weights, &g_all_diffs);
+    s->tvi_for_diff = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
+
+    for (int d=0; d<num_diffs; d++) {
         // BT1886 parameters
         s->tvi_for_diff[d] = get_tvi_for_diff(g_diffs_to_consider[d], s->tvi_threshold, 10,
                                               300.0, 0.01, "standard");
-        s->tvi_for_diff[d] += g_c_value_histogram_offset;
+        s->tvi_for_diff[d] += num_diffs;
     }
 
     adjust_window_size(&s->window_size, w);
     s->c_values = aligned_malloc(ALIGN_CEIL(w * sizeof(float)) * h, 32);
 
-    const uint16_t num_bins = 1024 + (g_all_diffs[NUM_ALL_DIFFS - 1] - g_all_diffs[0]);
+    const uint16_t num_bins = 1024 + (g_all_diffs[2*num_diffs] - g_all_diffs[0]);
     s->c_values_histograms = aligned_malloc(ALIGN_CEIL(w * num_bins * sizeof(uint16_t)), 32);
 
     int pad_size = MASK_FILTER_SIZE >> 1;
@@ -573,10 +608,11 @@ static float c_value_pixel(const uint16_t *histograms, uint16_t value, const int
 }
 
 static FORCE_INLINE inline void update_histogram_subtract(uint16_t *histograms, uint16_t *image, uint16_t *mask,
-                                                          int i, int j, int width, ptrdiff_t stride, uint16_t pad_size) {
+                                                          int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                          const uint16_t num_diffs) {
     uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
     if (mask_val) {
-        uint16_t val = image[(i - pad_size - 1) * stride + j] + g_c_value_histogram_offset;
+        uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
         for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
             histograms[val * width + col]--;
         }
@@ -584,10 +620,11 @@ static FORCE_INLINE inline void update_histogram_subtract(uint16_t *histograms, 
 }
 
 static FORCE_INLINE inline void update_histogram_add(uint16_t *histograms, uint16_t *image, uint16_t *mask,
-                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size) {
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
     uint16_t mask_val = mask[(i + pad_size) * stride + j];
     if (mask_val) {
-        uint16_t val = image[(i + pad_size) * stride + j] + g_c_value_histogram_offset;
+        uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
         for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
             histograms[val * width + col]++;
         }
@@ -596,11 +633,11 @@ static FORCE_INLINE inline void update_histogram_add(uint16_t *histograms, uint1
 
 static FORCE_INLINE inline void calculate_c_values_row(float *c_values, uint16_t *histograms, uint16_t *image,
                                                        uint16_t *mask, int row, int width, ptrdiff_t stride,
-                                                       const uint16_t *tvi_for_diff) {
+                                                       const uint16_t num_diffs, const uint16_t *tvi_for_diff) {
     for (int col = 0; col < width; col++) {
         if (mask[row * stride + col]) {
             c_values[row * width + col] = c_value_pixel(
-                histograms, image[row * stride + col] + g_c_value_histogram_offset, g_diffs_weights, g_all_diffs, NUM_DIFFS, tvi_for_diff, col, width
+                histograms, image[row * stride + col] + num_diffs, g_diffs_weights, g_all_diffs, num_diffs, tvi_for_diff, col, width
             );
         }
     }
@@ -608,9 +645,11 @@ static FORCE_INLINE inline void calculate_c_values_row(float *c_values, uint16_t
 
 static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
                                float *c_values, uint16_t *histograms, uint16_t window_size,
-                               const uint16_t *tvi_for_diff, int width, int height) {
+                               const uint16_t num_diffs, const uint16_t *tvi_for_diff,
+                               int width, int height) {
+
     uint16_t pad_size = window_size >> 1;
-    const uint16_t num_bins = 1024 + (g_all_diffs[NUM_ALL_DIFFS - 1] - g_all_diffs[0]);
+    const uint16_t num_bins = 1024 + (g_all_diffs[2*num_diffs] - g_all_diffs[0]);
 
     uint16_t *image = pic->data[0];
     uint16_t *mask = mask_pic->data[0];
@@ -628,7 +667,7 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
         for (int j = 0; j < width; j++) {
             uint16_t mask_val = mask[i * stride + j];
             if (mask_val) {
-                uint16_t val = image[i * stride + j] + g_c_value_histogram_offset;
+                uint16_t val = image[i * stride + j] + num_diffs;
                 for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
                     histograms[val * width + col]++;
                 }
@@ -640,25 +679,25 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
     for (int i = 0; i < pad_size + 1; i++) {
         if (i + pad_size < height) {
             for (int j = 0; j < width; j++) {
-                update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size);
+                update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
-        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, tvi_for_diff);
+        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff);
     }
     for (int i = pad_size + 1; i < height - pad_size; i++) {
         for (int j = 0; j < width; j++) {
-            update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size);
-            update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size);
+            update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
         }
-        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, tvi_for_diff);
+        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff);
     }
     for (int i = height - pad_size; i < height; i++) {
         if (i - pad_size - 1 >= 0) {
             for (int j = 0; j < width; j++) {
-                update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size);
+                update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
-        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, tvi_for_diff);
+        calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff);
     }
 }
 
@@ -720,8 +759,10 @@ static FORCE_INLINE inline double weight_scores_per_scale(double *scores_per_sca
 }
 
 static int cambi_score(VmafPicture *pics, uint32_t *mask_dp, uint16_t window_size, double topk,
-                       const uint16_t *tvi_for_diff, float *c_values, uint16_t *c_values_histograms, 
-                       uint8_t *filter_mode_histogram, uint16_t *filter_mode_buffer, double *score) {
+                       const uint16_t num_diffs, const uint16_t *tvi_for_diff, float *c_values,
+                       uint16_t *c_values_histograms, uint8_t *filter_mode_histogram,
+                       uint16_t *filter_mode_buffer, double *score) {
+
     double scores_per_scale[NUM_SCALES];
     VmafPicture *image = &pics[0];
     VmafPicture *mask = &pics[1];
@@ -742,7 +783,7 @@ static int cambi_score(VmafPicture *pics, uint32_t *mask_dp, uint16_t window_siz
         filter_mode(image, scaled_width, scaled_height, filter_mode_histogram, filter_mode_buffer);
 
         calculate_c_values(image, mask, c_values, c_values_histograms, window_size,
-                           tvi_for_diff, scaled_width, scaled_height);
+                           num_diffs, tvi_for_diff, scaled_width, scaled_height);
 
         scores_per_scale[scale] =
             spatial_pooling(c_values, topk, scaled_width, scaled_height);
@@ -767,7 +808,8 @@ static int extract(VmafFeatureExtractor *fex,
     if (err) return err;
 
     double score;
-    err = cambi_score(s->pics, s->mask_dp, s->window_size, s->topk, s->tvi_for_diff, s->c_values, s->c_values_histograms, s->filter_mode_histogram, s->filter_mode_buffer, &score);
+    const uint16_t num_diffs = 1<<s->max_log_contrast;
+    err = cambi_score(s->pics, s->mask_dp, s->window_size, s->topk, num_diffs, s->tvi_for_diff, s->c_values, s->c_values_histograms, s->filter_mode_histogram, s->filter_mode_buffer, &score);
     if (err) return err;
 
     err = vmaf_feature_collector_append(feature_collector, "cambi", score, index);
@@ -783,6 +825,10 @@ static int close(VmafFeatureExtractor *fex) {
     for (unsigned i = 0; i < PICS_BUFFER_SIZE; i++)
         err |= vmaf_picture_unref(&s->pics[i]);
 
+    aligned_free(g_diffs_to_consider);
+    aligned_free(g_diffs_weights);
+    aligned_free(g_all_diffs);
+    aligned_free(s->tvi_for_diff);
     aligned_free(s->c_values);
     aligned_free(s->c_values_histograms);
     aligned_free(s->mask_dp);

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -138,8 +138,9 @@ static const VmafOption options[] = {
     },
     {
         .name = "max_log_contrast",
-        .help = "Max contrast luma level at 10-bits, set to  2^max_log_contrast. "
-                "0 to 5: Default 2 is recommended for banding from compression",
+        .help = "Maximum contrast in log luma level (2^max_log_contrast) at 10-bits, "
+                "e.g., 2 is equivalent to 4 luma levels at 10-bit and 1 luma level at 8-bit. "
+                "From 0 to 5: default 2 is recommended for banding from compression.",
         .offset = offsetof(CambiState, max_log_contrast),
         .type = VMAF_OPT_TYPE_INT,
         .default_val.i = DEFAULT_MAX_LOG_CONTRAST,

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -293,12 +293,14 @@ static char *test_calculate_c_values()
     unsigned width = 4, height = 4;
     uint16_t tvi_for_diff[4] = {178, 305, 432, 559};
     uint16_t window_size = 3;
+    const uint16_t num_diffs = 4;
     uint16_t histograms[4*1032];
 
+    set_contrast_arrays(num_diffs, &g_diffs_to_consider, &g_diffs_weights, &g_all_diffs);
     get_sample_image(&input, 0);
     get_sample_image(&mask, 8);
     calculate_c_values(&input, &mask, combined_c_values, histograms,
-                       window_size, tvi_for_diff, width, height);
+                       window_size, num_diffs, tvi_for_diff, width, height);
 
     for (unsigned i=0; i<16; i++) {
         mu_assert("calculate_c_values error ws=3",
@@ -312,7 +314,7 @@ static char *test_calculate_c_values()
     window_size = 9;
     uint16_t histograms_8x8[8*1032];
     calculate_c_values(&input_8x8, &mask_8x8, combined_c_values_8x8, histograms_8x8,
-                       window_size, tvi_for_diff, 8, 8);
+                       window_size, num_diffs, tvi_for_diff, 8, 8);
 
     double sum = 0;
     for (unsigned i=0; i<64; i++)

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -485,6 +485,63 @@ static char *test_tvi_condition()
     return NULL;
 }
 
+static char *test_set_contrast_arrays()
+{
+    uint16_t *diffs_to_consider;
+    int *diffs_weights;
+    int *all_diffs;
+
+    int max_log_diff = 2;
+    int expected_diffs_to_consider_4[4] = {1, 2, 3, 4};
+    int expected_diffs_weights_4[4] = {1, 2, 3, 4};
+    int expected_all_diffs_4[9] = {-4, -3, -2, -1, 0, 1, 2, 3, 4};
+
+    int num_diffs = (1<<max_log_diff);
+    set_contrast_arrays(num_diffs, &diffs_to_consider, &diffs_weights, &all_diffs);
+
+    for (int i=0; i < num_diffs; i++) {
+        mu_assert("set_contrast_arrays max_log_diff 2, error at diffs_to_consider",
+                   expected_diffs_to_consider_4[i] == diffs_to_consider[i]);
+        mu_assert("set_contrast_arrays max_log_diff 2, error at diffs_weights",
+                   expected_diffs_weights_4[i] == diffs_weights[i]);
+    }
+
+    for (int i=0; i < 2*num_diffs + 1; i++) {
+        mu_assert("set_contrast_arrays max_log_diff 2, error at all_diffs",
+                   expected_all_diffs_4[i] == all_diffs[i]);
+    }
+
+    aligned_free(diffs_to_consider);
+    aligned_free(diffs_weights);
+    aligned_free(all_diffs);
+
+    max_log_diff = 3;
+    int expected_diffs_to_consider_8[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    int expected_diffs_weights_8[8] = {1, 2, 3, 4, 4, 5, 5, 6};
+    int expected_all_diffs_8[17] = {-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8};
+
+    num_diffs = (1<<max_log_diff);
+    set_contrast_arrays(num_diffs, &diffs_to_consider, &diffs_weights, &all_diffs);
+
+    for (int i=0; i < num_diffs; i++) {
+        mu_assert("set_contrast_arrays max_log_diff 3, error at diffs_to_consider",
+                   expected_diffs_to_consider_8[i] == diffs_to_consider[i]);
+        mu_assert("set_contrast_arrays max_log_diff 3, error at diffs_weights",
+                   expected_diffs_weights_8[i] == diffs_weights[i]);
+    }
+
+    for (int i=0; i < 2*num_diffs + 1; i++) {
+        mu_assert("set_contrast_arrays max_log_diff 3, error at all_diffs",
+                   expected_all_diffs_8[i] == all_diffs[i]);
+    }
+
+    aligned_free(diffs_to_consider);
+    aligned_free(diffs_weights);
+    aligned_free(all_diffs);
+
+    return NULL;
+}
+
 static char *test_tvi_hard_threshold_condition()
 {
     enum CambiTVIBisectFlag result;
@@ -589,6 +646,7 @@ char *run_tests()
     /* Visibility threshold functions */
     mu_run_test(test_get_tvi_for_diff);
     mu_run_test(test_tvi_condition);
+    mu_run_test(test_set_contrast_arrays);
     mu_run_test(test_tvi_hard_threshold_condition);
     mu_run_test(test_luminance_bt1886);
     mu_run_test(test_normalize_range);

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -79,6 +79,38 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
                                0.01451, places=4)
 
+    def test_run_cambi_fextractor_max_log_contrast(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'max_log_contrast': 4}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
+                               0.9182153958333333, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
+                               0.0024499791666667, places=4)
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'max_log_contrast': 0}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
+                               0.015840666666666666, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
+                               0.000671125, places=4)
+
 class CambiQualityRunnerTest(MyTestCase):
 
     def test_run_cambi_runner(self):

--- a/resource/doc/cambi.md
+++ b/resource/doc/cambi.md
@@ -50,6 +50,7 @@ The CAMBI feature extractor also supports additional optional parameters as list
 - `window_size` (min: 15, max: 127, default: 63): Window size to compute CAMBI (default: 63 corresponds to ~1 degree at 4K resolution and 1.5H)
 - `topk` (min: 0, max: 1.0, default: 0.6): Ratio of pixels for the spatial pooling computation
 - `tvi_threshold` (min: 0.0001, max: 1.0, default: 0.019): Visibilty threshold for luminance ΔL < tvi_threshold*L_mean for BT.1886
+- `max_log_contrast` (min: 0, max: 5, default: 2): Maximum contrast in log luma level (2^max_log_contrast) at 10-bits. Default 2 is equivalent to 4 luma levels at 10-bit and 1 luma level at 8-bit. The default is recommended for banding artifacts coming from video compression.
 - `enc_width` and `enc_height`: Encoding/processing resolution to compute the banding score, useful in cases where scaling was applied to the input prior to the computation of metrics
 
 An example using the `enc_width` and `enc_height` options on the input video [`KristenAndSara_1280x720_8bit_processed.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/KristenAndSara_1280x720_8bit_processed.yuv) which has been encoded at 540p and later upscaled to 1280p (specifying the accurate encoding width and height as input allows CAMBI to more accurately assess the banding artifact):


### PR DESCRIPTION
Add max_contrast parameter to account for larger contrast banding than 4 luma levels @ 10b  (e.g., for non-compression banding generated by bit-depth reduction).