### PR TITLE
libvmaf/feature: add vmaf_feature_collector_append_with_dict()

### DIFF
--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -181,6 +181,19 @@ int vmaf_dictionary_compare(VmafDictionary *a, VmafDictionary *b)
     return 0;
 }
 
+static int alphabetical_compare(const void* a, const void* b)
+{
+    const VmafDictionaryEntry *entry_a = a;
+    const VmafDictionaryEntry *entry_b = b;
+    return strcmp(entry_a->key, entry_b->key);
+}
+
+void vmaf_dictionary_alphabetical_sort(VmafDictionary *dict)
+{
+    if (!dict) return;
+    qsort(dict->entry, dict->cnt, sizeof(*dict->entry), alphabetical_compare);
+}
+
 int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
                                 const char *val)
 {

--- a/libvmaf/src/dict.h
+++ b/libvmaf/src/dict.h
@@ -53,6 +53,8 @@ VmafDictionary *vmaf_dictionary_merge(VmafDictionary **dict_a,
 
 int vmaf_dictionary_compare(VmafDictionary *dict_a, VmafDictionary *dict_b);
 
+void vmaf_dictionary_alphabetical_sort(VmafDictionary *dict);
+
 int vmaf_dictionary_free(VmafDictionary **dict);
 
 #ifdef __cplusplus

--- a/libvmaf/src/feature/feature_collector.c
+++ b/libvmaf/src/feature/feature_collector.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "dict.h"
 #include "feature_collector.h"
 #include "feature_name.h"
 #include "log.h"
@@ -286,41 +287,16 @@ unlock:
     return err;
 }
 
-int vmaf_feature_collector_append_formatted(VmafFeatureCollector *feature_collector,
-                                            double score, unsigned index,
-                                            const char *fmt, ...)
+int vmaf_feature_collector_append_with_dict(VmafFeatureCollector *fc,
+        VmafDictionary *dict, const char *feature_name, double score,
+        unsigned index)
 {
-    if (!feature_collector) return -EINVAL;
-    if (!fmt) return -EINVAL;
+    if (!fc) return -EINVAL;
+    if (!dict) return -EINVAL;
 
-    int err = 0;
-
-    va_list(args);
-    va_start(args, fmt);
-    char *feature_name = NULL;
-    vasprintf(&feature_name, fmt, args);
-    if (err || !feature_name) return -ENOMEM;
-    err = vmaf_feature_collector_append(feature_collector, feature_name,
-                                        score, index);
-    free(feature_name);
-    return err;
-}
-
-int vmaf_feature_collector_append_templated(VmafFeatureCollector *feature_collector,
-                                            const char *feature_name,
-                                            const char *key, double val,
-                                            double score,
-                                            unsigned picture_index)
-{
-    if (!feature_collector) return -EINVAL;
-    if (!feature_name) return -EINVAL;
-
-    char buf[VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE];
-    feature_name = vmaf_feature_name(feature_name, key, val, &buf[0],
-                                     VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE);
-
-    return vmaf_feature_collector_append(feature_collector, feature_name,
-                                         score, picture_index);
+    VmafDictionaryEntry *entry = vmaf_dictionary_get(&dict, feature_name, 0);
+    const char *fn = entry ? entry->val : feature_name;
+    return vmaf_feature_collector_append(fc, fn, score, index);
 }
 
 int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,

--- a/libvmaf/src/feature/feature_collector.h
+++ b/libvmaf/src/feature/feature_collector.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <time.h>
 
+#include "dict.h"
+
 typedef struct {
     char *name;
     struct {
@@ -54,15 +56,9 @@ int vmaf_feature_collector_append(VmafFeatureCollector *feature_collector,
                                   const char *feature_name, double score,
                                   unsigned index);
 
-int vmaf_feature_collector_append_formatted(VmafFeatureCollector *feature_collector,
-                                            double score, unsigned index,
-                                            const char *fmt, ...);
-
-int vmaf_feature_collector_append_templated(VmafFeatureCollector *feature_collector,
-                                            const char *feature_name,
-                                            const char *key, double val,
-                                            double score,
-                                            unsigned picture_index);
+int vmaf_feature_collector_append_with_dict(VmafFeatureCollector *fc,
+        VmafDictionary *dict, const char *feature_name, double score,
+        unsigned index);
 
 int vmaf_feature_collector_get_score(VmafFeatureCollector *feature_collector,
                                      const char *feature_name, double *score,

--- a/libvmaf/src/feature/feature_name.h
+++ b/libvmaf/src/feature/feature_name.h
@@ -19,14 +19,14 @@
 #ifndef __VMAF_FEATURE_NAME_H__
 #define __VMAF_FEATURE_NAME_H__
 
+#include "dict.h"
 #include "opt.h"
 
-#define VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE 256
+char *vmaf_feature_name_from_opts_dict(const char *name, const VmafOption *opts,
+                                       VmafDictionary *opts_dict);
 
-char *vmaf_feature_name(char *name, char *key, double val,
-                        char *buf, size_t buf_sz);
-
-char *vmaf_feature_name_from_options(char *name, VmafOption *opts, void *obj,
-                                     unsigned n, ...);
+VmafDictionary *
+vmaf_feature_name_dict_from_provided_features(const char **provided_features,
+                                              const VmafOption *opts, void *obj);
 
 #endif /* __VMAF_FEATURE_NAME_H__ */

--- a/libvmaf/src/feature/float_adm.c
+++ b/libvmaf/src/feature/float_adm.c
@@ -20,8 +20,10 @@
 #include <string.h>
 #include <stddef.h>
 
+#include "dict.h"
 #include "feature_collector.h"
 #include "feature_extractor.h"
+#include "feature_name.h"
 
 #include "adm.h"
 #include "adm_options.h"
@@ -36,6 +38,7 @@ typedef struct AdmState {
     double adm_enhn_gain_limit;
     double adm_norm_view_dist;
     int adm_ref_display_height;
+    VmafDictionary *feature_name_dict;
 } AdmState;
 
 static const VmafOption options[] = {
@@ -48,6 +51,7 @@ static const VmafOption options[] = {
     },
     {
         .name = "adm_enhn_gain_limit",
+        .alias = "egl",
         .help = "enhancement gain imposed on adm, must be >= 1.0, "
                 "where 1.0 means the gain is completely disabled",
         .offset = offsetof(AdmState, adm_enhn_gain_limit),
@@ -55,24 +59,29 @@ static const VmafOption options[] = {
         .default_val.d = DEFAULT_ADM_ENHN_GAIN_LIMIT,
         .min = 1.0,
         .max = DEFAULT_ADM_ENHN_GAIN_LIMIT,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     {
         .name = "adm_norm_view_dist",
+        .alias = "nvd",
         .help = "normalized viewing distance = viewing distance / ref display's physical height",
         .offset = offsetof(AdmState, adm_norm_view_dist),
         .type = VMAF_OPT_TYPE_DOUBLE,
         .default_val.d = DEFAULT_ADM_NORM_VIEW_DIST,
         .min = 0.75,
         .max = 24.0,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     {
         .name = "adm_ref_display_height",
+        .alias = "rdf",
         .help = "reference display height in pixels",
         .offset = offsetof(AdmState, adm_ref_display_height),
         .type = VMAF_OPT_TYPE_INT,
         .default_val.i = DEFAULT_ADM_REF_DISPLAY_HEIGHT,
         .min = 1,
         .max = 4320,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     { 0 }
 };
@@ -85,13 +94,19 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
-    if (!s->dist) goto free_ref;
+    if (!s->dist) goto fail;
+
+    s->feature_name_dict =
+        vmaf_feature_name_dict_from_provided_features(fex->provided_features,
+                fex->options, s);
+    if (!s->feature_name_dict) goto fail;
 
     return 0;
 
-free_ref:
-    free(s->ref);
 fail:
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
+    vmaf_dictionary_free(&s->feature_name_dict);
     return -ENOMEM;
 }
 
@@ -118,78 +133,59 @@ static int extract(VmafFeatureExtractor *fex,
                       s->adm_norm_view_dist, s->adm_ref_display_height);
     if (err) return err;
 
-    const char *key =
-        s->adm_enhn_gain_limit != DEFAULT_ADM_ENHN_GAIN_LIMIT ?
-        "adm_enhn_gain_limit" : NULL;
-    const double val = s->adm_enhn_gain_limit;
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_adm2_score", score, index);
 
-    err = vmaf_feature_collector_append_templated(feature_collector,
-                                                  "VMAF_feature_adm2_score",
-                                                  key, val,
-                                                  score, index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_adm_scale0_score",
+            scores[0] / scores[1], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                "VMAF_feature_adm_scale0_score",
-                                                key, val,
-                                                scores[0] / scores[1], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_adm_scale1_score",
+            scores[2] / scores[3], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                "VMAF_feature_adm_scale1_score",
-                                                key, val,
-                                                scores[2] / scores[3], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_adm_scale2_score",
+            scores[4] / scores[5], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                "VMAF_feature_adm_scale2_score",
-                                                key, val,
-                                                scores[4] / scores[5], index);
-
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                "VMAF_feature_adm_scale3_score",
-                                                key, val,
-                                                scores[6] / scores[7], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_adm_scale3_score",
+            scores[6] / scores[7], index);
 
     if (!s->debug) return err;
 
-    err |= vmaf_feature_collector_append_templated(feature_collector, "adm",
-                                                   key, val, score, index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm", score, index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector, "adm_num",
-                                                   key, val, score_num, index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_num", score_num, index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector, "adm_den",
-                                                   key, val, score_den, index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_den", score_den, index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_num_scale0",
-                                                    key, val, scores[0], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_num_scale0", scores[0], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_den_scale0",
-                                                   key, val, scores[1], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_den_scale0", scores[1], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_num_scale1",
-                                                   key, val, scores[2], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_num_scale1", scores[2], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_den_scale1",
-                                                   key, val, scores[3], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_den_scale1", scores[3], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_num_scale2",
-                                                   key, val, scores[4], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_num_scale2", scores[4], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_den_scale2",
-                                                   key, val, scores[5], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_den_scale2", scores[5], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_num_scale3",
-                                                   key, val, scores[6], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_num_scale3", scores[6], index);
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                                   "adm_den_scale3",
-                                                   key, val, scores[7], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "adm_den_scale3", scores[7], index);
 
     return err;
 }
@@ -199,15 +195,16 @@ static int close(VmafFeatureExtractor *fex)
     AdmState *s = fex->priv;
     if (s->ref) aligned_free(s->ref);
     if (s->dist) aligned_free(s->dist);
+    vmaf_dictionary_free(&s->feature_name_dict);
     return 0;
 }
 
 static const char *provided_features[] = {
-    "VMAF_feature_adm2_score",
-    "VMAF_feature_adm2_score",
-    "VMAF_feature_adm_scale0_score", "VMAF_feature_adm_scale1_score",
-    "VMAF_feature_adm_scale2_score", "VMAF_feature_adm_scale3_score",
-    "adm_scale0", "adm_scale1", "adm_scale2", "adm_scale3",
+    "VMAF_feature_adm2_score", "VMAF_feature_adm_scale0_score",
+    "VMAF_feature_adm_scale1_score", "VMAF_feature_adm_scale2_score",
+    "VMAF_feature_adm_scale3_score", "adm_num", "adm_den", "adm_scale0",
+    "adm_num_scale0", "adm_den_scale0", "adm_num_scale1", "adm_den_scale1",
+    "adm_num_scale2", "adm_den_scale2", "adm_num_scale3", "adm_den_scale3",
     NULL
 };
 

--- a/libvmaf/src/feature/float_vif.c
+++ b/libvmaf/src/feature/float_vif.c
@@ -20,8 +20,10 @@
 #include <string.h>
 #include <stddef.h>
 
+#include "dict.h"
 #include "feature_collector.h"
 #include "feature_extractor.h"
+#include "feature_name.h"
 #include "mem.h"
 
 #include "vif.h"
@@ -35,6 +37,7 @@ typedef struct VifState {
     bool debug;
     double vif_enhn_gain_limit;
     double vif_kernelscale;
+    VmafDictionary *feature_name_dict;
 } VifState;
 
 static const VmafOption options[] = {
@@ -47,6 +50,7 @@ static const VmafOption options[] = {
     },
     {
         .name = "vif_enhn_gain_limit",
+        .alias = "egl",
         .help = "enhancement gain imposed on vif, must be >= 1.0, "
                 "where 1.0 means the gain is completely disabled",
         .offset = offsetof(VifState, vif_enhn_gain_limit),
@@ -54,6 +58,7 @@ static const VmafOption options[] = {
         .default_val.d = DEFAULT_VIF_ENHN_GAIN_LIMIT,
         .min = 1.0,
         .max = DEFAULT_VIF_ENHN_GAIN_LIMIT,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     {
         .name = "vif_kernelscale",
@@ -65,6 +70,7 @@ static const VmafOption options[] = {
         .default_val.d = DEFAULT_VIF_KERNELSCALE,
         .min = 0.1,
         .max = 2.0,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     { NULL }
 };
@@ -77,13 +83,19 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->ref = aligned_malloc(s->float_stride * h, 32);
     if (!s->ref) goto fail;
     s->dist = aligned_malloc(s->float_stride * h, 32);
-    if (!s->dist) goto free_ref;
+    if (!s->dist) goto fail;
+
+    s->feature_name_dict =
+        vmaf_feature_name_dict_from_provided_features(fex->provided_features,
+                fex->options, s);
+    if (!s->feature_name_dict) goto fail;
 
     return 0;
 
-free_ref:
-    free(s->ref);
 fail:
+    if (s->ref) aligned_free(s->ref);
+    if (s->dist) aligned_free(s->dist);
+    vmaf_dictionary_free(&s->feature_name_dict);
     return -ENOMEM;
 }
 
@@ -110,59 +122,56 @@ static int extract(VmafFeatureExtractor *fex,
                       s->vif_kernelscale);
     if (err) return err;
 
-    const char *key =
-        s->vif_enhn_gain_limit != DEFAULT_VIF_ENHN_GAIN_LIMIT ?
-        "vif_enhn_gain_limit" : NULL;
-    const double val = s->vif_enhn_gain_limit;
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_vif_scale0_score",
+            scores[0] / scores[1], index);
 
-    err = vmaf_feature_collector_append_templated(feature_collector,
-                                        "VMAF_feature_vif_scale0_score",
-                                        key, val,
-                                        scores[0] / scores[1], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "VMAF_feature_vif_scale1_score",
-                                         key, val,
-                                         scores[2] / scores[3], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "VMAF_feature_vif_scale2_score",
-                                         key, val,
-                                         scores[4] / scores[5], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "VMAF_feature_vif_scale3_score",
-                                         key, val,
-                                         scores[6] / scores[7], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_vif_scale1_score",
+            scores[2] / scores[3], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_vif_scale2_score",
+            scores[4] / scores[5], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_feature_vif_scale3_score",
+            scores[6] / scores[7], index);
+
     if (!s->debug) return err;
 
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "vif", key, val, score, index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "vif_num", key, val, score_num, index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                         "vif_den", key, val, score_den, index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_num_scale0",
-                                        key, val, scores[0], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_den_scale0",
-                                        key, val, scores[1], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_num_scale1",
-                                        key, val, scores[2], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_den_scale1",
-                                        key, val, scores[3], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_num_scale2",
-                                        key, val, scores[4], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_den_scale2",
-                                        key, val, scores[5], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_num_scale3",
-                                        key, val, scores[6], index);
-    err |= vmaf_feature_collector_append_templated(feature_collector,
-                                        "vif_den_scale3",
-                                        key, val, scores[7], index);
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif", score, index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_num", score_num, index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_den", score_den, index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_num_scale0", scores[0], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_den_scale0", scores[1], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_num_scale1", scores[2], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_den_scale1", scores[3], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_num_scale2", scores[4], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_den_scale2", scores[5], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_num_scale3", scores[6], index);
+
+    err |= vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "vif_den_scale3", scores[7], index);
 
     return err;
 }
@@ -172,14 +181,16 @@ static int close(VmafFeatureExtractor *fex)
     VifState *s = fex->priv;
     if (s->ref) aligned_free(s->ref);
     if (s->dist) aligned_free(s->dist);
+    vmaf_dictionary_free(&s->feature_name_dict);
     return 0;
 }
 
 static const char *provided_features[] = {
     "VMAF_feature_vif_scale0_score", "VMAF_feature_vif_scale1_score",
     "VMAF_feature_vif_scale2_score", "VMAF_feature_vif_scale3_score",
-    "VMAF_feature_vif_scale0_score", "VMAF_feature_vif_scale1_score",
-    "VMAF_feature_vif_scale2_score", "VMAF_feature_vif_scale3_score",
+    "vif", "vif_num", "vif_den", "vif_num_scale0", "vif_den_scale0",
+    "vif_num_scale1", "vif_den_scale1", "vif_num_scale2", "vif_den_scale2",
+    "vif_num_scale3", "vif_den_scale3",
     NULL
 };
 

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -22,8 +22,10 @@
 
 #include "cpu.h"
 #include "common/alignment.h"
+#include "dict.h"
 #include "feature_collector.h"
 #include "feature_extractor.h"
+#include "feature_name.h"
 #include "integer_motion.h"
 #include "mem.h"
 #include "picture.h"
@@ -49,6 +51,7 @@ typedef struct MotionState {
                           unsigned height, ptrdiff_t src_stride,
                           ptrdiff_t dst_stride);
     void (*sad)(VmafPicture *pic_a, VmafPicture *pic_b, uint64_t *sad);
+    VmafDictionary *feature_name_dict;
 } MotionState;
 
 static const VmafOption options[] = {
@@ -61,10 +64,12 @@ static const VmafOption options[] = {
     },
     {
         .name = "motion_force_zero",
+        .alias = "force_0",
         .help = "forcing motion score to zero",
         .offset = offsetof(MotionState, motion_force_zero),
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     { 0 }
 };
@@ -249,16 +254,18 @@ static int extract_force_zero(VmafFeatureExtractor *fex,
     (void) ref_pic_90;
     (void) dist_pic;
     (void) dist_pic_90;
-    int err = 0;
 
-    err = vmaf_feature_collector_append_templated(feature_collector,
-                                           "VMAF_integer_feature_motion2_score",
-                                           "motion_force_zero", 0., 0., index);
-    if (s->debug) {
-        err |= vmaf_feature_collector_append_templated(feature_collector,
-                                            "VMAF_integer_feature_motion_score",
-                                            "motion_force_zero", 0., 0., index);
-    }
+    int err =
+        vmaf_feature_collector_append_with_dict(feature_collector,
+                s->feature_name_dict, "VMAF_integer_feature_motion2_score", 0.,
+                index);
+
+    if (!s->debug) return err;
+
+    err = vmaf_feature_collector_append_with_dict(feature_collector,
+            s->feature_name_dict, "VMAF_integer_feature_motion_score", 0.,
+            index);
+
     return err;
 }
 
@@ -266,6 +273,11 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     MotionState *s = fex->priv;
+
+    s->feature_name_dict =
+        vmaf_feature_name_dict_from_provided_features(fex->provided_features,
+                fex->options, s);
+    if (!s->feature_name_dict) goto fail;
 
     if (s->motion_force_zero) {
         fex->extract = extract_force_zero;
@@ -296,6 +308,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 
     s->sad = sad_c;
     s->score = 0.;
+
     return 0;
 
 fail:
@@ -303,6 +316,7 @@ fail:
     err |= vmaf_picture_unref(&s->blur[1]);
     err |= vmaf_picture_unref(&s->blur[2]);
     err |= vmaf_picture_unref(&s->tmp);
+    err |= vmaf_dictionary_free(&s->feature_name_dict);
     return err;
 }
 
@@ -402,6 +416,7 @@ static int close(VmafFeatureExtractor *fex)
     err |= vmaf_picture_unref(&s->blur[1]);
     err |= vmaf_picture_unref(&s->blur[2]);
     err |= vmaf_picture_unref(&s->tmp);
+    err |= vmaf_dictionary_free(&s->feature_name_dict);
     return err;
 }
 

