### PR TITLE
libvmaf: add null feature extractor

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -43,6 +43,7 @@ extern VmafFeatureExtractor vmaf_fex_integer_adm;
 extern VmafFeatureExtractor vmaf_fex_integer_motion;
 extern VmafFeatureExtractor vmaf_fex_integer_vif;
 extern VmafFeatureExtractor vmaf_fex_cambi;
+extern VmafFeatureExtractor vmaf_fex_null;
 
 static VmafFeatureExtractor *feature_extractor_list[] = {
 #if VMAF_FLOAT_FEATURES
@@ -62,6 +63,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_integer_motion,
     &vmaf_fex_integer_vif,
     &vmaf_fex_cambi,
+    &vmaf_fex_null,
     NULL
 };
 

--- a/libvmaf/src/feature/null.c
+++ b/libvmaf/src/feature/null.c
@@ -1,0 +1,53 @@
+/**
+ *
+ *  Copyright 2016-2022 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "feature_extractor.h"
+
+static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                unsigned bpc, unsigned w, unsigned h)
+{
+    (void) fex;
+    (void) pix_fmt;
+    (void) bpc;
+    (void) w;
+    (void) h;
+
+    return 0;
+}
+
+static int extract(VmafFeatureExtractor *fex,
+                   VmafPicture *ref_pic, VmafPicture *ref_pic_90,
+                   VmafPicture *dist_pic, VmafPicture *dist_pic_90,
+                   unsigned index, VmafFeatureCollector *feature_collector)
+{
+    (void) fex;
+    (void) ref_pic;
+    (void) ref_pic_90;
+    (void) dist_pic;
+    (void) dist_pic_90;
+    (void) index;
+    (void) feature_collector;
+
+    return 0;
+}
+
+VmafFeatureExtractor vmaf_fex_null = {
+    .name = "null",
+    .init = init,
+    .extract = extract,
+};

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -247,6 +247,7 @@ libvmaf_feature_sources = [
     feature_src_dir + 'iqa/convolve.c',
     feature_src_dir + 'cambi.c',
     feature_src_dir + 'luminance_tools.c',
+    feature_src_dir + 'null.c',
 ]
 
 if float_enabled


### PR DESCRIPTION
Adds a very simple noop feature extractor. Useful for testing overall libvmaf throughput without any computational overhead which would be required from a real feature extractor.