### PR TITLE
y4m_input: Add support for 422p10 y4m files

### DIFF
--- a/libvmaf/tools/y4m_input.c
+++ b/libvmaf/tools/y4m_input.c
@@ -611,6 +611,15 @@ static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
     _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
     _y4m->convert=y4m_convert_null;
   }
+  else if (strcmp(_y4m->chroma_type,"422p10")==0) {
+    _y4m->src_c_dec_h=_y4m->dst_c_dec_h=2;
+    _y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
+    _y4m->depth = 10;
+    _y4m->dst_buf_read_sz = 2*(_y4m->pic_w*_y4m->pic_h
+		    +2*((_y4m->pic_w+1)/2)*_y4m->pic_h);
+    _y4m->aux_buf_sz = _y4m->aux_buf_read_sz = 0;
+    _y4m->convert = y4m_convert_null;
+  }
   else if(strcmp(_y4m->chroma_type,"444p10")==0){
     _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
     _y4m->dst_buf_read_sz=_y4m->pic_w*_y4m->pic_h*3*2;


### PR DESCRIPTION
Earlier when we were trying to feed 422p10 files, vmaf did not support, with this patch it workss:) 
This is added based on how libaom handles of 422p10:
https://aomedia.googlesource.com/aom/+/28fe8d24fcd01cdaaf7e80ab6566df1f19ef6116/common/y4minput.c#1003