--- a/libvmaf/src/opt.h
+++ b/libvmaf/src/opt.h
@@ -28,6 +28,10 @@ enum VmafOptionType {
     VMAF_OPT_TYPE_DOUBLE,
 };
 
+enum VmafOptionFlag {
+    VMAF_OPT_FLAG_FEATURE_PARAM = 1 << 0,
+};
+
 typedef struct VmafOption {
     const char *name;
     const char *help;
@@ -40,6 +44,7 @@ typedef struct VmafOption {
         double d;
     } default_val;
     double min, max;
+    uint64_t flags;
 } VmafOption;
 
 int vmaf_option_set(const VmafOption *opt, void *obj, const char *val);

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -83,7 +83,7 @@ test_ref = executable('test_ref',
 )
 
 test_feature = executable('test_feature',
-    ['test.c', 'test_feature.c', '../src/feature/feature_name.c', '../src/feature/alias.c'],
+    ['test.c', 'test_feature.c', '../src/feature/alias.c', '../src/dict.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
 )
 

--- a/libvmaf/test/test_dict.c
+++ b/libvmaf/test/test_dict.c
@@ -308,6 +308,38 @@ static char *test_vmaf_feature_dictionary()
     return NULL;
 }
 
+static char *test_vmaf_dictionary_alphabetical_sort()
+{
+    int err = 0;
+
+    VmafDictionary *dict = NULL;
+    err |= vmaf_feature_dictionary_set(&dict, "z", "z");
+    err |= vmaf_feature_dictionary_set(&dict, "y", "y");
+    err |= vmaf_feature_dictionary_set(&dict, "x", "x");
+    err |= vmaf_feature_dictionary_set(&dict, "a", "a");
+    err |= vmaf_feature_dictionary_set(&dict, "b", "b");
+    err |= vmaf_feature_dictionary_set(&dict, "c", "c");
+    err |= vmaf_feature_dictionary_set(&dict, "2", "2");
+    err |= vmaf_feature_dictionary_set(&dict, "1", "1");
+    err |= vmaf_feature_dictionary_set(&dict, "0", "0");
+    mu_assert("problem during vmaf_feature_dictionary_set", !err);
+    mu_assert("dict should have 9 entries", dict->cnt == 9);
+
+    vmaf_dictionary_alphabetical_sort(dict);
+    mu_assert("dict should have 9 entries", dict->cnt == 9);
+    char *expected_order[9] = {"0", "1", "2", "a", "b", "c", "x", "y", "z"};
+
+    for (unsigned i = 0; i < 9; i++) {
+        mu_assert("dict is not alphabetically sorted",
+                  !strcmp(dict->entry[i].key, expected_order[i]));
+    }
+
+    err = vmaf_dictionary_free(&dict);
+    mu_assert("problem during vmaf_feature_dictionary_free", !err);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_vmaf_dictionary);
@@ -315,5 +347,6 @@ char *run_tests()
     mu_run_test(test_vmaf_dictionary_compare);
     mu_run_test(test_vmaf_dictionary_normalize_numerical_val);
     mu_run_test(test_vmaf_feature_dictionary);
