### PR TITLE
Factor EOTF out of CAMBI

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -333,7 +333,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 
     set_contrast_arrays(num_diffs, &g_diffs_to_consider, &g_diffs_weights, &g_all_diffs);
 
-    LumaRange luma_range = LumaRange_init(10, "standard");
+    LumaRange luma_range = LumaRange_init(10, LIMITED);
 
     s->tvi_for_diff = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
     if(!s->tvi_for_diff) return -ENOMEM;

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -228,9 +228,9 @@ static enum CambiTVIBisectFlag tvi_hard_threshold_condition(int sample, int diff
     return CAMBI_TVI_BISECT_CORRECT;
 }
 
-static int get_tvi_for_diff(int diff, double tvi_threshold, LumaRange luma_range, EOTF eotf) {
+static int get_tvi_for_diff(int diff, double tvi_threshold, int bitdepth, LumaRange luma_range, EOTF eotf) {
     enum CambiTVIBisectFlag tvi_bisect;
-    const int max_val = (1 << luma_range.bitdepth) - 1;
+    const int max_val = (1 << bitdepth) - 1;
 
     int foot = luma_range.foot;
     int head = luma_range.head;
@@ -338,7 +338,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->tvi_for_diff = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
     if(!s->tvi_for_diff) return -ENOMEM;
     for (int d = 0; d < num_diffs; d++) {
-        s->tvi_for_diff[d] = get_tvi_for_diff(g_diffs_to_consider[d], s->tvi_threshold, luma_range, bt1886_eotf);
+        s->tvi_for_diff[d] = get_tvi_for_diff(g_diffs_to_consider[d], s->tvi_threshold, 10, luma_range, bt1886_eotf);
         s->tvi_for_diff[d] += num_diffs;
     }
 

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -58,7 +58,6 @@ inline void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *
 
 LumaRange LumaRange_init(int bitdepth, PixelRange pix_range) {
     LumaRange luma_range;
-    luma_range.bitdepth = bitdepth;
     range_foot_head(bitdepth, pix_range, &luma_range.foot, &luma_range.head);
     return luma_range;
 }

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -17,7 +17,6 @@
  */
 
 #include <math.h>
-#include <string.h>
 
 #include "luminance_tools.h"
 
@@ -44,18 +43,20 @@ inline double bt1886_eotf(double V) {
  * Full range for 8 bit: [0, 255]
  * Full range for 10 bit: [0, 1023]
  */
-inline void range_foot_head(int bitdepth, const char *pix_range, int *foot, int *head) {
-    if (!strcmp(pix_range, "standard")) {
-        *foot = 16 * (1 << (bitdepth - 8));
-        *head = 235 * (1 << (bitdepth - 8));
-    }
-    else {
-        *foot = 0;
-        *head = (1 << bitdepth) - 1;
+inline void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head) {
+    switch (pix_range) {
+        case LIMITED:
+            *foot = 16 * (1 << (bitdepth - 8));
+            *head = 235 * (1 << (bitdepth - 8));
+            break;
+        case FULL:
+            *foot = 0;
+            *head = (1 << bitdepth) - 1;
+            break;
     }
 }
 
-LumaRange LumaRange_init(int bitdepth, const char *pix_range) {
+LumaRange LumaRange_init(int bitdepth, PixelRange pix_range) {
     LumaRange luma_range;
     luma_range.bitdepth = bitdepth;
     range_foot_head(bitdepth, pix_range, &luma_range.foot, &luma_range.head);

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -1,0 +1,34 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <math.h>
+
+#include "luminance_tools.h"
+
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+#define BT1886_GAMMA (2.4)
+#define BT1886_LW (300.0)
+#define BT1886_LB (0.01)
+
+inline double bt1886_eotf(double V) {
+    double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
+    double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
+    double L = a * pow(MAX(V + b, 0), BT1886_GAMMA);
+    return L;
+}

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -17,6 +17,7 @@
  */
 
 #include <math.h>
+#include <string.h>
 
 #include "luminance_tools.h"
 
@@ -26,9 +27,47 @@
 #define BT1886_LW (300.0)
 #define BT1886_LB (0.01)
 
+static inline int clip(int value, int low, int high) {
+    return value < low ? low : (value > high ? high : value);
+}
+
 inline double bt1886_eotf(double V) {
     double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
     double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
     double L = a * pow(MAX(V + b, 0), BT1886_GAMMA);
     return L;
+}
+
+/*
+ * Standard range for 8 bit: [16, 235]
+ * Standard range for 10 bit: [64, 940]
+ * Full range for 8 bit: [0, 255]
+ * Full range for 10 bit: [0, 1023]
+ */
+inline void range_foot_head(int bitdepth, const char *pix_range, int *foot, int *head) {
+    if (!strcmp(pix_range, "standard")) {
+        *foot = 16 * (1 << (bitdepth - 8));
+        *head = 235 * (1 << (bitdepth - 8));
+    }
+    else {
+        *foot = 0;
+        *head = (1 << bitdepth) - 1;
+    }
+}
+
+LumaRange LumaRange_init(int bitdepth, const char *pix_range) {
+    LumaRange luma_range;
+    luma_range.bitdepth = bitdepth;
+    range_foot_head(bitdepth, pix_range, &luma_range.foot, &luma_range.head);
+    return luma_range;
+}
+
+inline double normalize_range(int sample, LumaRange range) {
+    int clipped_sample = clip(sample, range.foot, range.head);
+    return (double)(clipped_sample - range.foot) / (range.head - range.foot);
+}
+
+inline double get_luminance(int sample, LumaRange luma_range, EOTF eotf) {
+    double normalized = normalize_range(sample, luma_range);
+    return eotf(normalized);
 }

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -1,0 +1,24 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef LUMINANCE_TOOLS_H_
+#define LUMINANCE_TOOLS_H_
+
+double bt1886_eotf(double V);
+
+#endif

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -21,6 +21,20 @@
 
 typedef double (*EOTF)(double V);
 
+typedef struct LumaRange {
+    int bitdepth;
+    int foot;
+    int head;
+} LumaRange;
+
+LumaRange LumaRange_init(int bitdepth, const char *pix_range);
+
+void range_foot_head(int bitdepth, const char *pix_range, int *foot, int *head);
+
+double normalize_range(int sample, LumaRange range);
+
 double bt1886_eotf(double V);
+
+double get_luminance(int sample, LumaRange luma_range, EOTF eotf);
 
 #endif

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -35,7 +35,6 @@ typedef enum  {
  * Contains the necessary information to normalize a luma value down to [0, 1].
  */
 typedef struct LumaRange {
-    int bitdepth;
     int foot;
     int head;
 } LumaRange;

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -21,15 +21,20 @@
 
 typedef double (*EOTF)(double V);
 
+typedef enum  {
+    LIMITED,
+    FULL,
+} PixelRange;
+
 typedef struct LumaRange {
     int bitdepth;
     int foot;
     int head;
 } LumaRange;
 
-LumaRange LumaRange_init(int bitdepth, const char *pix_range);
+LumaRange LumaRange_init(int bitdepth, PixelRange pix_range);
 
-void range_foot_head(int bitdepth, const char *pix_range, int *foot, int *head);
+void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head);
 
 double normalize_range(int sample, LumaRange range);
 

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -21,25 +21,49 @@
 
 typedef double (*EOTF)(double V);
 
+/*
+ * Limited pixel range means that only values between 16 and 235 will be used in 8 bits
+ * (rescale the bounds appropriately for other bitdepths).
+ * Full pixel range means that values from 0 to 2^bitdepth - 1 will be used.
+ */
 typedef enum  {
     LIMITED,
     FULL,
 } PixelRange;
 
+/*
+ * Contains the necessary information to normalize a luma value down to [0, 1].
+ */
 typedef struct LumaRange {
     int bitdepth;
     int foot;
     int head;
 } LumaRange;
 
+/*
+ * Constructor for the LumaRange struct.
+ */
 LumaRange LumaRange_init(int bitdepth, PixelRange pix_range);
 
+/*
+ * Determines the lowest and highest value possible for a given bitdepth and PixelRange.
+ * Is used in the constructor for LumaRange, not to be used directly.
+ */
 void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head);
 
+/*
+ * Takes a luma value and a LumaRange struct and returns a normalized value in the [0, 1] range.
+ */
 double normalize_range(int sample, LumaRange range);
 
+/*
+ * Takes a normalized luma value in the [0, 1] range and returns a luminance value.
+ */
 double bt1886_eotf(double V);
 
+/*
+ * Takes a luma value, normalizes it and applies the given EOTF to return a luminance value.
+ */
 double get_luminance(int sample, LumaRange luma_range, EOTF eotf);
 
 #endif

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -19,6 +19,8 @@
 #ifndef LUMINANCE_TOOLS_H_
 #define LUMINANCE_TOOLS_H_
 
+typedef double (*EOTF)(double V);
+
 double bt1886_eotf(double V);
 
 #endif

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -246,6 +246,7 @@ libvmaf_feature_sources = [
     feature_src_dir + 'iqa/math_utils.c',
     feature_src_dir + 'iqa/convolve.c',
     feature_src_dir + 'cambi.c',
+    feature_src_dir + 'luminance_tools.c',
 ]
 
 if float_enabled

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -99,6 +99,12 @@ test_cambi = executable('test_cambi',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
 )
 
+test_luminance_tools = executable('test_luminance_tools',
+    ['test.c', 'test_luminance_tools.c', '../src/feature/luminance_tools.c'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+)
+
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
 test('test_thread_pool', test_thread_pool)
@@ -111,3 +117,4 @@ test('test_ref', test_ref)
 test('test_feature', test_feature)
 test('test_ciede', test_ciede)
 test('test_cambi', test_cambi)
+test('test_luminance_tools', test_luminance_tools)

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -449,13 +449,13 @@ static char *test_get_tvi_for_diff()
 {
     LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
     
-    int tvi = get_tvi_for_diff(1, 0.019, range_10b_limited, bt1886_eotf);
+    int tvi = get_tvi_for_diff(1, 0.019, 10, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(2, 0.019, 10, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(3, 0.019, 10, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(4, 0.019, 10, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
     return NULL;

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,30 +447,35 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    int tvi = get_tvi_for_diff(1, 0.019, 10, "standard", bt1886_eotf);
+    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    
+    int tvi = get_tvi_for_diff(1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, 10, "standard", bt1886_eotf);
+    tvi = get_tvi_for_diff(2, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, 10, "standard", bt1886_eotf);
+    tvi = get_tvi_for_diff(3, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, 10, "standard", bt1886_eotf);
+    tvi = get_tvi_for_diff(4, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
     return NULL;
 }
 
+
 static char *test_tvi_condition()
 {
+    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+
     bool condition;
-    condition = tvi_condition(177, 1, 0.019, 10, "standard", bt1886_eotf);
+    condition = tvi_condition(177, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(178, 1, 0.019, 10, "standard", bt1886_eotf);
+    condition = tvi_condition(178, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(179, 1, 0.019, 10, "standard", bt1886_eotf);
+    condition = tvi_condition(179, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", !condition);
-    condition = tvi_condition(935, 4, 0.01, 10, "standard", bt1886_eotf);
+    condition = tvi_condition(935, 4, 0.01, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
-    condition = tvi_condition(936, 4, 0.01, 10, "standard", bt1886_eotf);
+    condition = tvi_condition(936, 4, 0.01, range_10b_standard, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
     return NULL;
 }
@@ -534,64 +539,19 @@ static char *test_set_contrast_arrays()
 
 static char *test_tvi_hard_threshold_condition()
 {
+    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+
     enum CambiTVIBisectFlag result;
-    result = tvi_hard_threshold_condition(177, 1, 0.019, 10, "standard", bt1886_eotf);
+    result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_SMALL);
-    result = tvi_hard_threshold_condition(178, 1, 0.019, 10, "standard", bt1886_eotf);
+    result = tvi_hard_threshold_condition(178, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_CORRECT);
-    result = tvi_hard_threshold_condition(179, 1, 0.019, 10, "standard", bt1886_eotf);
+    result = tvi_hard_threshold_condition(179, 1, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_BIG);
-    result = tvi_hard_threshold_condition(305, 2, 0.019, 10, "standard", bt1886_eotf);
+    result = tvi_hard_threshold_condition(305, 2, 0.019, range_10b_standard, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=2", result==CAMBI_TVI_BISECT_CORRECT);
     return NULL;
 }
-
-static char *test_get_luminance()
-{
-    double L;
-    L = get_luminance(100, 8, "standard", bt1886_eotf);
-    mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = get_luminance(400, 10, "standard", bt1886_eotf);
-    mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = get_luminance(400, 10, "full", bt1886_eotf);
-    mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.359349208106764));
-
-    return NULL;
-}
-
-static char *test_normalize_range()
-{
-    double n = normalize_range(0, 8, "full");
-    mu_assert("wrong 'full' 8b normalize range", almost_equal(n, 0.0));
-    n = normalize_range(128, 8, "standard");
-    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 0.5114155251141552));
-    n = normalize_range(255, 8, "standard");
-    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 1.0));
-
-    n = normalize_range(65, 10, "standard");
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.001141552511415525));
-    n = normalize_range(512, 10, "standard");
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.5114155251141552));
-    n = normalize_range(939, 10, "standard");
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.9988584474885844));
-
-    return NULL;
-}
-
-static char *test_range_foot_head()
-{
-    int foot, head;
-
-    range_foot_head(8, "standard", &foot, &head);
-    mu_assert("wrong 'standard' 8b range computation", (foot==16 && head==235));
-    range_foot_head(8, "full", &foot, &head);
-    mu_assert("wrong 'full' 8b range computation", (foot==0 && head==255));
-    range_foot_head(10, "standard", &foot, &head);
-    mu_assert("wrong 'standard' 10b range computation", (foot==64 && head==940));
-
-    return NULL;
-}
-
 
 char *run_tests()
 {
@@ -622,9 +582,6 @@ char *run_tests()
     mu_run_test(test_tvi_condition);
     mu_run_test(test_set_contrast_arrays);
     mu_run_test(test_tvi_hard_threshold_condition);
-    mu_run_test(test_get_luminance);
-    mu_run_test(test_normalize_range);
-    mu_run_test(test_range_foot_head);
 
     return NULL;
 }

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,40 +447,30 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    int tvi = get_tvi_for_diff(1, 0.019, 10, 300.0, 0.01, "standard");
+    int tvi = get_tvi_for_diff(1, 0.019, 10, "standard");
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, 10, 300.0, 0.01, "standard");
+    tvi = get_tvi_for_diff(2, 0.019, 10, "standard");
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, 10, 300.0, 0.01, "standard");
+    tvi = get_tvi_for_diff(3, 0.019, 10, "standard");
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, 10, 300.0, 0.01, "standard");
+    tvi = get_tvi_for_diff(4, 0.019, 10, "standard");
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
-    tvi = get_tvi_for_diff(1, 0.01, 10, 200.0, 0.02, "standard");
-    mu_assert("tvi_for_diff 1, non-default params", tvi==285);
-    tvi = get_tvi_for_diff(2, 0.01, 10, 200.0, 0.02, "standard");
-    mu_assert("tvi_for_diff 2, non-default params", tvi==526);
-
-    tvi = get_tvi_for_diff(2, 0.01, 8, 200.0, 0.02, "standard");
-    mu_assert("tvi_for_diff 2, bd=8, limit 255", tvi==255);
-
-    tvi = get_tvi_for_diff(4, 0.01, 10, 200.0, 0.02, "standard");
-    mu_assert("tvi_for_diff 4, bd=10, limit 1023", tvi==1023);
     return NULL;
 }
 
 static char *test_tvi_condition()
 {
     bool condition;
-    condition = tvi_condition(177, 1, 0.019, 10, 300.0, 0.01, "standard");
+    condition = tvi_condition(177, 1, 0.019, 10, "standard");
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(178, 1, 0.019, 10, 300.0, 0.01, "standard");
+    condition = tvi_condition(178, 1, 0.019, 10, "standard");
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(179, 1, 0.019, 10, 300.0, 0.01, "standard");
+    condition = tvi_condition(179, 1, 0.019, 10, "standard");
     mu_assert("tvi_condition for bitdepth 10 and diff 4", !condition);
-    condition = tvi_condition(935, 4, 0.01, 10, 200.0, 0.02, "standard");
+    condition = tvi_condition(935, 4, 0.01, 10, "standard");
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
-    condition = tvi_condition(936, 4, 0.01, 10, 200.0, 0.02, "standard");
+    condition = tvi_condition(936, 4, 0.01, 10, "standard");
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
     return NULL;
 }
