### PR TITLE
libvmaf/vmaf: add --frame_cnt cli option

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -24,6 +24,7 @@ enum {
     ARG_SUBSAMPLE,
     ARG_CPUMASK,
     ARG_AOM_CTC,
+    ARG_FRAME_CNT,
 };
 
 static const struct option long_opts[] = {
@@ -44,6 +45,7 @@ static const struct option long_opts[] = {
     { "subsample",        1, NULL, ARG_SUBSAMPLE },
     { "cpumask",          1, NULL, ARG_CPUMASK },
     { "aom_ctc",          1, NULL, ARG_AOM_CTC },
+    { "frame_cnt",        1, NULL, ARG_FRAME_CNT },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { "quiet",            0, NULL, 'q' },
@@ -78,6 +80,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --threads $unsigned:       number of threads to use\n"
             " --feature $string:         additional feature\n"
             " --cpumask: $bitmask        restrict permitted CPU instruction sets\n"
+            " --frame_cnt $unsigned:     maximum number of frames to process\n"
             " --subsample: $unsigned     compute scores only every N frames\n"
             " --quiet/-q:                disable FPS meter when run in a TTY\n"
             " --no_prediction/-n:        no prediction, extract features only\n"
@@ -367,6 +370,10 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case ARG_AOM_CTC:
             parse_aom_ctc(settings, optarg, argv[0]);
+            break;
+        case ARG_FRAME_CNT:
+            settings->frame_cnt =
+                parse_unsigned(optarg, ARG_FRAME_CNT, argv[0]);
             break;
         case 'n':
             settings->no_prediction = true;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -30,6 +30,7 @@ typedef struct {
 
 typedef struct {
     char *path_ref, *path_dist;
+    unsigned frame_cnt;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;
     unsigned bitdepth;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -310,6 +310,10 @@ int main(int argc, char *argv[])
     const time_t t0 = clock();
     unsigned picture_index;
     for (picture_index = 0 ;; picture_index++) {
+
+        if (c.frame_cnt && picture_index >= c.frame_cnt)
+            break;
+
         VmafPicture pic_ref, pic_dist;
         int ret1 = fetch_picture(&vid_ref, &pic_ref);
         int ret2 = fetch_picture(&vid_dist, &pic_dist);


### PR DESCRIPTION
Adds a `--frame_cnt` cli option to `vmaf`. Mainly useful for performance testing with endless streams (`/dev/zero` et al.) or development/debugging with longer files. `vmaf` uses `--frame_cnt` as an upper bound maximum number of frames to process. Default behavior is unchanged.