### PR TITLE
CAMBI: collection of changes that impact score

### DIFF
--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -17,7 +17,6 @@
  */
 
 #include <errno.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -284,8 +283,8 @@ static FORCE_INLINE inline void adjust_window_size(uint16_t *window_size,
                                                    unsigned input_width,
                                                    unsigned input_height)
 {
-    (void) input_height;
-    (*window_size) = ((*window_size) * input_width) / CAMBI_4K_WIDTH;
+    // Adjustment weight: (input_width + input_height) / (CAMBI_4K_WIDTH + CAMBI_4K_HEIGHT)
+    (*window_size) = (((*window_size) * (input_width+input_height)) / 375) >> 4;
 }
 
 static int set_contrast_arrays(const uint16_t num_diffs, uint16_t **diffs_to_consider,
@@ -655,11 +654,23 @@ static void filter_mode(const VmafPicture *image, int width, int height, uint16_
     }
 }
 
+static FORCE_INLINE inline uint16_t ceil_log2(uint32_t num) {
+    if (num==0)
+        return 0;
+
+    uint32_t tmp = num - 1;
+    uint16_t shift = 0;
+    while (tmp>0) {
+        tmp >>= 1;
+        shift += 1;
+    }
+    return shift;
+}
+
 static FORCE_INLINE inline uint16_t get_mask_index(unsigned input_width, unsigned input_height,
                                                    uint16_t filter_size) {
-    const int slope = 3;
-    double resolution_ratio = sqrt((CAMBI_4K_WIDTH * CAMBI_4K_HEIGHT) / (input_width * input_height));
-    return (uint16_t)(((filter_size * filter_size) >> 1) - slope * (resolution_ratio - 1));
+    uint32_t shifted_wh = (input_width >> 6) * (input_height >> 6);
+    return (filter_size * filter_size + 3 * (ceil_log2(shifted_wh) - 11) - 1)>>1;
 }
 
 static FORCE_INLINE inline bool get_derivative_data(const uint16_t *data, int width, int height, int i, int j, ptrdiff_t stride) {

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include "common/macros.h"
+#include "cpu.h"
 #include "feature_collector.h"
 #include "feature_extractor.h"
 #include "log.h"
@@ -29,6 +30,10 @@
 #include "mem.h"
 #include "mkdirp.h"
 #include "picture.h"
+
+#if ARCH_X86
+#include "x86/cambi_avx2.h"
+#endif
 
 /* Ratio of pixels for computation, must be 0 < topk <= 1.0 */
 #define DEFAULT_CAMBI_TOPK_POOLING (0.6)
@@ -83,6 +88,8 @@ typedef struct CambiBuffers {
     int *all_diffs;
 } CambiBuffers;
 
+typedef void (*VmafRangeUpdater)(uint16_t *arr, int left, int right);
+
 typedef struct CambiState {
     VmafPicture pics[PICS_BUFFER_SIZE];
     unsigned enc_width;
@@ -99,6 +106,8 @@ typedef struct CambiState {
     char *eotf;
     bool full_ref;
     FILE *heatmaps_files[NUM_SCALES];
+    VmafRangeUpdater inc_range_callback;
+    VmafRangeUpdater dec_range_callback;
     CambiBuffers buffers;
 } CambiState;
 
@@ -298,6 +307,18 @@ static int set_contrast_arrays(const uint16_t num_diffs, uint16_t **diffs_to_con
     return 0;
 }
 
+static void increment_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]++;
+    }
+}
+
+static void decrement_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]--;
+    }
+}
+
 #ifdef _WIN32
     #define PATH_SEPARATOR '\\'
 #else
@@ -401,6 +422,17 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
             scaled_h = (scaled_h + 1) >> 1;
         }
     }
+
+    s->inc_range_callback = increment_range;
+    s->dec_range_callback = decrement_range;
+
+#if ARCH_X86
+    unsigned flags = vmaf_get_cpu_flags();
+    if (flags & VMAF_X86_CPU_FLAG_AVX2) {
+        s->inc_range_callback = cambi_increment_range_avx2;
+        s->dec_range_callback = cambi_decrement_range_avx2;
+    }
+#endif
 
     return err;
 }
@@ -730,75 +762,63 @@ static float c_value_pixel(const uint16_t *histograms, uint16_t value, const int
     return c_value;
 }
 
