### PR TITLE
CAMBI: performance optimizations

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -730,15 +730,45 @@ static float c_value_pixel(const uint16_t *histograms, uint16_t value, const int
     return c_value;
 }
 
+static FORCE_INLINE inline void increment_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]++;
+    }
+}
+
+static FORCE_INLINE inline void decrement_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]--;
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_subtract_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                          int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                          const uint16_t num_diffs) {
+    uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
+    if (mask_val) {
+        uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
+        decrement_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+    }
+}
+
 static FORCE_INLINE inline void update_histogram_subtract(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                           int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
                                                           const uint16_t num_diffs) {
     uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
-        for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-            histograms[val * width + col]--;
-        }
+        decrement_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[(i + pad_size) * stride + j];
+    if (mask_val) {
+        uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
     }
 }
 
@@ -748,9 +778,27 @@ static FORCE_INLINE inline void update_histogram_add(uint16_t *histograms, uint1
     uint16_t mask_val = mask[(i + pad_size) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
-        for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-            histograms[val * width + col]++;
-        }
+        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_edge_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[i * stride + j];
+    if (mask_val) {
+        uint16_t val = image[i * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[i * stride + j];
+    if (mask_val) {
+        uint16_t val = image[i * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
     }
 }
 
@@ -788,37 +836,57 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
 
     // First pass: first pad_size rows
     for (int i = 0; i < pad_size; i++) {
-        for (int j = 0; j < width; j++) {
-            uint16_t mask_val = mask[i * stride + j];
-            if (mask_val) {
-                uint16_t val = image[i * stride + j] + num_diffs;
-                for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-                    histograms[val * width + col]++;
-                }
-            }
+        for (int j = 0; j < pad_size; j++) {
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = pad_size; j < width - pad_size - 1; j++) {
+            update_histogram_add_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
         }
     }
 
     // Iterate over all rows, unrolled into 3 loops to avoid conditions
     for (int i = 0; i < pad_size + 1; i++) {
         if (i + pad_size < height) {
-            for (int j = 0; j < width; j++) {
+            for (int j = 0; j < pad_size; j++) {
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = pad_size; j < width - pad_size - 1; j++) {
                 update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = pad_size + 1; i < height - pad_size; i++) {
-        for (int j = 0; j < width; j++) {
+        for (int j = 0; j < pad_size; j++) {
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = pad_size; j < width - pad_size - 1; j++) {
             update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = height - pad_size; i < height; i++) {
         if (i - pad_size - 1 >= 0) {
-            for (int j = 0; j < width; j++) {
+            for (int j = 0; j < pad_size; j++) {
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = pad_size; j < width - pad_size - 1; j++) {
                 update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -236,7 +236,6 @@ static char *test_filter_mode()
 {
     VmafPicture filtered_image, image;
     unsigned w = 5, h = 5;
-    uint8_t histogram[1024];
     uint16_t buffer[3 * w];
 
     int err = vmaf_picture_alloc(&filtered_image, VMAF_PIX_FMT_YUV400P, 10, w, h);
@@ -248,31 +247,32 @@ static char *test_filter_mode()
     uint16_t *filtered_data = filtered_image.data[0];
     ptrdiff_t output_stride = filtered_image.stride[0]>>1;
 
-    data[2 * stride + 2] = 1; data[3 * stride + 2] = 1;
-    data[2 * stride + 3] = 1; data[3 * stride + 3] = 1;
+    data[1 * stride + 2] = 1; data[2 * stride + 2] = 1;
+    data[1 * stride + 3] = 1; data[3 * stride + 3] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: all zeros", data_pic_sum(&filtered_image)==0);
 
     data[3 * stride + 4] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
-    mu_assert("filter_mode: two ones sum check", data_pic_sum(&filtered_image)==2);
-    mu_assert("filter_mode: two ones (3,3) check", filtered_data[3 * output_stride + 3]==1);
-    mu_assert("filter_mode: two ones (2,3) check", filtered_data[2 * output_stride + 3]==1);
+    filter_mode(&filtered_image, w, h, buffer);
+
+    mu_assert("filter_mode: one one sum check", data_pic_sum(&filtered_image)==1);
+    mu_assert("filter_mode: zero (3,3) check", filtered_data[3 * output_stride + 3]==0);
+    mu_assert("filter_mode: one (2,3) check", filtered_data[2 * output_stride + 3]==1);
 
     data[0 * stride + 0] = 2;
     data[0 * stride + 1] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: two in the corner check", filtered_data[0 * output_stride + 0]==2);
     data[1 * stride + 0] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
-    mu_assert("filter_mode: two in the corner and adjacent ones check", filtered_data[0 * output_stride + 0]==1);
+    filter_mode(&filtered_image, w, h, buffer);
+    mu_assert("filter_mode: two in the corner and adjacent one check", filtered_data[0 * output_stride + 1]==1);
     data[2 * stride + 0] = 2;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: two in corner and edge check", filtered_data[1 * output_stride + 0]==2);
 
     vmaf_picture_unref(&image);

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -28,7 +28,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.6892500624999999, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
                                0.0014658541666666667, places=4)
 
@@ -45,9 +45,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.9204257916666666, places=4)
+                               0.8740225, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.004251791666666667, places=4)
+                               0.004161041666666666, places=4)
 
     def test_run_cambi_fextractor_scaled_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -62,7 +62,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               1.218365, places=4)
+                               1.309229, places=4)
 
     def test_run_cambi_fextractor_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -77,7 +77,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.01451, places=4)
+                               0.016021, places=4)
 
     def test_run_cambi_fextractor_max_log_contrast(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -92,9 +92,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.9182153958333333, places=4)
+                               0.9313579999999999, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0024499791666667, places=4)
+                               0.0022395208333333334, places=4)
 
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -107,9 +107,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.015840666666666666, places=4)
+                               0.019885541666666666, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.000671125, places=4)
+                               0.0007890833333333334, places=4)
 
     def test_run_cambi_fextractor_full_reference(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -123,11 +123,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.689250, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
                                0.00146585416, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.687784, places=4)
+                               0.6635012083333333, places=4)
 
     def test_run_cambi_fextractor_full_reference_scaled_ref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -142,11 +142,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.689250, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.0042517916, places=4)
+                               0.004161041666666666, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.6849983125, places=4)
+                               0.66077, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):
@@ -163,7 +163,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.6892500624999999, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
                                0.0014658541666666667, places=4)
 
@@ -180,9 +180,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.9204257916666666, places=4)
+                               0.8740225, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.004251791666666667, places=4)
+                               0.004161041666666666, places=4)
 
     def test_run_cambi_runner_scale_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -197,7 +197,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               1.218365, places=4)
+                               1.309229, places=4)
 
     def test_run_cambi_runner_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -212,7 +212,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.01451, places=4)
+                               0.016021, places=4)
 
     def test_run_cambi_runner_fullref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -226,9 +226,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_score'],
-                               0.687784125, places=4)
+                               0.6635012083333333, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.68925006249, places=4)
+                               0.664931, places=4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* The mode filter now ignores the edges, which caused a lot of additional computation for no added benefit
* The 3x3 mode filter is substituted for iterated 1x3 and 3x1 mode filters, which aren't exactly equivalent (1) but will be equivalent on a large majority of inputs
* Unrolled a loop in the `c_value` computation to avoid checking for edges in the main part of the loop.

Speedups ranging from +27% (banding-prone videos) to +341% (non-banding-prone videos), speedup % is correlated to the spatial mask being mostly off.

(1) Example of non-equivalence:
```
1 1 1
1 2 2
1 2 2
```

which will give 2 as the mode when it should be 1.