### PR TITLE
vif_filter1d_rd_8_avx512: fix inf loop with j = j++

### DIFF
--- a/libvmaf/src/feature/x86/vif_avx512.c
+++ b/libvmaf/src/feature/x86/vif_avx512.c
@@ -2022,7 +2022,7 @@ void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
             _mm256_storeu_si256((__m256i *)(buf.mu2 + i * stride + j), _mm512_castsi512_si256(result));
         }
 
-        for (unsigned j = n << 4; j < w; j = j++)
+        for (unsigned j = n << 4; j < w; ++j)
         {
             uint32_t accum_ref = 0;
             uint32_t accum_dis = 0;


### PR DESCRIPTION
Reproducible by running on a machine with avx512

```bash
curl -L "https://media.xiph.org/video/av2/y4m/AOV5_1920x1080_60_8bit_420.y4m" | ffmpeg -i - -s 458x214 -vframes 2 out.y4m

vmaf --reference out.y4m --distorted out.y4m --aom_ctc v1.0
```

clang on windows gives a warning of
```c
../libvmaf/src/feature/x86/vif_avx512.c:2025:47: warning: multiple unsequenced modifications to 'j' [-Wunsequenced]
        for (unsigned j = n << 4; j < w; j = j++)
                                           ~  ^
```