-static FORCE_INLINE inline void increment_range(uint16_t *arr, int left, int right) {
-    for (int i = left; i < right; i++) {
-        arr[i]++;
-    }
-}
-
-static FORCE_INLINE inline void decrement_range(uint16_t *arr, int left, int right) {
-    for (int i = left; i < right; i++) {
-        arr[i]--;
-    }
-}
-
 static FORCE_INLINE inline void update_histogram_subtract_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                           int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                          const uint16_t num_diffs) {
+                                                          const uint16_t num_diffs, VmafRangeUpdater dec_range_callback) {
     uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
-        decrement_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+        dec_range_callback(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
     }
 }
 
 static FORCE_INLINE inline void update_histogram_subtract(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                           int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                          const uint16_t num_diffs) {
+                                                          const uint16_t num_diffs, VmafRangeUpdater dec_range_callback) {
     uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
-        decrement_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+        dec_range_callback(&histograms[val * width], j - pad_size, j + pad_size + 1);
     }
 }
 
 static FORCE_INLINE inline void update_histogram_add_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                      int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                     const uint16_t num_diffs) {
+                                                     const uint16_t num_diffs, VmafRangeUpdater inc_range_callback) {
     uint16_t mask_val = mask[(i + pad_size) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
-        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+        inc_range_callback(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
     }
 }
 
 static FORCE_INLINE inline void update_histogram_add(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                      int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                     const uint16_t num_diffs) {
+                                                     const uint16_t num_diffs, VmafRangeUpdater inc_range_callback) {
     uint16_t mask_val = mask[(i + pad_size) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
-        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+        inc_range_callback(&histograms[val * width], j - pad_size, j + pad_size + 1);
     }
 }
 
 static FORCE_INLINE inline void update_histogram_add_edge_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                      int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                     const uint16_t num_diffs) {
+                                                     const uint16_t num_diffs, VmafRangeUpdater inc_range_callback) {
     uint16_t mask_val = mask[i * stride + j];
     if (mask_val) {
         uint16_t val = image[i * stride + j] + num_diffs;
-        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+        inc_range_callback(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
     }
 }
 
 static FORCE_INLINE inline void update_histogram_add_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                      int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
-                                                     const uint16_t num_diffs) {
+                                                     const uint16_t num_diffs, VmafRangeUpdater inc_range_callback) {
     uint16_t mask_val = mask[i * stride + j];
     if (mask_val) {
         uint16_t val = image[i * stride + j] + num_diffs;
-        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+        inc_range_callback(&histograms[val * width], j - pad_size, j + pad_size + 1);
     }
 }
 
