### PR TITLE
CAMBI: change window_size to 65

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -33,8 +33,8 @@
 /* Ratio of pixels for computation, must be 0 < topk <= 1.0 */
 #define DEFAULT_CAMBI_TOPK_POOLING (0.6)
 
-/* Window size to compute CAMBI: 63 corresponds to approximately 1 degree at 4k scale */
-#define DEFAULT_CAMBI_WINDOW_SIZE (63)
+/* Window size to compute CAMBI: 65 corresponds to approximately 1 degree at 4k scale */
+#define DEFAULT_CAMBI_WINDOW_SIZE (65)
 
 /* Visibility threshold for luminance ΔL < tvi_threshold*L_mean for BT.1886 */
 #define DEFAULT_CAMBI_TVI (0.019)

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -45,9 +45,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.8740225, places=4)
+                               0.79470425, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
 
     def test_run_cambi_fextractor_scaled_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -62,7 +62,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               1.309229, places=4)
+                               1.270708, places=4)
 
     def test_run_cambi_fextractor_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -144,9 +144,9 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
                                0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.66077, places=4)
+                               0.6615367083333333, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):
@@ -180,9 +180,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.8740225, places=4)
+                               0.79470425, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
 
     def test_run_cambi_runner_scale_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -197,7 +197,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               1.309229, places=4)
+                               1.270708, places=4)
 
     def test_run_cambi_runner_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()


### PR DESCRIPTION
Benchmarks show that using a window size of 65 is better than 63 due to SIMD-ability, and results don't change much (and change slightly for the better). In fact, it seems that just by changing the window size to 65, the code is significantly faster without explicitly implementing SIMD, probably because the compiler is emitting those instructions by itself. 