@@ -545,13 +535,13 @@ static char *test_set_contrast_arrays()
 static char *test_tvi_hard_threshold_condition()
 {
     enum CambiTVIBisectFlag result;
-    result = tvi_hard_threshold_condition(177, 1, 0.019, 10, 300.0, 0.01, "standard");
+    result = tvi_hard_threshold_condition(177, 1, 0.019, 10, "standard");
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_SMALL);
-    result = tvi_hard_threshold_condition(178, 1, 0.019, 10, 300.0, 0.01, "standard");
+    result = tvi_hard_threshold_condition(178, 1, 0.019, 10, "standard");
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_CORRECT);
-    result = tvi_hard_threshold_condition(179, 1, 0.019, 10, 300.0, 0.01, "standard");
+    result = tvi_hard_threshold_condition(179, 1, 0.019, 10, "standard");
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_BIG);
-    result = tvi_hard_threshold_condition(305, 2, 0.019, 10, 300.0, 0.01, "standard");
+    result = tvi_hard_threshold_condition(305, 2, 0.019, 10, "standard");
     mu_assert("hard threshold error for bd=10 and diff=2", result==CAMBI_TVI_BISECT_CORRECT);
     return NULL;
 }
@@ -559,16 +549,12 @@ static char *test_tvi_hard_threshold_condition()
 static char *test_luminance_bt1886()
 {
     double L;
-    L = luminance_bt1886(100, 8, 100.0, 0.005, "standard");
-    mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 10.663418019592129));
-    L = luminance_bt1886(100, 8, 300.0, 0.01, "standard");
+    L = luminance_bt1886(100, 8, "standard");
     mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = luminance_bt1886(400, 10, 100.0, 0.005, "standard");
