### PR TITLE
CAMBI heatmap generation

### DIFF
--- a/libvmaf/src/feature/mkdirp.c
+++ b/libvmaf/src/feature/mkdirp.c
@@ -1,0 +1,84 @@
+
+//
+// mkdirp.c
+//
+// Copyright (c) 2013 Stephen Mathieson
+// MIT licensed
+//
+
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mkdirp.h"
+
+static char *
+path_normalize(const char *path) {
+  if (!path) return NULL;
+
+  char *copy = strdup(path);
+  if (NULL == copy) return NULL;
+  char *ptr = copy;
+
+  for (int i = 0; copy[i]; i++) {
+    *ptr++ = path[i];
+    if ('/' == path[i]) {
+      i++;
+      while ('/' == path[i]) i++;
+      i--;
+    }
+  }
+
+  *ptr = '\0';
+
+  return copy;
+}
+
+#ifdef _WIN32
+#define PATH_SEPARATOR   '\\'
+#else
+#define PATH_SEPARATOR   '/'
+#endif
+
+int
+mkdirp(const char *path, mode_t mode) {
+  char *pathname = NULL;
+  char *parent = NULL;
+
+  if (NULL == path) return -1;
+
+  pathname = path_normalize(path);
+  if (NULL == pathname) goto fail;
+
+  parent = strdup(pathname);
+  if (NULL == parent) goto fail;
+
+  char *p = parent + strlen(parent);
+  while (PATH_SEPARATOR != *p && p != parent) {
+    p--;
+  }
+  *p = '\0';
+
+  // make parent dir
+  if (p != parent && 0 != mkdirp(parent, mode)) goto fail;
+  free(parent);
+
+  // make this one if parent has been made
+  #ifdef _WIN32
+    // http://msdn.microsoft.com/en-us/library/2fkk4dzw.aspx
+    int rc = mkdir(pathname);
+  #else
+    int rc = mkdir(pathname, mode);
+  #endif
+
+  free(pathname);
+
+  return 0 == rc || EEXIST == errno
+    ? 0
+    : -1;
+
+fail:
+  free(pathname);
+  free(parent);
+  return -1;
+}

--- a/libvmaf/src/feature/mkdirp.h
+++ b/libvmaf/src/feature/mkdirp.h
@@ -1,0 +1,21 @@
+
+//
+// mkdirp.h
+//
+// Copyright (c) 2013 Stephen Mathieson
+// MIT licensed
+//
+
+#ifndef MKDIRP
+#define MKDIRP
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/*
+ * Recursively `mkdir(path, mode)`
+ */
+
+int mkdirp(const char *, mode_t );
+
+#endif

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -235,6 +235,7 @@ libvmaf_feature_sources = [
     feature_src_dir + 'integer_vif.c',
     feature_src_dir + 'ciede.c',
     feature_src_dir + 'common/alignment.c',
+    feature_src_dir + 'mkdirp.c',
 
     feature_src_dir + 'float_ssim.c',
     feature_src_dir + 'float_ms_ssim.c',

--- a/libvmaf/src/opt.c
+++ b/libvmaf/src/opt.c
@@ -62,6 +62,13 @@ static int set_option_double(double *dst, double default_val, const char *val,
     return 0;
 }
 
+static int set_option_string(char **dst, char *default_val, const char *val) {
+    *dst = default_val;
+    if (!val) return 0;
+    *dst = val;
+    return 0;
+}
+
 int vmaf_option_set(const VmafOption *opt, void *obj, const char *val)
 {
     if (!obj) return -EINVAL;
@@ -77,6 +84,8 @@ int vmaf_option_set(const VmafOption *opt, void *obj, const char *val)
     case VMAF_OPT_TYPE_DOUBLE:
         return set_option_double(dst, opt->default_val.d, val, opt->min,
                                  opt->max);
+    case VMAF_OPT_TYPE_STRING:
+        return set_option_string(dst, opt->default_val.s, val);
     default:
         return -EINVAL;
     }

--- a/libvmaf/src/opt.h
+++ b/libvmaf/src/opt.h
@@ -26,6 +26,7 @@ enum VmafOptionType {
     VMAF_OPT_TYPE_BOOL,
     VMAF_OPT_TYPE_INT,
     VMAF_OPT_TYPE_DOUBLE,
+    VMAF_OPT_TYPE_STRING,
 };
 
 typedef struct VmafOption {
@@ -37,6 +38,7 @@ typedef struct VmafOption {
         bool b;
         int i;
         double d;
+        char *s;
     } default_val;
     double min, max;
 } VmafOption;


### PR DESCRIPTION
* Enables string options for VMAF
* Factors out buffers used by CAMBI from `CambiState`  into `CambiBuffers` to avoid clutter
* Adds optional parameter to CAMBI which provides a path to save one 16-bit YUV400 (grayscale) video for each scale, representing the `c_values` at that scale. This allows the user to visualize the bands detected by CAMBI and their temporal movement.

Comments:
* If we agree that the YUV400 option is better than the multiple PFM option, we can squash the last 4 commits into one. I'm keeping it this way for now in case we want to leave the last commit out (in which case, we can squash the last 3).
* It'd be good to test this on Windows, I don't have a Windows system but I'll try to find one to try it on. Mostly worried about the path separator.
* I've tested this on Mac OS by opening the generated .yuv files with `vooya`.
* (minor) I'm not sure if `.yuv` is the right extension for single-channel videos, I haven't found a better one.
* It would be good to check if the provided path is not empty and exit to avoid possibly corrupting user data.