### PR TITLE
libvmaf/vmaf: prepare --aom_ctc v3.0 preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## (2022-04-11) [v2.3.1]
+
+This is a minor release with some CAMBI extensions and speed-ups and adding it to AOM CTC v3, as well as a few minor fixes/cleanups.
+- CAMBI extensions: full reference, PQ eotf, up to 16 bit-depth support, max_log_contrast parameter.
+- CAMBI: option to output heatmaps.
+
 ## (2021-10-16) [v2.3.0]
 
 New release to add CAMBI (Contrast Aware Multiscale Banding Index).

--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -1,5 +1,5 @@
 project('libvmaf', ['c', 'cpp'],
-    version : '2.3.0',
+    version : '2.3.1',
     default_options : ['c_std=c11',
                        'cpp_std=c++11',
                        'warning_level=2',
@@ -8,7 +8,7 @@ project('libvmaf', ['c', 'cpp'],
                       ],
     meson_version: '>= 0.47.0')
 
-vmaf_soname_version       = '1.1.2'
+vmaf_soname_version       = '1.1.3'
 vmaf_api_version_array    = vmaf_soname_version.split('.')
 vmaf_api_version_major    = vmaf_api_version_array[0]
 vmaf_api_version_minor    = vmaf_api_version_array[1]

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -287,14 +287,39 @@ static void aom_ctc_v1_0(CLISettings *settings, const char *const app)
         parse_feature_config("psnr_hvs", app);
 }
 
+static void aom_ctc_v2_0(CLISettings *settings, const char *app)
+{
+    aom_ctc_v1_0(settings, app);
+}
+
+static void aom_ctc_v3_0(CLISettings *settings, const char *app)
+{
+    aom_ctc_v2_0(settings, app);
+    settings->feature_cfg[settings->feature_cnt++] =
+        parse_feature_config("cambi", app);
+}
+
 static void parse_aom_ctc(CLISettings *settings, const char *const optarg,
                           const char *const app)
 {
     if (!strcmp(optarg, "proposed"))
-        usage(app, "`--aom_ctc proposed` is deprecated. Use `--aom_ctc v1.0`");
-    else if (!strcmp(optarg, "v1.0") || !strcmp(optarg, "v2.0"))
+        usage(app, "`--aom_ctc proposed` is deprecated.");
+
+    if (!strcmp(optarg, "v1.0")) {
         aom_ctc_v1_0(settings, app);
-    else
+        return;
+    }
+
+    if (!strcmp(optarg, "v2.0")) {
+        aom_ctc_v2_0(settings, app);
+        return;
+    }
+
+    if (!strcmp(optarg, "v3.0")) {
+        aom_ctc_v3_0(settings, app);
+        return;
+    }
+
     usage(app, "bad aom_ctc version \"%s\"", optarg);
 }
 

--- a/resource/doc/aom_ctc.md
+++ b/resource/doc/aom_ctc.md
@@ -44,3 +44,11 @@ There are also a few optional command-line settings you may find useful.
   * Initial CTC release, `--aom_ctc proposed` deprecated.
   * Release: [libvmaf v2.1.0](https://github.com/Netflix/vmaf/releases/tag/v2.1.0)
   * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.1.0)
+
+* v2.0: `--aom_ctc v2.0`
+  * 2020-12-22.
+  * Release: [libvmaf v2.2.1](https://github.com/Netflix/vmaf/releases/tag/v2.2.1)
+  * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.2.1)
+
+* v3.0: `--aom_ctc v3.0`
+  * TBD

--- a/resource/doc/aom_ctc.md
+++ b/resource/doc/aom_ctc.md
@@ -13,6 +13,7 @@ Using the versioned `--aom_ctc` preset, the following metrics will be computed a
 * CIEDE-2000
 * VMAF
 * VMAF NEG
+* CAMBI
 
 ## Usage
 Basic usage of the tool is described in the [`vmaf` README](../../libvmaf/tools/README.md). Use the versioned `--aom_ctc` presets to register and configure all metrics according to the AOM CTC. Basic AOM CTC usage is as follows:
@@ -46,9 +47,11 @@ There are also a few optional command-line settings you may find useful.
   * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.1.0)
 
 * v2.0: `--aom_ctc v2.0`
-  * 2020-12-22.
   * Release: [libvmaf v2.2.1](https://github.com/Netflix/vmaf/releases/tag/v2.2.1)
   * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.2.1)
 
 * v3.0: `--aom_ctc v3.0`
-  * TBD
+  * 2022-04-05
+  * Add CAMBI
+  * Release: [libvmaf v2.3.1](https://github.com/Netflix/vmaf/releases/tag/v2.3.1)
+  * Precompiled static binaries [here](https://github.com/Netflix/vmaf/releases/tag/v2.3.1)


### PR DESCRIPTION
This PR prepares the `--aom_ctc v3.0` preset. The only difference to previous versions is the addition of the `cambi` metric.