### PR TITLE
Add flexibility to CAMBI CLI parameters

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -278,13 +278,13 @@ static int set_contrast_arrays(const uint16_t num_diffs, uint16_t **diffs_to_con
                                int **diffs_weights, int **all_diffs)
 {
     *diffs_to_consider = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
-    if(!(*diffs_to_consider)) return -ENOMEM;
+    if (!(*diffs_to_consider)) return -ENOMEM;
 
     *diffs_weights = aligned_malloc(ALIGN_CEIL(sizeof(int)) * num_diffs, 32);
-    if(!(*diffs_weights)) return -ENOMEM;
+    if (!(*diffs_weights)) return -ENOMEM;
 
     *all_diffs = aligned_malloc(ALIGN_CEIL(sizeof(int)) * (2 * num_diffs + 1), 32);
-    if(!(*all_diffs)) return -ENOMEM;
+    if (!(*all_diffs)) return -ENOMEM;
 
     for (int d = 0; d < num_diffs; d++) {
         (*diffs_to_consider)[d] = d + 1;
@@ -354,7 +354,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     if (err) return err;
 
     s->tvi_for_diff = aligned_malloc(ALIGN_CEIL(sizeof(uint16_t)) * num_diffs, 16);
-    if(!s->tvi_for_diff) return -ENOMEM;
+    if (!s->tvi_for_diff) return -ENOMEM;
     for (int d = 0; d < num_diffs; d++) {
         s->tvi_for_diff[d] = get_tvi_for_diff(g_diffs_to_consider[d], s->tvi_threshold, 10, luma_range, eotf);
         s->tvi_for_diff[d] += num_diffs;
@@ -364,22 +364,22 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     adjust_window_size(&s->window_size, s->enc_width);
     adjust_window_size(&s->src_window_size, s->src_width);
     s->buffers.c_values = aligned_malloc(ALIGN_CEIL(w * sizeof(float)) * h, 32);
-    if(!s->buffers.c_values) return -ENOMEM;
+    if (!s->buffers.c_values) return -ENOMEM;
 
     const uint16_t num_bins = 1024 + (g_all_diffs[2 * num_diffs] - g_all_diffs[0]);
     s->buffers.c_values_histograms = aligned_malloc(ALIGN_CEIL(w * num_bins * sizeof(uint16_t)), 32);
-    if(!s->buffers.c_values_histograms) return -ENOMEM;
+    if (!s->buffers.c_values_histograms) return -ENOMEM;
 
     int pad_size = MASK_FILTER_SIZE >> 1;
     int dp_width = alloc_w + 2 * pad_size + 1;
     int dp_height = 2 * pad_size + 2;
 
     s->buffers.mask_dp = aligned_malloc(ALIGN_CEIL(dp_height * dp_width * sizeof(uint32_t)), 32);
-    if(!s->buffers.mask_dp) return -ENOMEM;
+    if (!s->buffers.mask_dp) return -ENOMEM;
     s->buffers.filter_mode_histogram = aligned_malloc(ALIGN_CEIL(1024 * sizeof(uint8_t)), 32);
-    if(!s->buffers.filter_mode_histogram) return -ENOMEM;
+    if (!s->buffers.filter_mode_histogram) return -ENOMEM;
     s->buffers.filter_mode_buffer = aligned_malloc(ALIGN_CEIL(3 * w * sizeof(uint16_t)), 32);
-    if(!s->buffers.filter_mode_buffer) return -ENOMEM;
+    if (!s->buffers.filter_mode_buffer) return -ENOMEM;
 
     if (s->heatmaps_path) {
         int err = mkdirp(s->heatmaps_path, 0770);

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -66,7 +66,7 @@ int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum
     return err;
 }
 
-int vmaf_luminance_init_eotf(VmafEOTF *eotf, char* eotf_str) {
+int vmaf_luminance_init_eotf(VmafEOTF *eotf, const char *eotf_str) {
     if (strcmp(eotf_str, "bt1886") == 0) {
         *eotf = vmaf_luminance_bt1886_eotf;
     }
@@ -83,19 +83,19 @@ int vmaf_luminance_init_eotf(VmafEOTF *eotf, char* eotf_str) {
 double vmaf_luminance_bt1886_eotf(double V) {
     double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
     double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
-    double L = a * pow(MAX(V + b, 0), BT1886_GAMMA);
-    return L;
+    return a * pow(MAX(V + b, 0), BT1886_GAMMA);
 }
 
 double vmaf_luminance_pq_eotf(double V) {
-    double m_1 = 0.1593017578125;
-    double m_2 = 78.84375;
-    double c_1 = 0.8359375;
-    double c_2 = 18.8515625;
-    double c_3 = 18.6875;  // c_3 = c_1 + c_2 - 1
-    double num = MAX(0, pow(V, 1.0 / m_2) - c_1);
+    const double m_1 = 0.1593017578125;
+    const double m_2 = 78.84375;
+    const double c_1 = 0.8359375;
+    const double c_2 = 18.8515625;
+    const double c_3 = 18.6875;  // c_3 = c_1 + c_2 - 1
+    double num = pow(V, 1.0 / m_2) - c_1;
+    double num_clipped = MAX(num, 0);
     double den = c_2 - c_3 * pow(V, 1.0 / m_2);
-    return 10000 * pow(num / den, 1.0 / m_1);
+    return 10000 * pow(num_clipped / den, 1.0 / m_1);
 }
 
 double vmaf_luminance_get_luminance(int sample, VmafLumaRange luma_range, VmafEOTF eotf) {

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -72,6 +72,17 @@ double vmaf_luminance_bt1886_eotf(double V) {
     return L;
 }
 
+inline double vmaf_luminance_pq_eotf(double V) {
+    double m_1 = 0.1593017578125;
+    double m_2 = 78.84375;
+    double c_1 = 0.8359375;
+    double c_2 = 18.8515625;
+    double c_3 = 18.6875;  // c_3 = c_1 + c_2 - 1
+    double num = MAX(0, pow(V, 1.0 / m_2) - c_1);
+    double den = c_2 - c_3 * pow(V, 1.0 / m_2);
+    return 10000 * pow(num / den, 1.0 / m_1);
+}
+
 double vmaf_luminance_get_luminance(int sample, VmafLumaRange luma_range, VmafEOTF eotf) {
     double normalized = normalize_range(sample, luma_range);
     return eotf(normalized);

--- a/libvmaf/src/feature/luminance_tools.c
+++ b/libvmaf/src/feature/luminance_tools.c
@@ -18,6 +18,7 @@
 
 #include <errno.h>
 #include <math.h>
+#include <string.h>
 
 #include "log.h"
 #include "luminance_tools.h"
@@ -65,6 +66,20 @@ int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum
     return err;
 }
 
+int vmaf_luminance_init_eotf(VmafEOTF *eotf, char* eotf_str) {
+    if (strcmp(eotf_str, "bt1886") == 0) {
+        *eotf = vmaf_luminance_bt1886_eotf;
+    }
+    else if (strcmp(eotf_str, "pq") == 0) {
+        *eotf = vmaf_luminance_pq_eotf;
+    }
+    else {
+        vmaf_log(VMAF_LOG_LEVEL_ERROR, "unknown EOTF received");
+        return -EINVAL;
+    }
+    return 0;
+}
+
 double vmaf_luminance_bt1886_eotf(double V) {
     double a = pow(pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA), BT1886_GAMMA);
     double b = pow(BT1886_LB, 1.0 / BT1886_GAMMA) / (pow(BT1886_LW, 1.0 / BT1886_GAMMA) - pow(BT1886_LB, 1.0 / BT1886_GAMMA));
@@ -72,7 +87,7 @@ double vmaf_luminance_bt1886_eotf(double V) {
     return L;
 }
 
-inline double vmaf_luminance_pq_eotf(double V) {
+double vmaf_luminance_pq_eotf(double V) {
     double m_1 = 0.1593017578125;
     double m_2 = 78.84375;
     double c_1 = 0.8359375;

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -51,6 +51,11 @@ int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum
 double vmaf_luminance_bt1886_eotf(double V);
 
 /*
+ * Takes a normalized luma value in the [0, 1] range and returns a luminance value.
+ */
+double vmaf_luminance_pq_eotf(double V);
+
+/*
  * Takes a luma value, normalizes it and applies the given VmafEOTF
  * to return a luminance value.
  */

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -46,6 +46,13 @@ typedef struct VmafLumaRange {
 int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum VmafPixelRange pix_range);
 
 /*
+ * Returns the EOTF corresponding to the string given.
+ * eotf_str must be one of ['bt1886', 'pq']
+ */
+int vmaf_luminance_init_eotf(VmafEOTF *eotf, char* eotf_str);
+
+
+/*
  * Takes a normalized luma value in the [0, 1] range and returns a luminance value.
  */
 double vmaf_luminance_bt1886_eotf(double V);

--- a/libvmaf/src/feature/luminance_tools.h
+++ b/libvmaf/src/feature/luminance_tools.h
@@ -49,7 +49,7 @@ int vmaf_luminance_init_luma_range(VmafLumaRange *luma_range, int bitdepth, enum
  * Returns the EOTF corresponding to the string given.
  * eotf_str must be one of ['bt1886', 'pq']
  */
-int vmaf_luminance_init_eotf(VmafEOTF *eotf, char* eotf_str);
+int vmaf_luminance_init_eotf(VmafEOTF *eotf, const char *eotf_str);
 
 
 /*

--- a/libvmaf/test/test_luminance_tools.c
+++ b/libvmaf/test/test_luminance_tools.c
@@ -40,6 +40,21 @@ static char *test_bt1886_eotf()
     return NULL;
 }
 
+static char *test_pq_eotf()
+{
+    double L;
+    L = vmaf_luminance_pq_eotf(0.0);
+    mu_assert("wrong pq_eotf result", almost_equal(L, 0.0));
+    L = vmaf_luminance_pq_eotf(0.1);
+    mu_assert("wrong pq_eotf result", almost_equal(L, 0.324565591464487));
+    L = vmaf_luminance_pq_eotf(0.3);
+    mu_assert("wrong pq_eotf result", almost_equal(L, 10.038226310511750));
+    L = vmaf_luminance_pq_eotf(0.8);
+    mu_assert("wrong pq_eotf result", almost_equal(L, 1555.178364289284673));
+
+    return NULL;
+}
+
 static char *test_range_foot_head()
 {
     int foot, head;
@@ -70,6 +85,13 @@ static char *test_get_luminance()
     mu_assert("wrong 'limited' 10b luminance bt1886", almost_equal(L, 31.68933962217197));
     L = vmaf_luminance_get_luminance(400, range_10b_full, vmaf_luminance_bt1886_eotf);
     mu_assert("wrong 'full' 10b luminance bt1886", almost_equal(L, 33.133003757557773));
+
+    L = vmaf_luminance_get_luminance(100, range_8b_limited, vmaf_luminance_pq_eotf);
+    mu_assert("wrong 'limited' 8b luminance pq", almost_equal(L, 27.048765018959795));
+    L = vmaf_luminance_get_luminance(400, range_10b_limited, vmaf_luminance_pq_eotf);
+    mu_assert("wrong 'limited' 10b luminance pq", almost_equal(L, 27.048765018959795));
+    L = vmaf_luminance_get_luminance(400, range_10b_full, vmaf_luminance_pq_eotf);
+    mu_assert("wrong 'full' 10b luminance pq", almost_equal(L, 29.385657130952264));
 
     return NULL;
 }
@@ -103,6 +125,7 @@ static char *test_normalize_range()
 char *run_tests()
 {
     mu_run_test(test_bt1886_eotf);
+    mu_run_test(test_pq_eotf);
     mu_run_test(test_range_foot_head);
     mu_run_test(test_get_luminance);
     mu_run_test(test_normalize_range);


### PR DESCRIPTION
* Implement PQ EOTF and add a CLI option to use it in CAMBI for the visibility threshold calculations.
* Add a CLI option to CAMBI to provide the encoding bitdepth so it can choose whether to use the anti-dithering filter accordingly. This is for cases where the original bitdepth is < 10 and it has been upscaled to a bitdepth >= 10.
* A few minor style/uniformity changes.