### PR TITLE
If user provides workfile_yuv_type, override the assets' type

### DIFF
--- a/python/test/executor_test.py
+++ b/python/test/executor_test.py
@@ -34,3 +34,19 @@ class ExecutorTest(unittest.TestCase):
         asset = Asset(dataset="test", content_id=0, asset_id=0, ref_path="", dis_path="",
                       asset_dict={'ref_yuv_type': 'yuv444p', 'dis_yuv_type': 'yuv444p'}, workdir_root="my_workdir_root")
         self.assertEqual(Executor._get_workfile_yuv_type(asset), 'yuv444p')
+
+        asset = Asset(dataset="test", content_id=0, asset_id=0, ref_path="", dis_path="",
+                      asset_dict={'ref_yuv_type': 'yuv444p', 'dis_yuv_type': 'yuv444p', 'workfile_yuv_type': 'yuv420p10le'}, workdir_root="my_workdir_root")
+        self.assertEqual(Executor._get_workfile_yuv_type(asset), 'yuv420p10le')
+
+        asset = Asset(dataset="test", content_id=0, asset_id=0, ref_path="", dis_path="",
+                      asset_dict={'ref_yuv_type': 'yuv444p', 'dis_yuv_type': 'notyuv', 'workfile_yuv_type': 'yuv420p'}, workdir_root="my_workdir_root")
+        self.assertEqual(Executor._get_workfile_yuv_type(asset), 'yuv420p')
+
+        asset = Asset(dataset="test", content_id=0, asset_id=0, ref_path="", dis_path="",
+                      asset_dict={'ref_yuv_type': 'yuv444p', 'dis_yuv_type': 'notyuv', 'workfile_yuv_type': 'yuv444p'}, workdir_root="my_workdir_root")
+        self.assertEqual(Executor._get_workfile_yuv_type(asset), 'yuv444p')
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -42,6 +42,23 @@ def set_default_576_324_videos_for_testing():
 
     return ref_path, dis_path, asset, asset_original
 
+def set_default_576_324_videos_for_testing_workfile_yuv_10b():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324, 'workfile_yuv_type': 'yuv420p10le'})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324, 'workfile_yuv_type': 'yuv420p10le'})
+
+    return ref_path, dis_path, asset, asset_original
+
 def set_default_576_324_videos_for_testing_scaled():
     ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
     dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
@@ -157,6 +174,20 @@ def set_default_576_324_noref_videos_for_testing():
 
     return ref_path, dis_path, asset, asset_original
 
+def set_default_576_324_noref_videos_for_testing_workfile_yuv_10b():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324, 'workfile_yuv_type': 'yuv420p10le'})
+
+    asset_original = NorefAsset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324, 'workfile_yuv_type': 'yuv420p10le'})
+
+    return ref_path, dis_path, asset, asset_original
 
 def set_default_cambi_video_for_testing():
     dis_path = VmafConfig.test_resource_path("yuv", "blue_sky_360p_60f.yuv")


### PR DESCRIPTION
Currently, we're treating `workfile_yuv_type` like this:
* if both ref and dis are "notyuv", we use the type given by the user, or a default if not provided
* if one is "notyuv" and the other is some type of yuv, we use the type of the yuv, ignoring the user input
* if both are yuv, we assert that they're the same type and use that type, ignoring the user input

This PR makes it so that if the user inputs `workfile_yuv_type` in the asset dict, it overrides all other types and both the dis and ref files are converted to that type. It's achieved by modifying `_need_ffmpeg` and `_get_workfile_yuv_type ` from both `Executor` and `NorefExecutorMixin`.

This PR also adds two test cases, one for `FeatureExtractor` and one for `NorefFeatureExtractor`, which use this to override the yuv type from 8b to 10b.