@@ -818,7 +838,8 @@ static FORCE_INLINE inline void calculate_c_values_row(float *c_values, uint16_t
 static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
                                float *c_values, uint16_t *histograms, uint16_t window_size,
                                const uint16_t num_diffs, const uint16_t *tvi_for_diff,
-                               const int *diff_weights, const int *all_diffs, int width, int height) {
+                               const int *diff_weights, const int *all_diffs, int width, int height,
+                               VmafRangeUpdater inc_range_callback, VmafRangeUpdater dec_range_callback) {
 
     uint16_t pad_size = window_size >> 1;
     const uint16_t num_bins = 1024 + (all_diffs[2*num_diffs] - all_diffs[0]);
@@ -837,13 +858,13 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
     // First pass: first pad_size rows
     for (int i = 0; i < pad_size; i++) {
         for (int j = 0; j < pad_size; j++) {
-            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
         for (int j = pad_size; j < width - pad_size - 1; j++) {
-            update_histogram_add_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
         for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
-            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
     }
 
@@ -851,42 +872,42 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
     for (int i = 0; i < pad_size + 1; i++) {
         if (i + pad_size < height) {
             for (int j = 0; j < pad_size; j++) {
-                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
             }
             for (int j = pad_size; j < width - pad_size - 1; j++) {
-                update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
             }
             for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
-                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = pad_size + 1; i < height - pad_size; i++) {
         for (int j = 0; j < pad_size; j++) {
-            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
-            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
         for (int j = pad_size; j < width - pad_size - 1; j++) {
-            update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
-            update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
+            update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
         for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
-            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
-            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, inc_range_callback);
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = height - pad_size; i < height; i++) {
         if (i - pad_size - 1 >= 0) {
             for (int j = 0; j < pad_size; j++) {
-                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
             }
             for (int j = pad_size; j < width - pad_size - 1; j++) {
-                update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
             }
             for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
-                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs, dec_range_callback);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
@@ -980,8 +1001,9 @@ static int dump_c_values(FILE *heatmaps_files[], const float *c_values, int widt
 
 static int cambi_score(VmafPicture *pics, uint16_t window_size, double topk,
                        const uint16_t num_diffs, const uint16_t *tvi_for_diff,
-                       CambiBuffers buffers, double *score, bool write_heatmaps,
-                       FILE *heatmaps_files[], int width, int height, int frame) {
+                       CambiBuffers buffers, VmafRangeUpdater inc_range_callback, VmafRangeUpdater dec_range_callback,
+                       double *score, bool write_heatmaps, FILE *heatmaps_files[],
+                       int width, int height, int frame) {
     double scores_per_scale[NUM_SCALES];
     VmafPicture *image = &pics[0];
     VmafPicture *mask = &pics[1];
@@ -1001,7 +1023,8 @@ static int cambi_score(VmafPicture *pics, uint16_t window_size, double topk,
         filter_mode(image, scaled_width, scaled_height, buffers.filter_mode_buffer);
 
         calculate_c_values(image, mask, buffers.c_values, buffers.c_values_histograms, window_size,
-                           num_diffs, tvi_for_diff, buffers.diff_weights, buffers.all_diffs, scaled_width, scaled_height);
+                           num_diffs, tvi_for_diff, buffers.diff_weights, buffers.all_diffs, scaled_width, scaled_height,
+                           inc_range_callback, dec_range_callback);
 
         if (write_heatmaps) {
             int err = dump_c_values(heatmaps_files, buffers.c_values, scaled_width, scaled_height, scale, window_size,
@@ -1029,7 +1052,7 @@ static int preprocess_and_extract_cambi(CambiState *s, VmafPicture *pic, double 
 
     bool write_heatmaps = s->heatmaps_path && !is_src;
     err = cambi_score(s->pics, window_size, s->topk, num_diffs, s->buffers.tvi_for_diff,
-                      s->buffers, score, write_heatmaps, s->heatmaps_files, width, height, frame);
+                      s->buffers, s->inc_range_callback, s->dec_range_callback, score, write_heatmaps, s->heatmaps_files, width, height, frame);
     if (err) return err;
 
     return 0;

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -280,7 +280,11 @@ static int get_tvi_for_diff(int diff, double tvi_threshold, int bitdepth, VmafLu
     }
 }
 
-static FORCE_INLINE inline void adjust_window_size(uint16_t *window_size, unsigned input_width) {
+static FORCE_INLINE inline void adjust_window_size(uint16_t *window_size,
+                                                   unsigned input_width,
+                                                   unsigned input_height)
+{
+    (void) input_height;
     (*window_size) = ((*window_size) * input_width) / CAMBI_4K_WIDTH;
 }
 
@@ -385,8 +389,8 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     }
 
     s->src_window_size = s->window_size;
-    adjust_window_size(&s->window_size, s->enc_width);
-    adjust_window_size(&s->src_window_size, s->src_width);
+    adjust_window_size(&s->window_size, s->enc_width, s->enc_height);
+    adjust_window_size(&s->src_window_size, s->src_width, s->src_height);
     s->buffers.c_values = aligned_malloc(ALIGN_CEIL(alloc_w * sizeof(float)) * alloc_h, 32);
     if (!s->buffers.c_values) return -ENOMEM;
 

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -33,8 +33,8 @@
 /* Ratio of pixels for computation, must be 0 < topk <= 1.0 */
 #define DEFAULT_CAMBI_TOPK_POOLING (0.6)
 
-/* Window size to compute CAMBI: 63 corresponds to approximately 1 degree at 4k scale */
-#define DEFAULT_CAMBI_WINDOW_SIZE (63)
+/* Window size to compute CAMBI: 65 corresponds to approximately 1 degree at 4k scale */
+#define DEFAULT_CAMBI_WINDOW_SIZE (65)
 
 /* Visibility threshold for luminance ΔL < tvi_threshold*L_mean for BT.1886 */
 #define DEFAULT_CAMBI_TVI (0.019)

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -117,7 +117,7 @@ static const VmafOption options[] = {
         .offset = offsetof(CambiState, enc_width),
         .type = VMAF_OPT_TYPE_INT,
         .default_val.i = 0,
-        .min = 320,
+        .min = 180,
         .max = 7680,
     },
     {
@@ -126,8 +126,8 @@ static const VmafOption options[] = {
         .offset = offsetof(CambiState, enc_height),
         .type = VMAF_OPT_TYPE_INT,
         .default_val.i = 0,
-        .min = 200,
-        .max = 4320,
+        .min = 180,
+        .max = 7680,
     },
     {
         .name = "enc_bitdepth",

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -730,15 +730,45 @@ static float c_value_pixel(const uint16_t *histograms, uint16_t value, const int
     return c_value;
 }
 
+static FORCE_INLINE inline void increment_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]++;
+    }
+}
+
+static FORCE_INLINE inline void decrement_range(uint16_t *arr, int left, int right) {
+    for (int i = left; i < right; i++) {
+        arr[i]--;
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_subtract_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                          int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                          const uint16_t num_diffs) {
+    uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
+    if (mask_val) {
+        uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
+        decrement_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+    }
+}
+
 static FORCE_INLINE inline void update_histogram_subtract(uint16_t *histograms, uint16_t *image, uint16_t *mask,
                                                           int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
                                                           const uint16_t num_diffs) {
     uint16_t mask_val = mask[(i - pad_size - 1) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i - pad_size - 1) * stride + j] + num_diffs;
-        for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-            histograms[val * width + col]--;
-        }
+        decrement_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_edge(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[(i + pad_size) * stride + j];
+    if (mask_val) {
+        uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
     }
 }
 
@@ -748,9 +778,27 @@ static FORCE_INLINE inline void update_histogram_add(uint16_t *histograms, uint1
     uint16_t mask_val = mask[(i + pad_size) * stride + j];
     if (mask_val) {
         uint16_t val = image[(i + pad_size) * stride + j] + num_diffs;
-        for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-            histograms[val * width + col]++;
-        }
+        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_edge_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[i * stride + j];
+    if (mask_val) {
+        uint16_t val = image[i * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], MAX(j - pad_size, 0), MIN(j + pad_size + 1, width));
+    }
+}
+
+static FORCE_INLINE inline void update_histogram_add_first_pass(uint16_t *histograms, uint16_t *image, uint16_t *mask,
+                                                     int i, int j, int width, ptrdiff_t stride, uint16_t pad_size,
+                                                     const uint16_t num_diffs) {
+    uint16_t mask_val = mask[i * stride + j];
+    if (mask_val) {
+        uint16_t val = image[i * stride + j] + num_diffs;
+        increment_range(&histograms[val * width], j - pad_size, j + pad_size + 1);
     }
 }
 
@@ -788,37 +836,57 @@ static void calculate_c_values(VmafPicture *pic, const VmafPicture *mask_pic,
 
     // First pass: first pad_size rows
     for (int i = 0; i < pad_size; i++) {
-        for (int j = 0; j < width; j++) {
-            uint16_t mask_val = mask[i * stride + j];
-            if (mask_val) {
-                uint16_t val = image[i * stride + j] + num_diffs;
-                for (int col = MAX(j - pad_size, 0); col < MIN(j + pad_size + 1, width); col++) {
-                    histograms[val * width + col]++;
-                }
-            }
+        for (int j = 0; j < pad_size; j++) {
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = pad_size; j < width - pad_size - 1; j++) {
+            update_histogram_add_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+            update_histogram_add_edge_first_pass(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
         }
     }
 
     // Iterate over all rows, unrolled into 3 loops to avoid conditions
     for (int i = 0; i < pad_size + 1; i++) {
         if (i + pad_size < height) {
-            for (int j = 0; j < width; j++) {
+            for (int j = 0; j < pad_size; j++) {
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = pad_size; j < width - pad_size - 1; j++) {
                 update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+                update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = pad_size + 1; i < height - pad_size; i++) {
-        for (int j = 0; j < width; j++) {
+        for (int j = 0; j < pad_size; j++) {
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = pad_size; j < width - pad_size - 1; j++) {
             update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             update_histogram_add(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+        }
+        for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+            update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            update_histogram_add_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);
     }
     for (int i = height - pad_size; i < height; i++) {
         if (i - pad_size - 1 >= 0) {
-            for (int j = 0; j < width; j++) {
+            for (int j = 0; j < pad_size; j++) {
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = pad_size; j < width - pad_size - 1; j++) {
                 update_histogram_subtract(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
+            }
+            for (int j = MAX(width - pad_size - 1, pad_size); j < width; j++) {
+                update_histogram_subtract_edge(histograms, image, mask, i, j, width, stride, pad_size, num_diffs);
             }
         }
         calculate_c_values_row(c_values, histograms, image, mask, i, width, stride, num_diffs, tvi_for_diff, diff_weights, all_diffs);

--- a/libvmaf/src/feature/x86/cambi_avx2.c
+++ b/libvmaf/src/feature/x86/cambi_avx2.c
@@ -1,0 +1,46 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <immintrin.h>
+#include <stdint.h>
+
+void cambi_increment_range_avx2(uint16_t *arr, int left, int right) {
+    __m256i val_vector = _mm256_set1_epi16(1);
+    int col = left;
+    for (; col + 15 < right; col += 16) {
+        __m256i data = _mm256_loadu_si256((__m256i*) &arr[col]);
+        data = _mm256_add_epi16(data, val_vector);
+        _mm256_storeu_si256((__m256i*) &arr[col], data);
+    }
+    for (; col < right; col++) {
+        arr[col]++;
+    } 
+}
+
+void cambi_decrement_range_avx2(uint16_t *arr, int left, int right) {
+    __m256i val_vector = _mm256_set1_epi16(1);
+    int col = left;
+    for (; col + 15 < right; col += 16) {
+        __m256i data = _mm256_loadu_si256((__m256i*) &arr[col]);
+        data = _mm256_sub_epi16(data, val_vector);
+        _mm256_storeu_si256((__m256i*) &arr[col], data);
+    }
+    for (; col < right; col++) {
+        arr[col]--;
+    } 
+}

--- a/libvmaf/src/feature/x86/cambi_avx2.h
+++ b/libvmaf/src/feature/x86/cambi_avx2.h
@@ -1,0 +1,29 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef X86_AVX2_CAMBI_H_
+#define X86_AVX2_CAMBI_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+void cambi_increment_range_avx2(uint16_t *arr, int left, int right);
+
+void cambi_decrement_range_avx2(uint16_t *arr, int left, int right);
+
+#endif /* X86_AVX2_CAMBI_H_ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -181,6 +181,7 @@ if is_asm_enabled
           feature_src_dir + 'x86/motion_avx2.c',
           feature_src_dir + 'x86/vif_avx2.c',
           feature_src_dir + 'x86/adm_avx2.c',
+          feature_src_dir + 'x86/cambi_avx2.c',
       ]
 
       x86_avx2_static_lib = static_library(

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -348,7 +348,8 @@ static char *test_calculate_c_values()
     get_sample_image(&input, 0);
     get_sample_image(&mask, 8);
     calculate_c_values(&input, &mask, combined_c_values, histograms, window_size,
-                       num_diffs, tvi_for_diff, diff_weights, all_diffs, width, height);
+                       num_diffs, tvi_for_diff, diff_weights, all_diffs, width, height, 
+                       increment_range, decrement_range);
 
     for (unsigned i=0; i<16; i++) {
         mu_assert("calculate_c_values error ws=3",
@@ -362,7 +363,8 @@ static char *test_calculate_c_values()
     window_size = 9;
     uint16_t histograms_8x8[8*1032];
     calculate_c_values(&input_8x8, &mask_8x8, combined_c_values_8x8, histograms_8x8,
-                       window_size, num_diffs, tvi_for_diff, diff_weights, all_diffs, 8, 8);
+                       window_size, num_diffs, tvi_for_diff, diff_weights, all_diffs, 8, 8, 
+                       increment_range, decrement_range);
 
     double sum = 0;
     for (unsigned i=0; i<64; i++)
@@ -398,6 +400,24 @@ static char *test_c_value_pixel()
     value = 4;
     c_value = c_value_pixel(histogram, value, diff_weights, diffs, num_diffs, tvi_thresholds, 0, 1);
     mu_assert("c_value_all_diffs for value=4, weights=4,5", almost_equal(c_value, 0));
+    return NULL;
+}
+
+static char *test_update_range()
+{
+    uint16_t arr[15] = {5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
+    increment_range(arr, 5, 10);
+    mu_assert("increment_range i=5", arr[5] == 6);
+    mu_assert("increment_range i=7", arr[7] == 6);
+    mu_assert("increment_range i=9", arr[9] == 6);
+    mu_assert("increment_range i=10", arr[10] == 5);
+
+    decrement_range(arr, 2, 6);
+    mu_assert("decrement_range i=2", arr[2] == 4);
+    mu_assert("decrement_range i=4", arr[4] == 4);
+    mu_assert("decrement_range i=5", arr[5] == 5);
+    mu_assert("decrement_range i=8", arr[8] == 6);
+
     return NULL;
 }
 
@@ -624,6 +644,7 @@ char *run_tests()
 
     mu_run_test(test_calculate_c_values);
     mu_run_test(test_c_value_pixel);
+    mu_run_test(test_update_range);
 
     mu_run_test(test_spatial_pooling);
     mu_run_test(test_quick_select);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -283,10 +283,24 @@ static char *test_filter_mode()
 
 static char *test_get_mask_index()
 {
-    uint16_t index = get_mask_index(1980, 1080, 7);
-    mu_assert("get_mask_index wrong index for (1980, 1080)", index==21);
-    index = get_mask_index(3840, 2160, 7);
+    uint16_t index = get_mask_index(3840, 2160, 7);
     mu_assert("get_mask_index wrong index for (3840, 2160)", index==24);
+    index = get_mask_index(2560, 1440, 7);
+    mu_assert("get_mask_index wrong index for (2560, 1440)", index==22);
+    index = get_mask_index(1980, 1080, 7);
+    mu_assert("get_mask_index wrong index for (1980, 1080)", index==21);
+    index = get_mask_index(1280, 720, 7);
+    mu_assert("get_mask_index wrong index for (1280, 720)", index==18);
+    index = get_mask_index(960, 540, 7);
+    mu_assert("get_mask_index wrong index for (960, 540)", index==15);
+    index = get_mask_index(640, 360, 7);
+    mu_assert("get_mask_index wrong index for (640, 360)", index==9);
+    index = get_mask_index(480, 270, 7);
+    mu_assert("get_mask_index wrong index for (480, 270)", index==3);
+    index = get_mask_index(320, 180, 7);
+    mu_assert("get_mask_index wrong index for (320, 180)", index==65527);
+    index = get_mask_index(6000, 4000, 7);
+    mu_assert("get_mask_index wrong index for (6000, 4000)", index==27);
     index = get_mask_index(960, 540, 5);
     mu_assert("get_mask_index wrong index for (960, 540)", index==3);
     return NULL;
@@ -502,8 +516,36 @@ static char *test_adjust_window_size()
     mu_assert("adjusted window size for input=3840, ws=63", window_size==63);
 
     window_size = 63;
+    adjust_window_size(&window_size, 2560);
+    mu_assert("adjusted window size for input=2560, ws=63", window_size==42);
+
+    window_size = 63;
     adjust_window_size(&window_size, 1920);
     mu_assert("adjusted window size for input=1920, ws=63", window_size==31);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 1280);
+    mu_assert("adjusted window size for input=1280, ws=63", window_size==21);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 960);
+    mu_assert("adjusted window size for input=960, ws=63", window_size==15);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 640);
+    mu_assert("adjusted window size for input=640, ws=63", window_size==10);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 480);
+    mu_assert("adjusted window size for input=480, ws=63", window_size==7);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 320);
+    mu_assert("adjusted window size for input=320, ws=63", window_size==5);
+
+    window_size = 63;
+    adjust_window_size(&window_size, 6000);
+    mu_assert("adjusted window size for input=6000, ws=63", window_size==98);
 
     window_size = 60;
     adjust_window_size(&window_size, 1920);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -290,19 +290,19 @@ static char *test_get_mask_index()
     index = get_mask_index(1980, 1080, 7);
     mu_assert("get_mask_index wrong index for (1980, 1080)", index==21);
     index = get_mask_index(1280, 720, 7);
-    mu_assert("get_mask_index wrong index for (1280, 720)", index==18);
+    mu_assert("get_mask_index wrong index for (1280, 720)", index==19);
     index = get_mask_index(960, 540, 7);
-    mu_assert("get_mask_index wrong index for (960, 540)", index==15);
+    mu_assert("get_mask_index wrong index for (960, 540)", index==18);
     index = get_mask_index(640, 360, 7);
-    mu_assert("get_mask_index wrong index for (640, 360)", index==9);
+    mu_assert("get_mask_index wrong index for (640, 360)", index==16);
     index = get_mask_index(480, 270, 7);
-    mu_assert("get_mask_index wrong index for (480, 270)", index==3);
+    mu_assert("get_mask_index wrong index for (480, 270)", index==15);
     index = get_mask_index(320, 180, 7);
-    mu_assert("get_mask_index wrong index for (320, 180)", index==65527);
+    mu_assert("get_mask_index wrong index for (320, 180)", index==13);
     index = get_mask_index(6000, 4000, 7);
     mu_assert("get_mask_index wrong index for (6000, 4000)", index==27);
     index = get_mask_index(960, 540, 5);
-    mu_assert("get_mask_index wrong index for (960, 540)", index==3);
+    mu_assert("get_mask_index wrong index for (960, 540)", index==6);
     return NULL;
 }
 
@@ -545,7 +545,7 @@ static char *test_adjust_window_size()
 
     window_size = 63;
     adjust_window_size(&window_size, 6000, 4000);
-    mu_assert("adjusted window size for input=(6000, 4000), ws=63", window_size==98);
+    mu_assert("adjusted window size for input=(6000, 4000), ws=63", window_size==105);
 
     window_size = 60;
     adjust_window_size(&window_size, 1920, 1080);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -236,7 +236,6 @@ static char *test_filter_mode()
 {
     VmafPicture filtered_image, image;
     unsigned w = 5, h = 5;
-    uint8_t histogram[1024];
     uint16_t buffer[3 * w];
 
     int err = vmaf_picture_alloc(&filtered_image, VMAF_PIX_FMT_YUV400P, 10, w, h);
@@ -248,31 +247,32 @@ static char *test_filter_mode()
     uint16_t *filtered_data = filtered_image.data[0];
     ptrdiff_t output_stride = filtered_image.stride[0]>>1;
 
-    data[2 * stride + 2] = 1; data[3 * stride + 2] = 1;
-    data[2 * stride + 3] = 1; data[3 * stride + 3] = 1;
+    data[1 * stride + 2] = 1; data[2 * stride + 2] = 1;
+    data[1 * stride + 3] = 1; data[3 * stride + 3] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: all zeros", data_pic_sum(&filtered_image)==0);
 
     data[3 * stride + 4] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
-    mu_assert("filter_mode: two ones sum check", data_pic_sum(&filtered_image)==2);
-    mu_assert("filter_mode: two ones (3,3) check", filtered_data[3 * output_stride + 3]==1);
-    mu_assert("filter_mode: two ones (2,3) check", filtered_data[2 * output_stride + 3]==1);
+    filter_mode(&filtered_image, w, h, buffer);
+
+    mu_assert("filter_mode: one one sum check", data_pic_sum(&filtered_image)==1);
+    mu_assert("filter_mode: zero (3,3) check", filtered_data[3 * output_stride + 3]==0);
+    mu_assert("filter_mode: one (2,3) check", filtered_data[2 * output_stride + 3]==1);
 
     data[0 * stride + 0] = 2;
     data[0 * stride + 1] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: two in the corner check", filtered_data[0 * output_stride + 0]==2);
     data[1 * stride + 0] = 1;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
-    mu_assert("filter_mode: two in the corner and adjacent ones check", filtered_data[0 * output_stride + 0]==1);
+    filter_mode(&filtered_image, w, h, buffer);
+    mu_assert("filter_mode: two in the corner and adjacent one check", filtered_data[0 * output_stride + 1]==1);
     data[2 * stride + 0] = 2;
     memcpy(filtered_data, data, stride * h * sizeof(uint16_t));
-    filter_mode(&filtered_image, w, h, histogram, buffer);
+    filter_mode(&filtered_image, w, h, buffer);
     mu_assert("filter_mode: two in corner and edge check", filtered_data[1 * output_stride + 0]==2);
 
     vmaf_picture_unref(&image);

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -512,48 +512,48 @@ static char *test_weight_scores_per_scale()
 static char *test_adjust_window_size()
 {
     uint16_t window_size = 63;
-    adjust_window_size(&window_size, 3840);
-    mu_assert("adjusted window size for input=3840, ws=63", window_size==63);
+    adjust_window_size(&window_size, 3840, 2160);
+    mu_assert("adjusted window size for input=(3840, 2160), ws=63", window_size==63);
 
     window_size = 63;
-    adjust_window_size(&window_size, 2560);
-    mu_assert("adjusted window size for input=2560, ws=63", window_size==42);
+    adjust_window_size(&window_size, 2560, 1440);
+    mu_assert("adjusted window size for input=(2560, 1440), ws=63", window_size==42);
 
     window_size = 63;
-    adjust_window_size(&window_size, 1920);
-    mu_assert("adjusted window size for input=1920, ws=63", window_size==31);
+    adjust_window_size(&window_size, 1920, 1080);
+    mu_assert("adjusted window size for input=(1920, 1080), ws=63", window_size==31);
 
     window_size = 63;
-    adjust_window_size(&window_size, 1280);
-    mu_assert("adjusted window size for input=1280, ws=63", window_size==21);
+    adjust_window_size(&window_size, 1280, 720);
+    mu_assert("adjusted window size for input=(1280, 720), ws=63", window_size==21);
 
     window_size = 63;
-    adjust_window_size(&window_size, 960);
-    mu_assert("adjusted window size for input=960, ws=63", window_size==15);
+    adjust_window_size(&window_size, 960, 540);
+    mu_assert("adjusted window size for input=(960, 540), ws=63", window_size==15);
 
     window_size = 63;
-    adjust_window_size(&window_size, 640);
-    mu_assert("adjusted window size for input=640, ws=63", window_size==10);
+    adjust_window_size(&window_size, 640, 360);
+    mu_assert("adjusted window size for input=(640, 360), ws=63", window_size==10);
 
     window_size = 63;
-    adjust_window_size(&window_size, 480);
-    mu_assert("adjusted window size for input=480, ws=63", window_size==7);
+    adjust_window_size(&window_size, 480, 270);
+    mu_assert("adjusted window size for input=(480, 270), ws=63", window_size==7);
 
     window_size = 63;
-    adjust_window_size(&window_size, 320);
-    mu_assert("adjusted window size for input=320, ws=63", window_size==5);
+    adjust_window_size(&window_size, 320, 180);
+    mu_assert("adjusted window size for input=(320, 180), ws=63", window_size==5);
 
     window_size = 63;
-    adjust_window_size(&window_size, 6000);
-    mu_assert("adjusted window size for input=6000, ws=63", window_size==98);
+    adjust_window_size(&window_size, 6000, 4000);
+    mu_assert("adjusted window size for input=(6000, 4000), ws=63", window_size==98);
 
     window_size = 60;
-    adjust_window_size(&window_size, 1920);
-    mu_assert("adjusted window size for input=1920, ws=60", window_size==30);
+    adjust_window_size(&window_size, 1920, 1080);
+    mu_assert("adjusted window size for input=(1920, 1080), ws=60", window_size==30);
 
     window_size = 31;
-    adjust_window_size(&window_size, 1280);
-    mu_assert("adjusted window size for input=1280, ws=31", window_size==10);
+    adjust_window_size(&window_size, 1280, 720);
+    mu_assert("adjusted window size for input=(1280, 720), ws=31", window_size==10);
 
     return NULL;
 }

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -28,9 +28,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.664931, places=4)
+                               0.25968416666666666, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0014658541666666667, places=4)
+                               0.00020847916666666663, places=4)
 
     def test_run_cambi_fextractor_scaled(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing_scaled()
@@ -45,9 +45,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.79470425, places=4)
+                               0.17871631249999997, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0033943124999999998, places=4)
+                               0.00022027083333333336, places=4)
 
     def test_run_cambi_fextractor_scaled_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -62,7 +62,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               1.270708, places=4)
+                               0.773078, places=4)
 
     def test_run_cambi_fextractor_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -77,7 +77,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.016021, places=4)
+                               0.0013863333333333334, places=4)
 
     def test_run_cambi_fextractor_max_log_contrast(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -92,9 +92,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.9313579999999999, places=4)
+                               0.32247770833333333, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0022395208333333334, places=4)
+                               0.0002582708333333333, places=4)
 
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -107,9 +107,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.019885541666666666, places=4)
+                               0.0024372291666666665, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0007890833333333334, places=4)
+                               0.00019045833333333336, places=4)
 
     def test_run_cambi_fextractor_full_reference(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -123,11 +123,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.664931, places=4)
