### PR TITLE
libvmaf: fix CLI parsing of string options that start with a number

### DIFF
--- a/libvmaf/src/dict.c
+++ b/libvmaf/src/dict.c
@@ -194,11 +194,20 @@ void vmaf_dictionary_alphabetical_sort(VmafDictionary *dict)
     qsort(dict->entry, dict->cnt, sizeof(*dict->entry), alphabetical_compare);
 }
 
+static int isnumeric(const char *str)
+{
+    float ignore;
+    char c;
+    int ret = sscanf(str, "%f %c", &ignore, &c);
+    return ret == 1;
+}
+
 int vmaf_feature_dictionary_set(VmafFeatureDictionary **dict, const char *key,
                                 const char *val)
 {
-    return vmaf_dictionary_set((VmafDictionary**)dict, key, val,
-                               VMAF_DICT_NORMALIZE_NUMERICAL_VALUES);
+    uint64_t flags = 0;
+    if (isnumeric(val)) flags |= VMAF_DICT_NORMALIZE_NUMERICAL_VALUES;
+    return vmaf_dictionary_set((VmafDictionary**)dict, key, val, flags);
 }
 
 int vmaf_feature_dictionary_free(VmafFeatureDictionary **dict)

--- a/libvmaf/test/test_dict.c
+++ b/libvmaf/test/test_dict.c
@@ -340,6 +340,45 @@ static char *test_vmaf_dictionary_alphabetical_sort()
     return NULL;
 }
 
+static char *test_isnumeric()
+{
+    int err = 0;
+
+    // not numeric
+    err = isnumeric("abc");
+    mu_assert("problem during isnumeric", !err);
+
+    err = isnumeric("/a/b/c");
+    mu_assert("problem during isnumeric", !err);
+
+    err = isnumeric("abc123");
+    mu_assert("problem during isnumeric", !err);
+
+    err = isnumeric("123abc");
+    mu_assert("problem during isnumeric", !err);
+
+    // numeric
+    err = isnumeric("123");
+    mu_assert("problem during isnumeric", err);
+
+    err = isnumeric("123.456");
+    mu_assert("problem during isnumeric", err);
+
+    err = isnumeric("    123.456    ");
+    mu_assert("problem during isnumeric", err);
+
+    err = isnumeric("NaN");
+    mu_assert("problem during isnumeric", err);
+
+    err = isnumeric("inf");
+    mu_assert("problem during isnumeric", err);
+
+    err = isnumeric("-inf");
+    mu_assert("problem during isnumeric", err);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_vmaf_dictionary);
@@ -348,5 +387,6 @@ char *run_tests()
     mu_run_test(test_vmaf_dictionary_normalize_numerical_val);
     mu_run_test(test_vmaf_feature_dictionary);
     mu_run_test(test_vmaf_dictionary_alphabetical_sort);
+    mu_run_test(test_isnumeric);
     return NULL;
 }


### PR DESCRIPTION
The `VMAF_DICT_NORMALIZE_NUMERICAL_VALUES` flag was causing string options like `123abc` to be chopped to `123`. This PR fixes this issue by only setting the flag if the input string is parseable as a float to begin with.