+    mu_run_test(test_vmaf_dictionary_alphabetical_sort);
     return NULL;
 }

--- a/libvmaf/test/test_feature.c
+++ b/libvmaf/test/test_feature.c
@@ -22,33 +22,7 @@
 
 #include "test.h"
 
-#include "feature/feature_name.h"
-
-static char *test_feature_name()
-{
-    char buf[VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE];
-    char *feature_name;
-
-    char *name = "VMAF_integer_feature_vif_scale0_score";
-    char *key = "vif_enhn_gain_limit";
-    const double val = 1.0;
-
-    feature_name = vmaf_feature_name(name, NULL, val, &buf[0],
-                                     VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE);
-    mu_assert("name should not be modified", !strcmp(feature_name, name));
-
-    feature_name = vmaf_feature_name(name, key, val, &buf[0],
-                                     VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE);
-    mu_assert("name should have been formatted according to key/val",
-        !strcmp(feature_name, "integer_vif_scale0_egl_1"));
-
-    feature_name = vmaf_feature_name(name, key, 1.23, &buf[0],
-                                     VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE);
-    mu_assert("name should have been formatted according to key/val",
-        !strcmp(feature_name, "integer_vif_scale0_egl_1.23"));
-
-    return NULL;
-}
+#include "feature/feature_name.c"
 
 static char *test_feature_name_from_options()
 {
@@ -56,6 +30,7 @@ static char *test_feature_name_from_options()
         bool opt_bool;
         double opt_double;
         int opt_int;
+        bool opt_bool2;
     } TestState;
 
 #define opt_bool_default false