+                               0.25968416666666666, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.00146585416, places=4)
+                               0.00020847916666666663, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.6635012083333333, places=4)
+                               0.2594353333333333, places=4)
 
     def test_run_cambi_fextractor_full_reference_scaled_ref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -142,11 +142,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.664931, places=4)
+                               0.25968416666666666, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.0033943124999999998, places=4)
+                               0.00022027083333333336, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.6615367083333333, places=4)
+                               0.25944045833333335, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):
@@ -163,9 +163,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.664931, places=4)
+                               0.25968416666666666, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.0014658541666666667, places=4)
+                               0.00020847916666666663, places=4)
 
     def test_run_cambi_runner_scale(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing_scaled()
@@ -180,9 +180,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.79470425, places=4)
+                               0.17871631249999997, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.0033943124999999998, places=4)
+                               0.00022027083333333336, places=4)
 
     def test_run_cambi_runner_scale_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -197,7 +197,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               1.270708, places=4)
+                               0.773078, places=4)
 
     def test_run_cambi_runner_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -212,7 +212,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.016021, places=4)
+                               0.0013863333333333334, places=4)
 
     def test_run_cambi_runner_fullref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -226,9 +226,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_score'],
-                               0.6635012083333333, places=4)
+                               0.2594353333333333, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.664931, places=4)
+                               0.25968416666666666, places=4)
 
 
 if __name__ == '__main__':

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -28,7 +28,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.6892500624999999, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
                                0.0014658541666666667, places=4)
 