-    mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 10.663418019592129));
-    L = luminance_bt1886(400, 10, 300.0, 0.01, "standard");
+    L = luminance_bt1886(400, 10, "standard");
     mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = luminance_bt1886(400, 10, 100.0, 0.005, "full");
-    mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 11.221687443343862));
+    L = luminance_bt1886(400, 10, "full");
+    mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.359349208106764));
 
     return NULL;
 }
@@ -588,18 +574,6 @@ static char *test_normalize_range()
     mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.5114155251141552));
     n = normalize_range(939, 10, "standard");
     mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.9988584474885844));
-
-    return NULL;
-}
-
-static char *test_bt1886_eotf()
-{
-    double L = bt1886_eotf(0.5, 2.4, 1.0, 0.0);
-    mu_assert("wrong bt1886_eotf result", almost_equal(L, 0.18946457081379978));
-    L = bt1886_eotf(0.5, 2.0, 1.0, 0.0);
-    mu_assert("wrong bt1886_eotf result", almost_equal(L, 0.25));
-    L = bt1886_eotf(0.2, 2.0, 1.0, 0.0);
-    mu_assert("wrong bt1886_eotf result", almost_equal(L, 0.04));
 
     return NULL;
 }
@@ -650,7 +624,6 @@ char *run_tests()
     mu_run_test(test_tvi_hard_threshold_condition);
     mu_run_test(test_luminance_bt1886);
     mu_run_test(test_normalize_range);
