### PR TITLE
CAMBI: support 12-bit and 16-bit inputs by converting them to 10b

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -428,7 +428,49 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 }
 
 /* Preprocessing functions */
-static void decimate_generic_10b(const VmafPicture *pic, VmafPicture *out_pic, unsigned out_w, unsigned out_h) {
+
+// For bitdepths <= 8.
+static void decimate_generic_uint8_and_convert_to_10b(const VmafPicture *pic, VmafPicture *out_pic, unsigned out_w, unsigned out_h) {
+    uint8_t *data = pic->data[0];
+    uint16_t *out_data = out_pic->data[0];
+    ptrdiff_t stride = pic->stride[0];
+    ptrdiff_t out_stride = out_pic->stride[0] >> 1;
+    unsigned in_w = pic->w[0];
+    unsigned in_h = pic->h[0];
+
+    int shift_factor = 10 - pic->bpc;
+
+    // if the input and output sizes are the same
+    if (in_w == out_w && in_h == out_h){
+        for (unsigned i = 0; i < out_h; i++) {
+            for (unsigned j = 0; j < out_w; j++) {
+                out_data[i * out_stride + j] = data[i * stride + j] << shift_factor;
+            }
+        }
+        return;
+    }
+
+    float ratio_x = (float)in_w / out_w;
+    float ratio_y = (float)in_h / out_h;
+
+    float start_x = ratio_x / 2 - 0.5;
+    float start_y = ratio_y / 2 - 0.5;
+
+    float y = start_y;
+    for (unsigned i = 0; i < out_h; i++) {
+        unsigned ori_y = (int)(y + 0.5);
+        float x = start_x;
+        for (unsigned j = 0; j < out_w; j++) {
+            unsigned ori_x = (int)(x + 0.5);
+            out_data[i * out_stride + j] = data[ori_y * stride + ori_x] << shift_factor;
+            x += ratio_x;
+        }
+        y += ratio_y;
+    }
+}
+
+// For the special case of bitdepth 9, which doesn't fit into uint8_t but has to be upscaled to 10b.
+static void decimate_generic_9b_and_convert_to_10b(const VmafPicture *pic, VmafPicture *out_pic, unsigned out_w, unsigned out_h) {
     uint16_t *data = pic->data[0];
     uint16_t *out_data = out_pic->data[0];
     ptrdiff_t stride = pic->stride[0] >> 1;
@@ -437,8 +479,12 @@ static void decimate_generic_10b(const VmafPicture *pic, VmafPicture *out_pic, u
     unsigned in_h = pic->h[0];
 
     // if the input and output sizes are the same
-    if (in_w == out_w && in_h == out_h){
-        memcpy(out_data, data, stride * out_h * sizeof(uint16_t));
+    if (in_w == out_w && in_h == out_h) {
+        for (unsigned i = 0; i < out_h; i++) {
+            for (unsigned j = 0; j < out_w; j++) {
+                out_data[i * out_stride + j] = data[i * stride + j] << 1;
+            }
+        }
         return;
     }
 
@@ -454,26 +500,38 @@ static void decimate_generic_10b(const VmafPicture *pic, VmafPicture *out_pic, u
         float x = start_x;
         for (unsigned j = 0; j < out_w; j++) {
             unsigned ori_x = (int)(x + 0.5);
-            out_data[i * out_stride + j] = data[ori_y * stride + ori_x];
+            out_data[i * out_stride + j] = data[ori_y * stride + ori_x] << 1;
             x += ratio_x;
         }
         y += ratio_y;
     }
 }
 
-static void decimate_generic_8b_and_convert_to_10b(const VmafPicture *pic, VmafPicture *out_pic, unsigned out_w, unsigned out_h) {
-    uint8_t *data = pic->data[0];
+// For bitdepths >= 10.
+static void decimate_generic_uint16_and_convert_to_10b(const VmafPicture *pic, VmafPicture *out_pic, unsigned out_w, unsigned out_h) {
+    uint16_t *data = pic->data[0];
     uint16_t *out_data = out_pic->data[0];
-    ptrdiff_t stride = pic->stride[0];
+    ptrdiff_t stride = pic->stride[0] >> 1;
     ptrdiff_t out_stride = out_pic->stride[0] >> 1;
     unsigned in_w = pic->w[0];
     unsigned in_h = pic->h[0];
 
+    int shift_factor = pic->bpc - 10;
+    int rounding_offset = shift_factor == 0 ? 0 : 1 << (shift_factor - 1);
+
     // if the input and output sizes are the same
     if (in_w == out_w && in_h == out_h) {
-        for (unsigned i = 0; i < out_h; i++)
-            for (unsigned j = 0; j < out_w; j++)
-                out_data[i * out_stride + j] = data[i * stride + j] << 2;
+        if (pic->bpc == 10) {
+            // memcpy is faster in case the original bitdepth is already 10
+            memcpy(out_data, data, stride * pic->h[0] * sizeof(uint16_t));
+        }
+        else {
+            for (unsigned i = 0; i < out_h; i++) {
+                for (unsigned j = 0; j < out_w; j++) {
+                    out_data[i * out_stride + j] = (data[i * stride + j] + rounding_offset) >> shift_factor;
+                }
+            }
+        }
         return;
     }
 
@@ -489,7 +547,7 @@ static void decimate_generic_8b_and_convert_to_10b(const VmafPicture *pic, VmafP
         float x = start_x;
         for (unsigned j = 0; j < out_w; j++) {
             unsigned ori_x = (int)(x + 0.5);
-            out_data[i * out_stride + j] = data[ori_y * stride + ori_x] << 2;
+            out_data[i * out_stride + j] = (data[ori_y * stride + ori_x] + rounding_offset) >> shift_factor;
             x += ratio_x;
         }
         y += ratio_y;
@@ -523,14 +581,19 @@ static void anti_dithering_filter(VmafPicture *pic, unsigned width, unsigned hei
 }
 
 static int cambi_preprocessing(const VmafPicture *image, VmafPicture *preprocessed, int width, int height) {
-    if (image->bpc == 8) {
-        decimate_generic_8b_and_convert_to_10b(image, preprocessed, width, height);
-        anti_dithering_filter(preprocessed, width, height);
+    if (image->bpc >= 10) {
+        decimate_generic_uint16_and_convert_to_10b(image, preprocessed, width, height);
     }
     else {
-        decimate_generic_10b(image, preprocessed, width, height);
+        if (image->bpc <= 8) {
+            decimate_generic_uint8_and_convert_to_10b(image, preprocessed, width, height);
+        }
+        else {
+            decimate_generic_9b_and_convert_to_10b(image, preprocessed, width, height);
+        }
+        anti_dithering_filter(preprocessed, width, height);
     }
-
+    
     return 0;
 }
 

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -164,7 +164,8 @@ static char *test_decimate_generic()
     int err = vmaf_picture_alloc(&out_pic, VMAF_PIX_FMT_YUV400P, 10, 2, 2);
     (void)err;
 
-    decimate_generic_10b(&pic, &out_pic, out_pic.w[0], out_pic.h[0]);
+    pic.bpc = 10;
+    decimate_generic_uint16_and_convert_to_10b(&pic, &out_pic, out_pic.w[0], out_pic.h[0]);
 
     uint16_t *data = out_pic.data[0];
     ptrdiff_t stride = out_pic.stride[0] >> 1;
@@ -174,18 +175,44 @@ static char *test_decimate_generic()
     mu_assert("decimate generic 10b wrong pixel value (1,0)", data[stride]==2);
     mu_assert("decimate generic 10b wrong pixel value (1,1)", data[1+stride]==100);
 
+    pic.bpc = 16;
+    decimate_generic_uint16_and_convert_to_10b(&pic, &out_pic, out_pic.w[0], out_pic.h[0]);
+
+    mu_assert("decimate generic 16b wrong pixel value (0,0)", data[0]==0);
+    mu_assert("decimate generic 16b wrong pixel value (0,1)", data[1]==2);
+    mu_assert("decimate generic 16b wrong pixel value (1,0)", data[stride]==0);
+    mu_assert("decimate generic 16b wrong pixel value (1,1)", data[1+stride]==2);
+
+    pic.bpc = 12;
+    decimate_generic_uint16_and_convert_to_10b(&pic, &out_pic, out_pic.w[0], out_pic.h[0]);
+
+    mu_assert("decimate generic 12b wrong pixel value (0,0)", data[0]==1);
+    mu_assert("decimate generic 12b wrong pixel value (0,1)", data[1]==25);
+    mu_assert("decimate generic 12b wrong pixel value (1,0)", data[stride]==1);
+    mu_assert("decimate generic 12b wrong pixel value (1,1)", data[1+stride]==25);
+
+    pic.bpc = 9;
+    decimate_generic_9b_and_convert_to_10b(&pic, &out_pic, out_pic.w[0], out_pic.h[0]);
+
+    mu_assert("decimate generic 9b to 10b wrong pixel value (0,0)", data[0]==4);
+    mu_assert("decimate generic 9b to 10b wrong pixel value (0,1)", data[1]==200);
+    mu_assert("decimate generic 9b to 10b wrong pixel value (1,0)", data[stride]==4);
+    mu_assert("decimate generic 9b to 10b wrong pixel value (1,1)", data[1+stride]==200);
+
     VmafPicture out_pic_4x4;
     err = vmaf_picture_alloc(&out_pic_4x4, VMAF_PIX_FMT_YUV400P, 10, 4, 4);
     (void)err;
 
-    decimate_generic_10b(&pic, &out_pic_4x4, out_pic_4x4.w[0], out_pic_4x4.h[0]);
+    pic.bpc = 10;
+    decimate_generic_uint16_and_convert_to_10b(&pic, &out_pic_4x4, out_pic_4x4.w[0], out_pic_4x4.h[0]);
 
     mu_assert("decimate generic 10b wrong for same dimensions", pic_data_equality(&pic, &out_pic_4x4));
 
     VmafPicture pic_8b;
     get_sample_image_8b(&pic_8b);
 
-    decimate_generic_8b_and_convert_to_10b(&pic_8b, &out_pic, out_pic.w[0], out_pic.h[0]);
+    pic_8b.bpc = 8;
+    decimate_generic_uint8_and_convert_to_10b(&pic_8b, &out_pic, out_pic.w[0], out_pic.h[0]);
 
     mu_assert("decimate generic 8b to 10b wrong pixel value (0,0)", data[0]==8);
     mu_assert("decimate generic 8b to 10b wrong pixel value (0,1)", data[1]==400);

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -65,7 +65,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --width/-w $unsigned:      width\n"
             " --height/-h $unsigned:     height\n"
             " --pixel_format/-p: $string pixel format (420/422/444)\n"
-            " --bitdepth/-b $unsigned:   bitdepth (8/10/12)\n"
+            " --bitdepth/-b $unsigned:   bitdepth (8/10/12/16)\n"
             " --model/-m $params:        model parameters, colon \":\" delimited\n"
             "                            `path=` path to model file\n"
             "                            `version=` built-in model version\n"

--- a/resource/doc/cambi.md
+++ b/resource/doc/cambi.md
@@ -6,7 +6,9 @@ CAMBI (Contrast Aware Multiscale Banding Index) is Netflix's detector for bandin
 
 For an introduction to CAMBI, please refer to the [tech blog](https://netflixtechblog.medium.com/cambi-a-banding-artifact-detector-96777ae12fe2). For a detailed technical description, please refer to the [technical paper](papers/CAMBI_PCS2021.pdf) published at PCS 2021. Note that the paper describes an initial version of CAMBI that no longer matches the code exactly, but it is still a good introduction.
 
-The current version of CAMBI is a [no-reference metric](https://en.wikipedia.org/wiki/Video_quality#Classification_of_objective_video_quality_models), and operates on a frame-by-frame basis (no temporal information is leveraged). To integrate it as part of the VMAF framework, which employs a [full-reference metric](https://en.wikipedia.org/wiki/Video_quality#Classification_of_objective_video_quality_models) API, CAMBI takes both a reference and a distorted video as its input. For simplicity, one can point the input arguments `--reference` and `--distorted` to the same video path.
+By default, the current version of CAMBI is a [no-reference metric](https://en.wikipedia.org/wiki/Video_quality#Classification_of_objective_video_quality_models), and operates on a frame-by-frame basis (no temporal information is leveraged). To integrate it as part of the VMAF framework, which employs a [full-reference metric](https://en.wikipedia.org/wiki/Video_quality#Classification_of_objective_video_quality_models) API, CAMBI takes both a reference and a distorted video as its input. For simplicity, one can point the input arguments `--reference` and `--distorted` to the same video path. 
+
+CAMBI also offers a full-reference mode which computes its score as `MAX(0, distorted_score - reference_score)`. This mode can be activated with the `--full_ref` command line option. In this case, both the `--reference` and `--distorted` inputs will be used.
 
 ## Scores
 
@@ -42,6 +44,10 @@ This will yield the output:
   <aggregate_metrics />
 </VMAF>
 ```
+
+## Bit depths
+
+CAMBI supports the same input bit depths as VMAF: 8, 10, 12 and 16. However, the computations in CAMBI will always be performed at the 10-bit level, and the other formats will be converted to 10-bit as a preprocessing step.
 
 ## Options
 


### PR DESCRIPTION
CAMBI previously supported 8-bit and 10-bit inputs. This PR adds support for 12-bit and 16-bit inputs. Internally, CAMBI still works at the 10-bit level, and the inputs are upscaled/downscaled appropriately in the preprocessing steps.

Added unit tests to cover these cases, also manually upscaled a 10b video to 12b and 16b and the results were identical.

This PR refactors the upscaling/downscaling code into two functions, one to handle the case where the input is given as `uint8` and the other for `uint16`.