@@ -68,6 +43,7 @@ static char *test_feature_name_from_options()
             .offset = offsetof(TestState, opt_bool),
             .type = VMAF_OPT_TYPE_BOOL,
             .default_val.b = opt_bool_default,
+            .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
         },
         {
             .name = "opt_double",
@@ -75,6 +51,7 @@ static char *test_feature_name_from_options()
             .offset = offsetof(TestState, opt_double),
             .type = VMAF_OPT_TYPE_DOUBLE,
             .default_val.d = opt_double_default,
+            .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
         },
         {
             .name = "opt_int",
@@ -82,6 +59,14 @@ static char *test_feature_name_from_options()
             .offset = offsetof(TestState, opt_int),
             .type = VMAF_OPT_TYPE_INT,
             .default_val.i = opt_int_default,
+            .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
+        },
+        {
+            .name = "opt_bool2",
+            .offset = offsetof(TestState, opt_bool),
+            .type = VMAF_OPT_TYPE_BOOL,
+            .default_val.b = opt_bool_default,
+            .flags = 0,
         },
         { 0 }
     };
@@ -90,11 +75,11 @@ static char *test_feature_name_from_options()
         .opt_bool = opt_bool_default,
         .opt_double = opt_double_default,
         .opt_int = opt_int_default,
