### PR TITLE
More explicit names for enum types VMAF_PIXEL_RANGE_*

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -333,7 +333,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 
     set_contrast_arrays(num_diffs, &g_diffs_to_consider, &g_diffs_weights, &g_all_diffs);
 
-    LumaRange luma_range = LumaRange_init(10, LIMITED);
+    LumaRange luma_range = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
 
     s->tvi_for_diff = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
     if(!s->tvi_for_diff) return -ENOMEM;

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -16,8 +16,10 @@
  *
  */
 
+#include <errno.h>
 #include <math.h>
 
+#include "log.h"
 #include "luminance_tools.h"
 
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
@@ -30,44 +32,47 @@ static inline int clip(int value, int low, int high) {
     return value < low ? low : (value > high ? high : value);
 }
 
-inline double bt1886_eotf(double V) {
-    double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
-    double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
-    double L = a * pow(MAX(V + b, 0), BT1886_GAMMA);
-    return L;
-}
-
 /*
  * Standard range for 8 bit: [16, 235]
  * Standard range for 10 bit: [64, 940]
  * Full range for 8 bit: [0, 255]
  * Full range for 10 bit: [0, 1023]
  */
-inline void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head) {
+static inline int range_foot_head(int bitdepth, enum VmafPixelRange pix_range, int *foot, int *head) {
     switch (pix_range) {
-        case VMAF_PIXEL_RANGE_LIMITED:
-            *foot = 16 * (1 << (bitdepth - 8));
-            *head = 235 * (1 << (bitdepth - 8));
-            break;
-        case VMAF_PIXEL_RANGE_FULL:
-            *foot = 0;
-            *head = (1 << bitdepth) - 1;
-            break;
+    case VMAF_PIXEL_RANGE_LIMITED:
+        *foot = 16 * (1 << (bitdepth - 8));
+        *head = 235 * (1 << (bitdepth - 8));
+        break;
+    case VMAF_PIXEL_RANGE_FULL:
+        *foot = 0;
+        *head = (1 << bitdepth) - 1;
+        break;
+    default:
+        vmaf_log(VMAF_LOG_LEVEL_ERROR, "unknown pixel range received");
+        return -EINVAL;
     }
+    return 0;
 }
 
-LumaRange LumaRange_init(int bitdepth, PixelRange pix_range) {
-    LumaRange luma_range;
-    range_foot_head(bitdepth, pix_range, &luma_range.foot, &luma_range.head);
-    return luma_range;
-}
-
-inline double normalize_range(int sample, LumaRange range) {
+static inline double normalize_range(int sample, VmafLumaRange range) {
     int clipped_sample = clip(sample, range.foot, range.head);
     return (double)(clipped_sample - range.foot) / (range.head - range.foot);
 }
 
-inline double get_luminance(int sample, LumaRange luma_range, EOTF eotf) {
+int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum VmafPixelRange pix_range) {
+    int err = range_foot_head(bitdepth, pix_range, &(luma_range->foot), &(luma_range->head));
+    return err;
+}
+
+double vmaf_luminance_bt1886_eotf(double V) {
+    double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
+    double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
+    double L = a * pow(MAX(V + b, 0), BT1886_GAMMA);
+    return L;
+}
+
+double vmaf_luminance_get_luminance(int sample, VmafLumaRange luma_range, VmafEOTF eotf) {
     double normalized = normalize_range(sample, luma_range);
     return eotf(normalized);
 }

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -45,11 +45,11 @@ inline double bt1886_eotf(double V) {
  */
 inline void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head) {
     switch (pix_range) {
-        case LIMITED:
+        case VMAF_PIXEL_RANGE_LIMITED:
             *foot = 16 * (1 << (bitdepth - 8));
             *head = 235 * (1 << (bitdepth - 8));
             break;
-        case FULL:
+        case VMAF_PIXEL_RANGE_FULL:
             *foot = 0;
             *head = (1 << bitdepth) - 1;
             break;

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -27,8 +27,8 @@ typedef double (*EOTF)(double V);
  * Full pixel range means that values from 0 to 2^bitdepth - 1 will be used.
  */
 typedef enum  {
-    LIMITED,
-    FULL,
+    VMAF_PIXEL_RANGE_LIMITED,
+    VMAF_PIXEL_RANGE_FULL,
 } PixelRange;
 
 /*

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -16,53 +16,44 @@
  *
  */
 
-#ifndef LUMINANCE_TOOLS_H_
-#define LUMINANCE_TOOLS_H_
+#ifndef VMAF_LUMINANCE_TOOLS_H_
+#define VMAF_LUMINANCE_TOOLS_H_
 
-typedef double (*EOTF)(double V);
+typedef double (*VmafEOTF)(double V);
 
 /*
  * Limited pixel range means that only values between 16 and 235 will be used in 8 bits
  * (rescale the bounds appropriately for other bitdepths).
  * Full pixel range means that values from 0 to 2^bitdepth - 1 will be used.
  */
-typedef enum  {
+enum VmafPixelRange {
+    VMAF_PIXEL_RANGE_UNKNOWN,
     VMAF_PIXEL_RANGE_LIMITED,
     VMAF_PIXEL_RANGE_FULL,
-} PixelRange;
+};
 
 /*
  * Contains the necessary information to normalize a luma value down to [0, 1].
  */
-typedef struct LumaRange {
+typedef struct VmafLumaRange {
     int foot;
     int head;
-} LumaRange;
+} VmafLumaRange;
 
 /*
  * Constructor for the LumaRange struct.
  */
-LumaRange LumaRange_init(int bitdepth, PixelRange pix_range);
-
-/*
- * Determines the lowest and highest value possible for a given bitdepth and PixelRange.
- * Is used in the constructor for LumaRange, not to be used directly.
- */
-void range_foot_head(int bitdepth, PixelRange pix_range, int *foot, int *head);
-
-/*
- * Takes a luma value and a LumaRange struct and returns a normalized value in the [0, 1] range.
- */
-double normalize_range(int sample, LumaRange range);
+int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum VmafPixelRange pix_range);
 
 /*
  * Takes a normalized luma value in the [0, 1] range and returns a luminance value.
  */
-double bt1886_eotf(double V);
+double vmaf_luminance_bt1886_eotf(double V);
 
 /*
- * Takes a luma value, normalizes it and applies the given EOTF to return a luminance value.
+ * Takes a luma value, normalizes it and applies the given VmafEOTF
+ * to return a luminance value.
  */
-double get_luminance(int sample, LumaRange luma_range, EOTF eotf);
+double vmaf_luminance_get_luminance(int sample, VmafLumaRange luma_range, VmafEOTF eotf);
 
 #endif

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -100,7 +100,7 @@ test_cambi = executable('test_cambi',
 )
 
 test_luminance_tools = executable('test_luminance_tools',
-    ['test.c', 'test_luminance_tools.c', '../src/feature/luminance_tools.c'],
+    ['test.c', 'test_luminance_tools.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
 )

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,15 +447,16 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_10b_limited;
+    vmaf_luminance_init_luma_range(&range_10b_limited, 10, VMAF_PIXEL_RANGE_LIMITED);
     
-    int tvi = get_tvi_for_diff(1, 0.019, 10, range_10b_limited, bt1886_eotf);
+    int tvi = get_tvi_for_diff(1, 0.019, 10, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
-    tvi = get_tvi_for_diff(2, 0.019, 10, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(2, 0.019, 10, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_for_diff 2 and bd=10", tvi==305);
-    tvi = get_tvi_for_diff(3, 0.019, 10, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(3, 0.019, 10, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_for_diff 3 and bd=10", tvi==432);
-    tvi = get_tvi_for_diff(4, 0.019, 10, range_10b_limited, bt1886_eotf);
+    tvi = get_tvi_for_diff(4, 0.019, 10, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_for_diff 4 and bd=10", tvi==559);
 
     return NULL;
@@ -464,18 +465,19 @@ static char *test_get_tvi_for_diff()
 
 static char *test_tvi_condition()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_10b_limited;
+    vmaf_luminance_init_luma_range(&range_10b_limited, 10, VMAF_PIXEL_RANGE_LIMITED);
 
     bool condition;
-    condition = tvi_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);
+    condition = tvi_condition(177, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(178, 1, 0.019, range_10b_limited, bt1886_eotf);
+    condition = tvi_condition(178, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 1", condition);
-    condition = tvi_condition(179, 1, 0.019, range_10b_limited, bt1886_eotf);
+    condition = tvi_condition(179, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", !condition);
-    condition = tvi_condition(935, 4, 0.01, range_10b_limited, bt1886_eotf);
+    condition = tvi_condition(935, 4, 0.01, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
-    condition = tvi_condition(936, 4, 0.01, range_10b_limited, bt1886_eotf);
+    condition = tvi_condition(936, 4, 0.01, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("tvi_condition for bitdepth 10 and diff 4", condition);
     return NULL;
 }
@@ -539,16 +541,17 @@ static char *test_set_contrast_arrays()
 
 static char *test_tvi_hard_threshold_condition()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_10b_limited;
+    vmaf_luminance_init_luma_range(&range_10b_limited, 10, VMAF_PIXEL_RANGE_LIMITED);
 
     enum CambiTVIBisectFlag result;
-    result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);
+    result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_SMALL);
-    result = tvi_hard_threshold_condition(178, 1, 0.019, range_10b_limited, bt1886_eotf);
+    result = tvi_hard_threshold_condition(178, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_CORRECT);
-    result = tvi_hard_threshold_condition(179, 1, 0.019, range_10b_limited, bt1886_eotf);
+    result = tvi_hard_threshold_condition(179, 1, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=1", result==CAMBI_TVI_BISECT_TOO_BIG);
-    result = tvi_hard_threshold_condition(305, 2, 0.019, range_10b_limited, bt1886_eotf);
+    result = tvi_hard_threshold_condition(305, 2, 0.019, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("hard threshold error for bd=10 and diff=2", result==CAMBI_TVI_BISECT_CORRECT);
     return NULL;
 }

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -447,7 +447,7 @@ static char *test_adjust_window_size()
 /* Visibility threshold functions */
 static char *test_get_tvi_for_diff()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
+    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
     
     int tvi = get_tvi_for_diff(1, 0.019, 10, range_10b_limited, bt1886_eotf);
     mu_assert("tvi_for_diff 1 and bd=10", tvi==178);
@@ -464,7 +464,7 @@ static char *test_get_tvi_for_diff()
 
 static char *test_tvi_condition()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
+    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
 
     bool condition;
     condition = tvi_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);
@@ -539,7 +539,7 @@ static char *test_set_contrast_arrays()
 
 static char *test_tvi_hard_threshold_condition()
 {
-    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
+    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
 
     enum CambiTVIBisectFlag result;
     result = tvi_hard_threshold_condition(177, 1, 0.019, range_10b_limited, bt1886_eotf);

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -17,7 +17,7 @@
  */
 
 #include "test.h"
-#include "feature/luminance_tools.h"
+#include "feature/luminance_tools.c"
 
 #define EPS 0.00001
 
@@ -30,11 +30,11 @@ int almost_equal(double a, double b)
 
 static char *test_bt1886_eotf()
 {
-    double L = bt1886_eotf(0.5);
+    double L = vmaf_luminance_bt1886_eotf(0.5);
     mu_assert("wrong bt1886_eotf result", almost_equal(L, 58.716634));
-    L = bt1886_eotf(0.1);
+    L = vmaf_luminance_bt1886_eotf(0.1);
     mu_assert("wrong bt1886_eotf result", almost_equal(L, 1.576653));
-    L = bt1886_eotf(0.9);
+    L = vmaf_luminance_bt1886_eotf(0.9);
     mu_assert("wrong bt1886_eotf result", almost_equal(L, 233.819503));
 
     return NULL;
@@ -56,17 +56,19 @@ static char *test_range_foot_head()
 
 static char *test_get_luminance()
 {
-    LumaRange range_8b_limited = LumaRange_init(8, VMAF_PIXEL_RANGE_LIMITED);
-    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
-    LumaRange range_10b_full = LumaRange_init(10, VMAF_PIXEL_RANGE_FULL);
+    VmafLumaRange range_8b_limited;
+    vmaf_luminance_init_luma_range(&range_8b_limited, 8, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_10b_limited;
+    vmaf_luminance_init_luma_range(&range_10b_limited, 10, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_10b_full;
+    vmaf_luminance_init_luma_range(&range_10b_full, 10, VMAF_PIXEL_RANGE_FULL);
 
     double L;
-    L = get_luminance(100, range_8b_limited, bt1886_eotf);
+    L = vmaf_luminance_get_luminance(100, range_8b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("wrong 'limited' 8b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = get_luminance(400, range_10b_limited, bt1886_eotf);
+    L = vmaf_luminance_get_luminance(400, range_10b_limited, vmaf_luminance_bt1886_eotf);
     mu_assert("wrong 'limited' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
-    L = get_luminance(400, range_10b_full, bt1886_eotf);
-    printf("%.15lf\n", L);
+    L = vmaf_luminance_get_luminance(400, range_10b_full, vmaf_luminance_bt1886_eotf);
     mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.133003757557773));
 
     return NULL;
@@ -74,9 +76,12 @@ static char *test_get_luminance()
 
 static char *test_normalize_range()
 {
-    LumaRange range_8b_limited = LumaRange_init(8, VMAF_PIXEL_RANGE_LIMITED);
-    LumaRange range_8b_full = LumaRange_init(8, VMAF_PIXEL_RANGE_FULL);
-    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_8b_limited;
+    vmaf_luminance_init_luma_range(&range_8b_limited, 8, VMAF_PIXEL_RANGE_LIMITED);
+    VmafLumaRange range_8b_full;
+    vmaf_luminance_init_luma_range(&range_8b_full, 10, VMAF_PIXEL_RANGE_FULL);
+    VmafLumaRange range_10b_limited;
+    vmaf_luminance_init_luma_range(&range_10b_limited, 10, VMAF_PIXEL_RANGE_LIMITED);
 
     double n = normalize_range(0, range_8b_full);
     mu_assert("wrong 'full' 8b normalize range", almost_equal(n, 0.0));

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -44,11 +44,11 @@ static char *test_range_foot_head()
 {
     int foot, head;
 
-    range_foot_head(8, LIMITED, &foot, &head);
+    range_foot_head(8, VMAF_PIXEL_RANGE_LIMITED, &foot, &head);
     mu_assert("wrong 'limited' 8b range computation", (foot==16 && head==235));
-    range_foot_head(8, FULL, &foot, &head);
+    range_foot_head(8, VMAF_PIXEL_RANGE_FULL, &foot, &head);
     mu_assert("wrong 'full' 8b range computation", (foot==0 && head==255));
-    range_foot_head(10, LIMITED, &foot, &head);
+    range_foot_head(10, VMAF_PIXEL_RANGE_LIMITED, &foot, &head);
     mu_assert("wrong 'limited' 10b range computation", (foot==64 && head==940));
 
     return NULL;
@@ -56,9 +56,9 @@ static char *test_range_foot_head()
 
 static char *test_get_luminance()
 {
-    LumaRange range_8b_limited = LumaRange_init(8, LIMITED);
-    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
-    LumaRange range_10b_full = LumaRange_init(10, FULL);
+    LumaRange range_8b_limited = LumaRange_init(8, VMAF_PIXEL_RANGE_LIMITED);
+    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
+    LumaRange range_10b_full = LumaRange_init(10, VMAF_PIXEL_RANGE_FULL);
 
     double L;
     L = get_luminance(100, range_8b_limited, bt1886_eotf);
@@ -74,9 +74,9 @@ static char *test_get_luminance()
 
 static char *test_normalize_range()
 {
-    LumaRange range_8b_limited = LumaRange_init(8, LIMITED);
-    LumaRange range_8b_full = LumaRange_init(8, FULL);
-    LumaRange range_10b_limited = LumaRange_init(10, LIMITED);
+    LumaRange range_8b_limited = LumaRange_init(8, VMAF_PIXEL_RANGE_LIMITED);
+    LumaRange range_8b_full = LumaRange_init(8, VMAF_PIXEL_RANGE_FULL);
+    LumaRange range_10b_limited = LumaRange_init(10, VMAF_PIXEL_RANGE_LIMITED);
 
     double n = normalize_range(0, range_8b_full);
     mu_assert("wrong 'full' 8b normalize range", almost_equal(n, 0.0));


### PR DESCRIPTION
Very simple change to have more explicit names.

`LIMITED` -> `VMAF_PIXEL_RANGE_LIMITED`
`FULL` -> `VMAF_PIXEL_RANGE_FULL`