### PR TITLE
Fix meson warnings about missing keyword arguments

### DIFF
--- a/libvmaf/src/feature/vif_tools.c
+++ b/libvmaf/src/feature/vif_tools.c
@@ -525,7 +525,7 @@ void vif_filter1d_xy_s(const float *f, const float *src1, const float *src2, flo
 {
 
 	int src1_px_stride = src1_stride / sizeof(float);
-	int src2_px_stride = src1_stride / sizeof(float);
+	int src2_px_stride = src2_stride / sizeof(float);
 	int dst_px_stride = dst_stride / sizeof(float);
 
 	/* if support avx */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -41,7 +41,7 @@ if is_asm_enabled
         # check NASM version
         nasm = find_program('nasm')
         if nasm.found()
-            nasm_r = run_command(nasm, '-v')
+            nasm_r = run_command(nasm, '-v', check: true)
 
             if nasm_r.returncode() != 0
                 error('failed running nasm to obtain its version')
@@ -190,7 +190,7 @@ if is_asm_enabled
           c_args : ['-mavx', '-mavx2'] + vmaf_cflags_common,
       )
 
-      platform_specific_cpu_objects += x86_avx2_static_lib.extract_all_objects()
+      platform_specific_cpu_objects += x86_avx2_static_lib.extract_all_objects(recursive: true)
 
       if is_avx512_enabled
         x86_avx512_sources = [
@@ -207,7 +207,7 @@ if is_asm_enabled
                      vmaf_cflags_common,
         )
 
-        platform_specific_cpu_objects += x86_avx512_static_lib.extract_all_objects()
+        platform_specific_cpu_objects += x86_avx512_static_lib.extract_all_objects(recursive: true)
       endif
 
     endif
@@ -321,8 +321,8 @@ libvmaf = library(
     ],
     objects : [
         platform_specific_cpu_objects,
-        libvmaf_feature_static_lib.extract_all_objects(),
-        libvmaf_cpu_static_lib.extract_all_objects(),
+        libvmaf_feature_static_lib.extract_all_objects(recursive: true),
+        libvmaf_cpu_static_lib.extract_all_objects(recursive: true),
     ],
     version : vmaf_soname_version,
     soversion : vmaf_soversion,

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -61,8 +61,8 @@ test_feature_extractor = executable('test_feature_extractor',
     dependencies : [math_lib, stdatomic_dependency],
     objects : [
       platform_specific_cpu_objects,
-      libvmaf_feature_static_lib.extract_all_objects(),
-      libvmaf_cpu_static_lib.extract_all_objects(),
+      libvmaf_feature_static_lib.extract_all_objects(recursive: true),
+      libvmaf_cpu_static_lib.extract_all_objects(recursive: true),
     ]
 )
 
@@ -74,7 +74,7 @@ test_dict = executable('test_dict',
 test_cpu = executable('test_cpu',
     ['test.c', 'test_cpu.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
-    objects : libvmaf_cpu_static_lib.extract_all_objects(),
+    objects : libvmaf_cpu_static_lib.extract_all_objects(recursive: true),
 )
 
 test_ref = executable('test_ref',


### PR DESCRIPTION
Meson is planning to change the default value of optional arguments in two functions:
* `run_command`: `check` will go from false to true, [link](https://github.com/mesonbuild/meson/issues/9300)
* `extract_all_objects`: `recursive` will go from false to true, [link](https://mesonbuild.com/Release-notes-for-0-46-0.html#recursively-extract-objects)

Since these don't affect our build, we can just add the keyword arguments to avoid warnings.