### PR TITLE
libvmaf: fix unused function warning in adm.c

### DIFF
--- a/libvmaf/src/feature/adm.c
+++ b/libvmaf/src/feature/adm.c
@@ -49,6 +49,7 @@ static char *init_dwt_band(adm_dwt_band_t *band, char *data_top, size_t buf_sz_o
     return data_top;
 }
 
+__attribute__((unused))
 static char *init_dwt_band_d(adm_dwt_band_t_d *band, char *data_top, size_t buf_sz_one)
 {
     band->band_a = (double *)data_top; data_top += buf_sz_one;


### PR DESCRIPTION
As mentioned in #1004, this function is used by a Cython file, but it's not used by any C code so it throws an "unused function" warning. My fix is to use `__attribute__((unused))`, which works on all compilers that I've tried. There are also a few usages of `__attribute__` in libvmaf already so I think it shouldn't restrict portability.

After this, the only warnings left are the deprecated `compute_vmaf` call and the `vif_avx2` file. There may be other warnings when compiling with `-Denable_avx512=true` which I haven't checked.