+        .opt_bool2 = opt_bool_default,
     };
 
     char *feature_name1 =
-        vmaf_feature_name_from_options("feature_name", options, &s1, 3,
-                                       &s1.opt_bool, &s1.opt_double, &s1.opt_int);
+        vmaf_feature_name_from_options("feature_name", options, &s1);
 
     mu_assert("when all options are default, feature_name should not change",
               !strcmp(feature_name1, "feature_name"));
@@ -105,15 +90,15 @@ static char *test_feature_name_from_options()
         .opt_bool = !opt_bool_default,
         .opt_double = opt_double_default,
         .opt_int = opt_int_default,
+        .opt_bool2 = opt_bool_default,
     };
 
     char *feature_name2 =
-        vmaf_feature_name_from_options("feature_name", options, &s2, 3,
-                                       &s2.opt_bool, &s2.opt_double, &s2.opt_int);
+        vmaf_feature_name_from_options("feature_name", options, &s2);
 
     mu_assert("when opt_bool has a non-default value, "
               "feature_name should have a non-aliased opt_bool suffix",
-              !strcmp(feature_name2, "feature_name_opt_bool_1"));
+              !strcmp(feature_name2, "feature_name_opt_bool"));
 
     free(feature_name2);
 
@@ -121,11 +106,11 @@ static char *test_feature_name_from_options()
         .opt_bool = opt_bool_default,
         .opt_double = opt_double_default + 1,
         .opt_int = opt_int_default,