@@ -45,9 +45,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.9204257916666666, places=4)
+                               0.8740225, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.004251791666666667, places=4)
+                               0.004161041666666666, places=4)
 
     def test_run_cambi_fextractor_scaled_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -62,7 +62,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               1.218365, places=4)
+                               1.309229, places=4)
 
     def test_run_cambi_fextractor_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -77,7 +77,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.01451, places=4)
+                               0.016021, places=4)
 
     def test_run_cambi_fextractor_max_log_contrast(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -92,9 +92,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.9182153958333333, places=4)
+                               0.9313579999999999, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.0024499791666667, places=4)
+                               0.0022395208333333334, places=4)
 
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -107,9 +107,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.015840666666666666, places=4)
+                               0.019885541666666666, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.000671125, places=4)
+                               0.0007890833333333334, places=4)
 
     def test_run_cambi_fextractor_full_reference(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -123,11 +123,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.689250, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
                                0.00146585416, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.687784, places=4)
+                               0.6635012083333333, places=4)
 
     def test_run_cambi_fextractor_full_reference_scaled_ref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -142,11 +142,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.689250, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.0042517916, places=4)
+                               0.004161041666666666, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.6849983125, places=4)
+                               0.66077, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):
@@ -163,7 +163,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.6892500624999999, places=4)
+                               0.664931, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
                                0.0014658541666666667, places=4)
 
