### PR TITLE
libvmaf/predict: use vmaf_feature_name_from_options

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -93,7 +93,7 @@ VmafFeatureExtractor *vmaf_get_feature_extractor_by_feature_name(const char *nam
     return NULL;
 }
 
-int vmaf_fex_ctx_parse_options(VmafFeatureExtractorContext *fex_ctx)
+static int vmaf_fex_ctx_parse_options(VmafFeatureExtractorContext *fex_ctx)
 {
     const VmafOption *opt = NULL;
     for (unsigned i = 0; (opt = &fex_ctx->fex->options[i]); i++) {

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -154,6 +154,4 @@ int vmaf_fex_ctx_pool_flush(VmafFeatureExtractorContextPool *pool,
 
 int vmaf_fex_ctx_pool_destroy(VmafFeatureExtractorContextPool *pool);
 
-int vmaf_fex_ctx_parse_options(VmafFeatureExtractorContext *fex_ctx);
-
 #endif /* __VMAF_FEATURE_EXTRACTOR_H__ */

--- a/libvmaf/src/feature/feature_name.c
+++ b/libvmaf/src/feature/feature_name.c
@@ -41,8 +41,8 @@ static size_t snprintfcat(char* buf, size_t buf_sz, char const* fmt, ...)
 
 #define VMAF_FEATURE_NAME_DEFAULT_BUFFER_SIZE 256
 
-char *vmaf_feature_name_from_opts_dict(const char *name, const VmafOption *opts,
-                                       VmafDictionary *opts_dict)
+static char *vmaf_feature_name_from_opts_dict(const char *name,
+                              const VmafOption *opts, VmafDictionary *opts_dict)
 {
     VmafDictionary *sorted_dict = NULL;
     vmaf_dictionary_copy(&opts_dict, &sorted_dict);
@@ -104,15 +104,16 @@ static int option_is_default(const VmafOption *opt, const void *data)
     }
 }
 
-static char *vmaf_feature_name_from_options(const char *name,
-                                            const VmafOption *opts, void *obj)
+char *vmaf_feature_name_from_options(const char *name, const VmafOption *opts,
+                                     void *obj)
 {
     if (!name) return NULL;
-    if (!opts) return NULL;
-    if (!obj) return NULL;
 
     VmafDictionary *opts_dict = NULL;
     char *output = NULL;
+
+    if (!opts) goto write_output;
+    if (!obj) goto write_output;
 
     const VmafOption *opt = NULL;
     for (unsigned i = 0; (opt = &opts[i]); i++) {
@@ -143,8 +144,8 @@ static char *vmaf_feature_name_from_options(const char *name,
         if (err) goto exit;
     }
 
+write_output:
     output = vmaf_feature_name_from_opts_dict(name, opts, opts_dict);
-
 exit:
     vmaf_dictionary_free(&opts_dict);
     return output;

--- a/libvmaf/src/feature/feature_name.h
+++ b/libvmaf/src/feature/feature_name.h
@@ -22,8 +22,8 @@
 #include "dict.h"
 #include "opt.h"
 
-char *vmaf_feature_name_from_opts_dict(const char *name, const VmafOption *opts,
-                                       VmafDictionary *opts_dict);
+char *vmaf_feature_name_from_options(const char *name, const VmafOption *opts,
+                                     void *obj);
 
 VmafDictionary *
 vmaf_feature_name_dict_from_provided_features(const char **provided_features,

--- a/libvmaf/src/fex_ctx_vector.c
+++ b/libvmaf/src/fex_ctx_vector.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "feature/feature_extractor.h"
+#include "feature/feature_name.h"
 #include "fex_ctx_vector.h"
 #include "log.h"
 
@@ -44,18 +45,22 @@ int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
     (void) flags;
 
     for (unsigned i = 0; i < rfe->cnt; i++) {
-        VmafFeatureExtractorContext *registered_fex_ctx = rfe->fex_ctx[i];
+        char *feature_a =
+            vmaf_feature_name_from_options(rfe->fex_ctx[i]->fex->name,
+                    rfe->fex_ctx[i]->fex->options, rfe->fex_ctx[i]->fex->priv);
 
-        if (strcmp(registered_fex_ctx->fex->name, fex_ctx->fex->name))
-            continue;
+        char *feature_b =
+            vmaf_feature_name_from_options(fex_ctx->fex->name,
+                    fex_ctx->fex->options, fex_ctx->fex->priv);
 
-        //TODO: OK to merge when VMAF_OPT_FLAG_FEATURE_PARAM is unset?
+        int ret = 1;
+        if (feature_a && feature_b)
+            ret = strcmp(feature_a, feature_b);
 
-        int ret =
-            vmaf_dictionary_compare(registered_fex_ctx->opts_dict,
-                                    fex_ctx->opts_dict);
+        free(feature_a);
+        free(feature_b);
 
-        if (ret != 0) continue;
+        if (ret) continue;
 
         return vmaf_feature_extractor_context_destroy(fex_ctx);
     }

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -250,10 +250,28 @@ int vmaf_predict_score_at_index(VmafModel *model,
             goto free_node;
         }
 
+        VmafDictionary *opts_dict = NULL;
+        if (model->feature[i].opts_dict) {
+            err = vmaf_dictionary_copy(&model->feature[i].opts_dict, &opts_dict);
+            if (err) return err;
+        }
+
+        VmafFeatureExtractorContext *fex_ctx;
+        err = vmaf_feature_extractor_context_create(&fex_ctx, fex, opts_dict);
+        if (err) {
+            vmaf_log(VMAF_LOG_LEVEL_ERROR,
+                     "vmaf_predict_score_at_index(): could not generate "
+                     "feature extractor context\n");
+            vmaf_dictionary_free(&opts_dict);
+            return err;
+        }
+
         char *feature_name =
-            vmaf_feature_name_from_opts_dict(model->feature[i].name,
-                                             fex->options,
-                                             model->feature[i].opts_dict);
+            vmaf_feature_name_from_options(model->feature[i].name,
+                    fex_ctx->fex->options, fex_ctx->fex->priv);
+
+        vmaf_feature_extractor_context_destroy(fex_ctx);
+
         if (!feature_name) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,
                      "vmaf_predict_score_at_index(): could not generate "
@@ -264,8 +282,8 @@ int vmaf_predict_score_at_index(VmafModel *model,
 
         double feature_score;
         err = vmaf_feature_collector_get_score(feature_collector,
-                                               feature_name,
-                                               &feature_score, index);
+                                               feature_name, &feature_score,
+                                               index);
         free(feature_name);
 
         if (err) {


### PR DESCRIPTION
Small fix, prediction was failing when a feature extractor was overloaded with its default value. 