### PR TITLE
Fix typo-related bug in `vif_tools.c`

### DIFF
--- a/libvmaf/src/feature/vif_tools.c
+++ b/libvmaf/src/feature/vif_tools.c
@@ -525,7 +525,7 @@ void vif_filter1d_xy_s(const float *f, const float *src1, const float *src2, flo
 {
 
 	int src1_px_stride = src1_stride / sizeof(float);
-	int src2_px_stride = src1_stride / sizeof(float);
+	int src2_px_stride = src2_stride / sizeof(float);
 	int dst_px_stride = dst_stride / sizeof(float);
 
 	/* if support avx */


### PR DESCRIPTION
This line was supposed to use `src2_stride`, but it uses `src1_stride`, likely due to a typo. `src2_stride` is then never used, which triggered a warning. Check line 561 where this stride is used to index `src2`.