@@ -180,9 +180,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.9204257916666666, places=4)
+                               0.8740225, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.004251791666666667, places=4)
+                               0.004161041666666666, places=4)
 
     def test_run_cambi_runner_scale_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -197,7 +197,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               1.218365, places=4)
+                               1.309229, places=4)
 
     def test_run_cambi_runner_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -212,7 +212,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.01451, places=4)
+                               0.016021, places=4)
 
     def test_run_cambi_runner_fullref(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -226,9 +226,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_FR_score'],
-                               0.687784125, places=4)
+                               0.6635012083333333, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
-                               0.68925006249, places=4)
+                               0.664931, places=4)
 
 
 if __name__ == '__main__':

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -45,9 +45,9 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               0.8740225, places=4)
+                               0.79470425, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
 
     def test_run_cambi_fextractor_scaled_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -62,7 +62,7 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_score'],
-                               1.309229, places=4)
+                               1.270708, places=4)
 
     def test_run_cambi_fextractor_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
@@ -144,9 +144,9 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_score'],
                                0.664931, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
-                               0.66077, places=4)
+                               0.6615367083333333, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):
@@ -180,9 +180,9 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               0.8740225, places=4)
+                               0.79470425, places=4)
         self.assertAlmostEqual(results[1]['Cambi_score'],
-                               0.004161041666666666, places=4)
+                               0.0033943124999999998, places=4)
 
     def test_run_cambi_runner_scale_b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_b()
@@ -197,7 +197,7 @@ class CambiQualityRunnerTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_score'],
-                               1.309229, places=4)
+                               1.270708, places=4)
 
     def test_run_cambi_runner_10b(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()


### PR DESCRIPTION
- Simplification of `filter_mode` by separating it into iterated smaller mode filters
- Unrolling of loops in `calculate_c_values` so that edge case checking doesn't impact the majority of the loop iterations
- Default `window_size` changed from 63 to 65 for better computational performance
- SIMD implementation of the histogram updates
- Adjustment of the `mask_index` computation to fix small resolutions and not use floating point math
- Adjustment of the `window_size` computation to be rotation invariant and not use floating point math
- Update resolution limits to accept smaller and larger videos

These changes include #997, #999, #1000. Those PRs will be closed.