+        .opt_bool2 = opt_bool_default,
     };
 
     char *feature_name3 =
-        vmaf_feature_name_from_options("feature_name", options, &s3, 3,
-                                       &s3.opt_bool, &s3.opt_double, &s3.opt_int);
+        vmaf_feature_name_from_options("feature_name", options, &s3);
 
     mu_assert("when opt_double has a non-default value, "
               "feature_name should have a aliased opt_double_alias suffix",
@@ -137,51 +122,37 @@ static char *test_feature_name_from_options()
         .opt_bool = !opt_bool_default,
         .opt_double = opt_double_default + 1,
         .opt_int = opt_int_default + 1,
+        .opt_bool2 = !opt_bool_default,
     };
 
     char *feature_name4 =
-        vmaf_feature_name_from_options("feature_name", options, &s4, 3,
-                                       &s4.opt_bool, &s4.opt_double, &s4.opt_int);
+        vmaf_feature_name_from_options("feature_name", options, &s4);
 
 
     mu_assert("when all opts have a non-default value, "
-              "feature_name should have a suffix with aliases and values",
-              !strcmp(feature_name4, "feature_name_opt_bool_1_opt_double_alias_4.14_opt_int_alias_201"));
+              "feature_name should have a suffix with aliases and values. "
+              "opt_bool2 should not parameterize since its flags are unset.",
+              !strcmp(feature_name4, "feature_name_opt_bool_opt_double_alias_4.14_opt_int_alias_201"));
 
     free(feature_name4);
 
     TestState s5 = s4;
 
     char *feature_name5 =
