### PR TITLE
Fix quick-select for edge case n = k

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -671,6 +671,7 @@ static double average_topk_elements(const float *arr, int topk_elements) {
 }
 
 static void quick_select(float *arr, int n, int k) {
+    if (n == k) return;
     int left = 0;
     int right = n - 1;
     while (left < right) {


### PR DESCRIPTION
When `n = k` in quick-select, we can immediately return as the top `n` elements will always be in the first `n` spots (the whole array). This fixes an edge case with this quick-select implementation which previously would have accessed out of bounds and caused UB. This case is never present in the actual CAMBI code with default parameters since `k = 0.6*n`, but could come up if the `topk` parameter is set to 1.