-    mu_run_test(test_bt1886_eotf);
     mu_run_test(test_range_foot_head);
 
     return NULL;

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,13 +447,13 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    int tvi = get_tvi_for_diff(1, 0.019, 10, "standard");
+    int tvi = get_tvi_for_diff(1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, 10, "standard");
+    tvi = get_tvi_for_diff(2, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, 10, "standard");
+    tvi = get_tvi_for_diff(3, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, 10, "standard");
+    tvi = get_tvi_for_diff(4, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
     return NULL;
@@ -462,15 +462,15 @@ static char *test_get_tvi_for_diff()
 static char *test_tvi_condition()
 {
     bool condition;
-    condition = tvi_condition(177, 1, 0.019, 10, "standard");
+    condition = tvi_condition(177, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(178, 1, 0.019, 10, "standard");
+    condition = tvi_condition(178, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(179, 1, 0.019, 10, "standard");
+    condition = tvi_condition(179, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", !condition);
-    condition = tvi_condition(935, 4, 0.01, 10, "standard");
+    condition = tvi_condition(935, 4, 0.01, 10, "standard", bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
-    condition = tvi_condition(936, 4, 0.01, 10, "standard");
+    condition = tvi_condition(936, 4, 0.01, 10, "standard", bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
     return NULL;
 }
@@ -535,25 +535,25 @@ static char *test_set_contrast_arrays()
 static char *test_tvi_hard_threshold_condition()
 {
     enum CambiTVIBisectFlag result;
-    result = tvi_hard_threshold_condition(177, 1, 0.019, 10, "standard");
+    result = tvi_hard_threshold_condition(177, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_SMALL);
-    result = tvi_hard_threshold_condition(178, 1, 0.019, 10, "standard");
+    result = tvi_hard_threshold_condition(178, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_CORRECT);
-    result = tvi_hard_threshold_condition(179, 1, 0.019, 10, "standard");
+    result = tvi_hard_threshold_condition(179, 1, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_BIG);
-    result = tvi_hard_threshold_condition(305, 2, 0.019, 10, "standard");
+    result = tvi_hard_threshold_condition(305, 2, 0.019, 10, "standard", bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=2", result==CAMBI_TVI_BISECT_CORRECT);
     return NULL;
 }
 
-static char *test_luminance_bt1886()
+static char *test_get_luminance()
 {
     double L;
-    L = luminance_bt1886(100, 8, "standard");
+    L = get_luminance(100, 8, "standard", bt1886_eotf);
     mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = luminance_bt1886(400, 10, "standard");
+    L = get_luminance(400, 10, "standard", bt1886_eotf);
     mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = luminance_bt1886(400, 10, "full");
+    L = get_luminance(400, 10, "full", bt1886_eotf);
     mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.359349208106764));
 
     return NULL;
@@ -622,7 +622,7 @@ char *run_tests()
     mu_run_test(test_tvi_condition);
     mu_run_test(test_set_contrast_arrays);
     mu_run_test(test_tvi_hard_threshold_condition);
-    mu_run_test(test_luminance_bt1886);
+    mu_run_test(test_get_luminance);
     mu_run_test(test_normalize_range);
     mu_run_test(test_range_foot_head);
 

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,15 +447,15 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
     
-    int tvi = get_tvi_for_diff(1, 0.019, range_10b_standard, bt1886_eotf);
+    int tvi = get_tvi_for_diff(1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, range_10b_standard, bt1886_eotf);
+    tvi = get_tvi_for_diff(2, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, range_10b_standard, bt1886_eotf);
+    tvi = get_tvi_for_diff(3, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, range_10b_standard, bt1886_eotf);
+    tvi = get_tvi_for_diff(4, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
     return NULL;
@@ -464,18 +464,18 @@ static char *test_get_tvi_for_diff()
 
 static char *test_tvi_condition()
 {
-    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
 
     bool condition;
-    condition = tvi_condition(177, 1, 0.019, range_10b_standard, bt1886_eotf);
+    condition = tvi_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(178, 1, 0.019, range_10b_standard, bt1886_eotf);
+    condition = tvi_condition(178, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(179, 1, 0.019, range_10b_standard, bt1886_eotf);
+    condition = tvi_condition(179, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", !condition);
-    condition = tvi_condition(935, 4, 0.01, range_10b_standard, bt1886_eotf);
+    condition = tvi_condition(935, 4, 0.01, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
-    condition = tvi_condition(936, 4, 0.01, range_10b_standard, bt1886_eotf);
+    condition = tvi_condition(936, 4, 0.01, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
     return NULL;
 }
@@ -539,16 +539,16 @@ static char *test_set_contrast_arrays()
 
 static char *test_tvi_hard_threshold_condition()
 {
-    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
 
     enum CambiTVIBisectFlag result;
-    result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_standard, bt1886_eotf);
+    result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_SMALL);
-    result = tvi_hard_threshold_condition(178, 1, 0.019, range_10b_standard, bt1886_eotf);
+    result = tvi_hard_threshold_condition(178, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_CORRECT);
-    result = tvi_hard_threshold_condition(179, 1, 0.019, range_10b_standard, bt1886_eotf);
+    result = tvi_hard_threshold_condition(179, 1, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_BIG);
-    result = tvi_hard_threshold_condition(305, 2, 0.019, range_10b_standard, bt1886_eotf);
+    result = tvi_hard_threshold_condition(305, 2, 0.019, range_10b_limited, bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=2", result==CAMBI_TVI_BISECT_CORRECT);
     return NULL;
 }

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -17,7 +17,6 @@
  */
 
 #include "test.h"
-#include "ref.h"
 #include "feature/luminance_tools.h"
 
 #define EPS 0.00001
@@ -45,27 +44,27 @@ static char *test_range_foot_head()
 {
     int foot, head;
 
-    range_foot_head(8, "standard", &foot, &head);
-    mu_assert("wrong 'standard' 8b range computation", (foot==16 && head==235));
-    range_foot_head(8, "full", &foot, &head);
+    range_foot_head(8, LIMITED, &foot, &head);
+    mu_assert("wrong 'limited' 8b range computation", (foot==16 && head==235));
+    range_foot_head(8, FULL, &foot, &head);
     mu_assert("wrong 'full' 8b range computation", (foot==0 && head==255));
-    range_foot_head(10, "standard", &foot, &head);
-    mu_assert("wrong 'standard' 10b range computation", (foot==64 && head==940));
+    range_foot_head(10, LIMITED, &foot, &head);
+    mu_assert("wrong 'limited' 10b range computation", (foot==64 && head==940));
 
     return NULL;
 }
 
 static char *test_get_luminance()
 {
-    LumaRange range_8b_standard = LumaRange_init(8, "standard");
-    LumaRange range_10b_standard = LumaRange_init(10, "standard");
-    LumaRange range_10b_full = LumaRange_init(10, "full");
+    LumaRange range_8b_limited = LumaRange_init(8, LIMITED);
+    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
+    LumaRange range_10b_full = LumaRange_init(10, FULL);
 
     double L;
-    L = get_luminance(100, range_8b_standard, bt1886_eotf);
-    mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = get_luminance(400, range_10b_standard, bt1886_eotf);
-    mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
+    L = get_luminance(100, range_8b_limited, bt1886_eotf);
+    mu_assert("wrong 'limited' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
+    L = get_luminance(400, range_10b_limited, bt1886_eotf);
+    mu_assert("wrong 'limited' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
     L = get_luminance(400, range_10b_full, bt1886_eotf);
     printf("%.15lf\n", L);
     mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.133003757557773));
@@ -75,23 +74,23 @@ static char *test_get_luminance()
 
 static char *test_normalize_range()
 {
-    LumaRange range_8b_standard = LumaRange_init(8, "standard");
-    LumaRange range_8b_full = LumaRange_init(8, "full");
-    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    LumaRange range_8b_limited = LumaRange_init(8, LIMITED);
+    LumaRange range_8b_full = LumaRange_init(8, FULL);
+    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
 
     double n = normalize_range(0, range_8b_full);
     mu_assert("wrong 'full' 8b normalize range", almost_equal(n, 0.0));
-    n = normalize_range(128, range_8b_standard);
-    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 0.5114155251141552));
-    n = normalize_range(255, range_8b_standard);
-    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 1.0));
+    n = normalize_range(128, range_8b_limited);
+    mu_assert("wrong 'limited' 8b normalize range", almost_equal(n, 0.5114155251141552));
+    n = normalize_range(255, range_8b_limited);
+    mu_assert("wrong 'limited' 8b normalize range", almost_equal(n, 1.0));
 
-    n = normalize_range(65, range_10b_standard);
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.001141552511415525));
-    n = normalize_range(512, range_10b_standard);
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.5114155251141552));
-    n = normalize_range(939, range_10b_standard);
-    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.9988584474885844));
+    n = normalize_range(65, range_10b_limited);
+    mu_assert("wrong 'limited' 10b normalize range", almost_equal(n, 0.001141552511415525));
+    n = normalize_range(512, range_10b_limited);
+    mu_assert("wrong 'limited' 10b normalize range", almost_equal(n, 0.5114155251141552));
+    n = normalize_range(939, range_10b_limited);
+    mu_assert("wrong 'limited' 10b normalize range", almost_equal(n, 0.9988584474885844));
 
     return NULL;
 }

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -41,9 +41,67 @@ static char *test_bt1886_eotf()
     return NULL;
 }
 
