### PR TITLE
libvmaf: add vmaf_feature_name_from_options

### DIFF
--- a/libvmaf/src/feature/feature_name.c
+++ b/libvmaf/src/feature/feature_name.c
@@ -117,14 +117,14 @@ char *vmaf_feature_name_from_options(char *name, VmafOption *opts, void *obj,
 
     snprintfcat(buf, buf_sz, "%s", name);
 
-    va_list(args);
-    va_start(args, param_cnt);
 
-    for (unsigned i = 0; i < param_cnt; i++) {
-        VmafOption *opt = NULL;
-        const void *param = va_arg(args, void*);
-        for (unsigned j = 0; (opt = &opts[j]); j++) {
-            if (!opt->name) break;
+    VmafOption *opt = NULL;
+    for (unsigned i = 0; (opt = &opts[i]); i++) {
+        if (!opt->name) break;
+        va_list(args);
+        va_start(args, param_cnt);
+        for (unsigned j = 0; j < param_cnt; j++) {
+            const void *param = va_arg(args, void*);
             const void *data = (uint8_t*)obj + opt->offset;
             if (data != param) continue;
             if (option_is_default(opt, data)) continue;
@@ -146,9 +146,9 @@ char *vmaf_feature_name_from_options(char *name, VmafOption *opts, void *obj,
                 break;
             }
         }
+        va_end(args);
     }
 
-    va_end(args);
 
     const size_t dst_sz = strnlen(buf, buf_sz) + 1;
     char *dst = malloc(dst_sz);

--- a/libvmaf/src/feature/feature_name.c
+++ b/libvmaf/src/feature/feature_name.c
@@ -16,11 +16,16 @@
  *
  */
 
+#include <errno.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "alias.h"
+#include "feature_name.h"
+#include "opt.h"
 
 typedef struct {
     const char *name, *alias;
@@ -69,4 +74,85 @@ char *vmaf_feature_name(char *name, char *key, double val,
     snprintf(buf, buf_sz - 1, "%s_%s_%g",
              vmaf_feature_name_alias(name), key_alias(key), val);
     return buf;
+}
+
+static int option_is_default(const VmafOption *opt, const void *data)
+{
+    if (!opt) return -EINVAL;
+    if (!data) return -EINVAL;
+
+    switch (opt->type) {
+    case VMAF_OPT_TYPE_BOOL:
+        return opt->default_val.b == *((bool*)data);
+    case VMAF_OPT_TYPE_INT:
+        return opt->default_val.i == *((int*)data);
+    case VMAF_OPT_TYPE_DOUBLE:
+        return opt->default_val.d == *((double*)data);
+    default:
+        return -EINVAL;
+    }
+}
+
+static size_t snprintfcat(char* buf, size_t buf_sz, char const* fmt, ...)
+{
+    va_list args;
+    const size_t len = strnlen(buf, buf_sz);
+    va_start(args, fmt);
+    const size_t result = vsnprintf(buf + len, buf_sz - len, fmt, args);
+    va_end(args);
+
+    return result + len;
+}
+
+char *vmaf_feature_name_from_options(char *name, VmafOption *opts, void *obj,
+                                     unsigned param_cnt, ...)
+{
+    if (!name) return NULL;
+    if (!opts) return NULL;
+    if (!obj) return NULL;
+    if (!param_cnt) return NULL;
+
+    const size_t buf_sz = VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE;
+    char buf[VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE + 1] = { 0 };
+
+    snprintfcat(buf, buf_sz, "%s", name);
+
+    va_list(args);
+    va_start(args, param_cnt);
+
+    for (unsigned i = 0; i < param_cnt; i++) {
+        VmafOption *opt = NULL;
+        const void *param = va_arg(args, void*);
+        for (unsigned j = 0; (opt = &opts[j]); j++) {
+            if (!opt->name) break;
+            const void *data = (uint8_t*)obj + opt->offset;
+            if (data != param) continue;
+            if (option_is_default(opt, data)) continue;
+
+            const char *key = opt->alias ? opt->alias : opt->name;
+            const void *val = data;
+
+            switch (opt->type) {
+            case VMAF_OPT_TYPE_BOOL:
+                snprintfcat(buf, buf_sz, "_%s_%d", key, *(bool*)val);
+                break;
+            case VMAF_OPT_TYPE_INT:
+                snprintfcat(buf, buf_sz, "_%s_%d", key, *((int*)val));
+                break;
+            case VMAF_OPT_TYPE_DOUBLE:
+                snprintfcat(buf, buf_sz, "_%s_%g", key, *((double*)val));
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    va_end(args);
+
+    const size_t dst_sz = strnlen(buf, buf_sz) + 1;
+    char *dst = malloc(dst_sz);
+    if (!dst) return NULL;
+    strncpy(dst, buf, dst_sz);
+    return dst;
 }

--- a/libvmaf/src/feature/feature_name.h
+++ b/libvmaf/src/feature/feature_name.h
@@ -19,9 +19,14 @@
 #ifndef __VMAF_FEATURE_NAME_H__
 #define __VMAF_FEATURE_NAME_H__
 
+#include "opt.h"
+
 #define VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE 256
 
 char *vmaf_feature_name(char *name, char *key, double val,
                         char *buf, size_t buf_sz);
+
+char *vmaf_feature_name_from_options(char *name, VmafOption *opts, void *obj,
+                                     unsigned n, ...);
 
 #endif /* __VMAF_FEATURE_NAME_H__ */

--- a/libvmaf/src/opt.h
+++ b/libvmaf/src/opt.h
@@ -31,6 +31,7 @@ enum VmafOptionType {
 typedef struct VmafOption {
     const char *name;
     const char *help;
+    const char *alias;
     int offset;
     enum VmafOptionType type;
     union {

--- a/libvmaf/test/test_feature.c
+++ b/libvmaf/test/test_feature.c
@@ -157,8 +157,9 @@ static char *test_feature_name_from_options()
                                        &s5.opt_double, &s5.opt_bool, &s5.opt_int);
 
     mu_assert("feature_name should have a suffix with aliases and values, "
-              "ordering should follow the ordering of variadac params",
-              !strcmp(feature_name5, "feature_name_opt_double_alias_4.14_opt_bool_1_opt_int_alias_201"));
+              "ordering should not follow the ordering of variadac params,"
+              "rather it should follow the order of options",
+              !strcmp(feature_name5, "feature_name_opt_bool_1_opt_double_alias_4.14_opt_int_alias_201"));
 
     free(feature_name5);
 

--- a/libvmaf/test/test_feature.c
+++ b/libvmaf/test/test_feature.c
@@ -17,6 +17,7 @@
  */
 
 #include <stddef.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "test.h"
@@ -49,8 +50,137 @@ static char *test_feature_name()
     return NULL;
 }
 
+static char *test_feature_name_from_options()
+{
+    typedef struct TestState {
+        bool opt_bool;
+        double opt_double;
+        int opt_int;
+    } TestState;
+
+#define opt_bool_default false
+#define opt_double_default 3.14
+#define opt_int_default 200
+
+    static VmafOption options[] = {
+        {
+            .name = "opt_bool",
+            .offset = offsetof(TestState, opt_bool),
+            .type = VMAF_OPT_TYPE_BOOL,
+            .default_val.b = opt_bool_default,
+        },
+        {
+            .name = "opt_double",
+            .alias = "opt_double_alias",
+            .offset = offsetof(TestState, opt_double),
+            .type = VMAF_OPT_TYPE_DOUBLE,
+            .default_val.d = opt_double_default,
+        },
+        {
+            .name = "opt_int",
+            .alias = "opt_int_alias",
+            .offset = offsetof(TestState, opt_int),
+            .type = VMAF_OPT_TYPE_INT,
+            .default_val.i = opt_int_default,
+        },
+        { 0 }
+    };
+
+    TestState s1 = {
+        .opt_bool = opt_bool_default,
+        .opt_double = opt_double_default,
+        .opt_int = opt_int_default,
+    };
+
+    char *feature_name1 =
+        vmaf_feature_name_from_options("feature_name", options, &s1, 3,
+                                       &s1.opt_bool, &s1.opt_double, &s1.opt_int);
+
+    mu_assert("when all options are default, feature_name should not change",
+              !strcmp(feature_name1, "feature_name"));
+
+    free(feature_name1);
+
+    TestState s2 = {
+        .opt_bool = !opt_bool_default,
+        .opt_double = opt_double_default,
+        .opt_int = opt_int_default,
+    };
+
+    char *feature_name2 =
+        vmaf_feature_name_from_options("feature_name", options, &s2, 3,
+                                       &s2.opt_bool, &s2.opt_double, &s2.opt_int);
+
+    mu_assert("when opt_bool has a non-default value, "
+              "feature_name should have a non-aliased opt_bool suffix",
+              !strcmp(feature_name2, "feature_name_opt_bool_1"));
+
+    free(feature_name2);
+
+    TestState s3 = {
+        .opt_bool = opt_bool_default,
+        .opt_double = opt_double_default + 1,
+        .opt_int = opt_int_default,
+    };
+
+    char *feature_name3 =
+        vmaf_feature_name_from_options("feature_name", options, &s3, 3,
+                                       &s3.opt_bool, &s3.opt_double, &s3.opt_int);
+
+    mu_assert("when opt_double has a non-default value, "
+              "feature_name should have a aliased opt_double_alias suffix",
+              !strcmp(feature_name3, "feature_name_opt_double_alias_4.14"));
+
+    free(feature_name3);
+
+    TestState s4 = {
+        .opt_bool = !opt_bool_default,
+        .opt_double = opt_double_default + 1,
+        .opt_int = opt_int_default + 1,
+    };
+
+    char *feature_name4 =
+        vmaf_feature_name_from_options("feature_name", options, &s4, 3,
+                                       &s4.opt_bool, &s4.opt_double, &s4.opt_int);
+
+
+    mu_assert("when all opts have a non-default value, "
+              "feature_name should have a suffix with aliases and values",
+              !strcmp(feature_name4, "feature_name_opt_bool_1_opt_double_alias_4.14_opt_int_alias_201"));
+
+    free(feature_name4);
+
+    TestState s5 = s4;
+
+    char *feature_name5 =
+        vmaf_feature_name_from_options("feature_name", options, &s5, 3,
+                                       &s5.opt_double, &s5.opt_bool, &s5.opt_int);
+
+    mu_assert("feature_name should have a suffix with aliases and values, "
+              "ordering should follow the ordering of variadac params",
+              !strcmp(feature_name5, "feature_name_opt_double_alias_4.14_opt_bool_1_opt_int_alias_201"));
+
+    free(feature_name5);
+
+    TestState s6 = s4;
+
+    char *feature_name6 =
+        vmaf_feature_name_from_options("feature_name", options, &s6, 1,
+                                       &s6.opt_double);
+
+    mu_assert("feature_name should have a single opt_double_alias suffix, "
+              "although all members of TestState have non-default values, "
+              "since just one variadic param is passed",
+              !strcmp(feature_name6, "feature_name_opt_double_alias_4.14"));
+
+    free(feature_name6);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_feature_name);
+    mu_run_test(test_feature_name_from_options);
     return NULL;
 }


### PR DESCRIPTION
This PR adds a helper function for building parameterized feature names: `vmaf_feature_name_from_options()`. Parameterized feature names are constructed using a base feature name and a set of `VmafOptions` and a state struct.  Suffixes are added to the base feature name only when an option has a non-default value in the form of `_key_val`. The option name (`VmafOption.name`) is used for `key`, but an alias (`VmafOption.alias`) may also be used. This is a variadic function so feature names can be parametrized using any number of options. This is an allocating function, so normal usage inside a feature extractor would be to generate/allocate once in `.init()` and then free in `.close()`.

For example usage and output, see `test_feature_name_from_options()`.