-        vmaf_feature_name_from_options("feature_name", options, &s5, 3,
-                                       &s5.opt_double, &s5.opt_bool, &s5.opt_int);
+        vmaf_feature_name_from_options("feature_name", options, &s5);
 
     mu_assert("feature_name should have a suffix with aliases and values, "
               "ordering should not follow the ordering of variadac params,"
               "rather it should follow the order of options",
-              !strcmp(feature_name5, "feature_name_opt_bool_1_opt_double_alias_4.14_opt_int_alias_201"));
+              !strcmp(feature_name5, "feature_name_opt_bool_opt_double_alias_4.14_opt_int_alias_201"));
 
     free(feature_name5);
-
-    TestState s6 = s4;
-
-    char *feature_name6 =
-        vmaf_feature_name_from_options("feature_name", options, &s6, 1,
-                                       &s6.opt_double);
-
-    mu_assert("feature_name should have a single opt_double_alias suffix, "
-              "although all members of TestState have non-default values, "
-              "since just one variadic param is passed",
-              !strcmp(feature_name6, "feature_name_opt_double_alias_4.14"));
-
-    free(feature_name6);
 
     return NULL;
 }
 
 char *run_tests()
 {
-    mu_run_test(test_feature_name);
     mu_run_test(test_feature_name_from_options);
     return NULL;
 }