+static char *test_range_foot_head()
+{
+    int foot, head;
+
+    range_foot_head(8, "standard", &foot, &head);
+    mu_assert("wrong 'standard' 8b range computation", (foot==16 && head==235));
+    range_foot_head(8, "full", &foot, &head);
+    mu_assert("wrong 'full' 8b range computation", (foot==0 && head==255));
+    range_foot_head(10, "standard", &foot, &head);
+    mu_assert("wrong 'standard' 10b range computation", (foot==64 && head==940));
+
+    return NULL;
+}
+
+static char *test_get_luminance()
+{
+    LumaRange range_8b_standard = LumaRange_init(8, "standard");
+    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+    LumaRange range_10b_full = LumaRange_init(10, "full");
+
+    double L;
+    L = get_luminance(100, range_8b_standard, bt1886_eotf);
+    mu_assert("wrong 'standard' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
+    L = get_luminance(400, range_10b_standard, bt1886_eotf);
+    mu_assert("wrong 'standard' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
+    L = get_luminance(400, range_10b_full, bt1886_eotf);
+    printf("%.15lf\n", L);
+    mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.133003757557773));
+
+    return NULL;
+}
+
+static char *test_normalize_range()
+{
+    LumaRange range_8b_standard = LumaRange_init(8, "standard");
+    LumaRange range_8b_full = LumaRange_init(8, "full");
+    LumaRange range_10b_standard = LumaRange_init(10, "standard");
+
+    double n = normalize_range(0, range_8b_full);
+    mu_assert("wrong 'full' 8b normalize range", almost_equal(n, 0.0));
+    n = normalize_range(128, range_8b_standard);
+    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 0.5114155251141552));
+    n = normalize_range(255, range_8b_standard);
+    mu_assert("wrong 'standard' 8b normalize range", almost_equal(n, 1.0));
+
+    n = normalize_range(65, range_10b_standard);
+    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.001141552511415525));
+    n = normalize_range(512, range_10b_standard);
+    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.5114155251141552));
+    n = normalize_range(939, range_10b_standard);
+    mu_assert("wrong 'standard' 10b normalize range", almost_equal(n, 0.9988584474885844));
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_bt1886_eotf);
+    mu_run_test(test_range_foot_head);
+    mu_run_test(test_get_luminance);
+    mu_run_test(test_normalize_range);
 
     return NULL;
 }

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -1,0 +1,49 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "test.h"
+#include "ref.h"
+#include "feature/luminance_tools.h"
+
+#define EPS 0.00001
+
+/* Test support function */
+int almost_equal(double a, double b)
+{
+    double diff = a > b ? a - b : b - a;
+    return diff < EPS;
+}
+
+static char *test_bt1886_eotf()
+{
+    double L = bt1886_eotf(0.5);
+    mu_assert("wrong bt1886_eotf result", almost_equal(L, 58.716634));
+    L = bt1886_eotf(0.1);
+    mu_assert("wrong bt1886_eotf result", almost_equal(L, 1.576653));
+    L = bt1886_eotf(0.9);
+    mu_assert("wrong bt1886_eotf result", almost_equal(L, 233.819503));
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_bt1886_eotf);
+
+    return NULL;
+}


### PR DESCRIPTION
Since we want to use EOTFs outside of CAMBI, this PR factors out the EOTF functions into a separate file where they can be accessed by other features as well.