--- a/libvmaf/test/test_feature_collector.c
+++ b/libvmaf/test/test_feature_collector.c
@@ -156,35 +156,10 @@ static char *test_feature_collector_init_append_get_and_destroy()
     return NULL;
 }
 
-static char *test_feature_collector_append_formatted()
-{
-    int err = 0;
-
-    VmafFeatureCollector *feature_collector;
-    err = vmaf_feature_collector_init(&feature_collector);
-    mu_assert("problem during vmaf_feature_collector_init", !err);
-
-    err = vmaf_feature_collector_append_formatted(feature_collector, 60., 1,
-                                                  "feature_%s_%s_%.2f_%d",
-                                                  "a", "b", 123.456, 88);
-    mu_assert("problem during vmaf_feature_collector_append_formatted", !err);
-
-    double score;
-    err = vmaf_feature_collector_get_score(feature_collector,
-                                           "feature_a_b_123.46_88", &score, 1);
-    mu_assert("problem during vmaf_feature_collector_get_score", !err);
-    mu_assert("vmaf_feature_collector_get_score did not get the expected score",
-              score == 60.);
-
-    vmaf_feature_collector_destroy(feature_collector);
-    return NULL;
-}
-
 char *run_tests()
 {
     mu_run_test(test_feature_vector_init_append_and_destroy);
     mu_run_test(test_feature_collector_init_append_get_and_destroy);
     mu_run_test(test_aggregate_vector_init_append_and_destroy);
-    mu_run_test(test_feature_collector_append_formatted);
     return NULL;
 }

--- a/libvmaf/test/test_predict.c
+++ b/libvmaf/test/test_predict.c
@@ -38,9 +38,8 @@ static char *test_predict_score_at_index()
         .name = "vmaf",
         .flags = VMAF_MODEL_FLAGS_DEFAULT,
     };
-    const char *path = "../../model/vmaf_float_v0.6.1.json";
-    err = vmaf_model_load_from_path(&model, &cfg, path);
-    mu_assert("problem during vmaf_model_load_from_path", !err);
+    err = vmaf_model_load(&model, &cfg, "vmaf_v0.6.1");
+    mu_assert("problem during vmaf_model_load", !err);
 
     for (unsigned i = 0; i < model->n_features; i++) {
         err = vmaf_feature_collector_append(feature_collector,


### PR DESCRIPTION
This PR opens up feature name parameterization via one or several feature options. We previously supported something similar for a single key/val pair, but the new API supports many modifying options at once. Feature names are parameterized when a feature extractor `VmafOption` is set to a non-default and has its `VMAF_OPT_FLAG_FEATURE_PARAM ` flag set. Base feature names are extended with `_key_val` where `key` is `VmafOption.name` or `VmafOption.alias` if the alias exists. `val` comes from the non default value set when the feature extractor was registered. The parameter strings are appended in alphabetical order.

This PR also deprecates two previous attempts to provide similar functionality: `vmaf_feature_collector_append_templated()` and `vmaf_feature_collector_append_formatted()`

Replaces #953.