### PR TITLE
libvmaf: add picture_pool api

### DIFF
--- a/libvmaf/include/libvmaf/picture.h
+++ b/libvmaf/include/libvmaf/picture.h
@@ -35,19 +35,37 @@ enum VmafPixelFormat {
 
 typedef struct VmafRef VmafRef;
 
-typedef struct {
+typedef struct VmafPicture {
     enum VmafPixelFormat pix_fmt;
     unsigned bpc;
     unsigned w[3], h[3];
     ptrdiff_t stride[3];
     void *data[3];
     VmafRef *ref;
+    void *priv;
 } VmafPicture;
 
 int vmaf_picture_alloc(VmafPicture *pic, enum VmafPixelFormat pix_fmt,
                        unsigned bpc, unsigned w, unsigned h);
 
 int vmaf_picture_unref(VmafPicture *pic);
+
+typedef struct VmafPicturePoolConfig {
+    unsigned pic_cnt;
+    int (*alloc_picture_callback)(VmafPicture *pic, void *cookie);
+    int (*free_picture_callback)(VmafPicture *pic, void *cookie);
+    void *cookie;
+} VmafPicturePoolConfig;
+
+typedef struct VmafPicturePool VmafPicturePool;
+
+int vmaf_picture_pool_init(VmafPicturePool **pic_pool,
+                           VmafPicturePoolConfig cfg);
+
+int vmaf_picture_pool_request_picture(VmafPicturePool *pic_pool,
+                                      VmafPicture *pic);
+
+int vmaf_picture_pool_close(VmafPicturePool *pic_pool);
 
 #ifdef __cplusplus
 }

--- a/libvmaf/include/libvmaf/picture.h
+++ b/libvmaf/include/libvmaf/picture.h
@@ -53,6 +53,7 @@ int vmaf_picture_unref(VmafPicture *pic);
 typedef struct VmafPicturePoolConfig {
     unsigned pic_cnt;
     int (*alloc_picture_callback)(VmafPicture *pic, void *cookie);
+    int (*synchronize_picture_callback)(VmafPicture *pic, void *cookie);
     int (*free_picture_callback)(VmafPicture *pic, void *cookie);
     void *cookie;
 } VmafPicturePoolConfig;

--- a/libvmaf/src/picture.h
+++ b/libvmaf/src/picture.h
@@ -21,6 +21,16 @@
 
 #include "libvmaf/picture.h"
 
+typedef struct VmafPicturePrivate {
+    void *cookie;
+    int (*release_picture)(VmafPicture *pic, void *cookie);
+} VmafPicturePrivate;
+
+int vmaf_picture_priv_init(VmafPicture *pic);
+
 int vmaf_picture_ref(VmafPicture *dst, VmafPicture *src);
+
+int vmaf_picture_set_release_callback(VmafPicture *pic, void *cookie,
+                        int (*release_picture)(VmafPicture *pic, void *cookie));
 
 #endif /* __VMAF_SRC_PICTURE_H__ */

--- a/libvmaf/src/picture_pool.c
+++ b/libvmaf/src/picture_pool.c
@@ -1,0 +1,136 @@
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "picture.h"
+#include "ref.h"
+
+typedef struct VmafPicturePool {
+    VmafPicturePoolConfig cfg;
+    pthread_mutex_t lock;
+    VmafPicture *pic;
+    struct {
+        VmafPicture *head, *tail;
+        pthread_cond_t available;
+        pthread_cond_t empty;
+    } queue;
+} VmafPicturePool;
+
+static int release_picture_callback(VmafPicture *pic, void *cookie)
+{
+    if (!pic) return -EINVAL;
+
+    int err = 0;
+    VmafPicturePool *pic_pool = cookie;
+
+    VmafPicture pic_copy;
+    memcpy(&pic_copy, pic, sizeof(pic_copy));
+
+    err |= vmaf_ref_init(&pic_copy.ref);
+    err |= vmaf_picture_priv_init(&pic_copy);
+    err |= vmaf_picture_set_release_callback(&pic_copy, pic_pool,
+                                             release_picture_callback);
+
+    pthread_mutex_lock(&(pic_pool->lock));
+    pic_pool->queue.head--;
+    memcpy(pic_pool->queue.head, &pic_copy, sizeof(pic_copy));
+    pthread_cond_signal(&(pic_pool->queue.available));
+    if (pic_pool->queue.head == pic_pool->pic)
+        pthread_cond_signal(&(pic_pool->queue.empty));
+    pthread_mutex_unlock(&(pic_pool->lock));
+
+    return err;
+}
+
+int vmaf_picture_pool_init(VmafPicturePool **pic_pool,
+                           VmafPicturePoolConfig cfg)
+{
+    if (!pic_pool) return -EINVAL;
+    if (!cfg.pic_cnt) return -EINVAL;
+    if (!cfg.alloc_picture_callback) return -EINVAL;
+    if (!cfg.free_picture_callback) return -EINVAL;
+
+    int err = 0;
+
+    VmafPicturePool *const p = *pic_pool = malloc(sizeof(*p));
+    if (!p) goto fail;
+    memset(p, 0, sizeof(*p));
+    p->cfg = cfg;
+
+    const size_t pic_data_sz =
+        sizeof(VmafPicture) * p->cfg.pic_cnt + 1;
+    p->pic = malloc(pic_data_sz);
+    if (!p->pic) goto free_p;
+    memset(p->pic, 0, pic_data_sz);
+
+    p->queue.head = &p->pic[0];
+    p->queue.tail = &p->pic[p->cfg.pic_cnt];
+
+    pthread_mutex_init(&(p->lock), NULL);
+    pthread_mutex_lock(&(p->lock));
+    pthread_cond_init(&(p->queue.available), NULL);
+    pthread_cond_init(&(p->queue.empty), NULL);
+
+    for (unsigned i = 0; i < p->cfg.pic_cnt; i++) {
+        VmafPicture *pic = &p->pic[i];
+        err |= p->cfg.alloc_picture_callback(pic, p->cfg.cookie);
+
+        err |= vmaf_ref_init(&pic->ref);
+        err |= vmaf_picture_priv_init(pic);
+        err |= vmaf_picture_set_release_callback(pic, p,
+                                                 release_picture_callback);
+    }
+
+    pthread_mutex_unlock(&(p->lock));
+    return err;
+
+free_p:
+    free(p);
+fail:
+    return -ENOMEM;
+}
+
+int vmaf_picture_pool_request_picture(VmafPicturePool *pic_pool,
+                                      VmafPicture *pic)
+{
+    if (!pic_pool) return -EINVAL;
+    if (!pic) return -EINVAL;
+
+    int err = 0;
+    pthread_mutex_lock(&(pic_pool->lock));
+
+    while (pic_pool->queue.head == pic_pool->queue.tail)
+        pthread_cond_wait(&(pic_pool->queue.available), &(pic_pool->lock));
+
+    *pic = *pic_pool->queue.head;
+    pic_pool->queue.head++;
+
+    pthread_mutex_unlock(&(pic_pool->lock));
+    return err;
+}
+
+int vmaf_picture_pool_close(VmafPicturePool *pic_pool)
+{
+    if (!pic_pool) return -EINVAL;
+
+    int err = 0;
+
+    pthread_mutex_lock(&(pic_pool->lock));
+
+    while (pic_pool->queue.head != pic_pool->pic)
+        pthread_cond_wait(&(pic_pool->queue.empty), &(pic_pool->lock));
+
+    for (unsigned i = 0; i < pic_pool->cfg.pic_cnt; i++) {
+        err |= pic_pool->cfg.free_picture_callback(&pic_pool->pic[i],
+                                                   pic_pool->cfg.cookie);
+    }
+
+    pthread_cond_destroy(&(pic_pool->queue.empty));
+    pthread_cond_destroy(&(pic_pool->queue.available));
+    pthread_mutex_destroy(&(pic_pool->lock));
+    free(pic_pool);
+
+    return err;
+}

--- a/libvmaf/src/picture_pool.c
+++ b/libvmaf/src/picture_pool.c
@@ -25,6 +25,9 @@ static int release_picture_callback(VmafPicture *pic, void *cookie)
     int err = 0;
     VmafPicturePool *pic_pool = cookie;
 
+    if (pic_pool->cfg.synchronize_picture_callback)
+        pic_pool->cfg.synchronize_picture_callback(pic, cookie);
+
     VmafPicture pic_copy;
     memcpy(&pic_copy, pic, sizeof(pic_copy));
 

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -12,9 +12,9 @@ test_context = executable('test_context',
 )
 
 test_picture = executable('test_picture',
-    ['test.c', 'test_picture.c', '../src/picture.c', '../src/mem.c', '../src/ref.c'],
+    ['test.c', 'test_picture.c', '../src/picture.c', '../src/picture_pool.c', '../src/mem.c', '../src/ref.c', '../src/thread_pool.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
-    dependencies:[stdatomic_dependency],
+    dependencies:[stdatomic_dependency, thread_lib],
 )
 
 test_feature_collector = executable('test_feature_collector',

--- a/libvmaf/test/test_picture.c
+++ b/libvmaf/test/test_picture.c
@@ -17,11 +17,15 @@
  */
 
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "test.h"
 #include "picture.h"
 #include "libvmaf/picture.h"
 #include "ref.h"
+#include "thread_pool.h"
 
 static char *test_picture_alloc_ref_and_unref()
 {
@@ -65,9 +69,219 @@ static char *test_picture_data_alignment()
     return NULL;
 }
 
+typedef struct MyCookie {
+    size_t data_sz;
+    enum VmafPixelFormat pix_fmt;
+} MyCookie;
+
+static int my_alloc_picture(VmafPicture *pic, void *cookie)
+{
+    if (!pic) return -1;
+
+    //fprintf(stderr, "my_alloc_picture\n");
+    memset(pic, 0, sizeof(*pic));
+
+    MyCookie *my_cookie = cookie;
+    void *data = malloc(my_cookie->data_sz);
+    if (!data) return -1;
+
+    pic->data[0] = data;
+    pic->data[1] = NULL;
+    pic->data[2] = NULL;
+    pic->pix_fmt = my_cookie->pix_fmt;
+
+    return 0;
+}
+
+static int my_free_picture(VmafPicture *pic, void *cookie)
+{
+    if (!pic) return -1;
+    if (!pic->data[0]) return -1;
+
+    //fprintf(stderr, "my_free_picture\n");
+
+    MyCookie *my_cookie = cookie;
+    (void) my_cookie;
+    free(pic->data[0]);
+
+    return 0;
+}
+
+static char *test_picture_pool()
+{
+    int err;
+
+    MyCookie my_cookie = {
+        .data_sz = 1920*1080,
+        .pix_fmt = VMAF_PIX_FMT_YUV400P,
+    };
+
+    VmafPicturePoolConfig cfg = {
+        .pic_cnt = 4,
+        .cookie = &my_cookie,
+        .alloc_picture_callback = my_alloc_picture,
+        .free_picture_callback = my_free_picture,
+    };
+
+    VmafPicturePool *pic_pool;
+    err = vmaf_picture_pool_init(&pic_pool, cfg);
+    mu_assert("problem during vmaf_picture_pool_init", !err);
+
+    VmafPicture pic_1;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_1);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_1.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_1.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_1.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_1.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    VmafPicture pic_2;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_2);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_2.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_2.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_2.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_2.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    VmafPicture pic_3;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_3);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_3.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_3.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_3.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_3.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    VmafPicture pic_4;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_4);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_4.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_4.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_4.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_4.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    const void *pic_2_data_buf = pic_2.data[0];
+    const void *pic_1_data_buf = pic_1.data[0];
+    err |= vmaf_picture_unref(&pic_2);
+    err |= vmaf_picture_unref(&pic_1);
+    mu_assert("problem during vmaf_picture_unref", !err);
+
+    VmafPicture pic_5;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_5);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_5.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_5.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_5.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_5.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    mu_assert("pic_5 should use the same data buffer as pic_1 did. "
+              "the underlying queue should be LIFO.",
+              pic_1_data_buf == pic_5.data[0]);
+
+    VmafPicture pic_6;
+    err = vmaf_picture_pool_request_picture(pic_pool, &pic_6);
+    mu_assert("problem during vmaf_picture_pool_request_picture", !err);
+    mu_assert("data[0] should have been allocated", pic_6.data[0]);
+    mu_assert("data[1] should not have been allocated", !pic_6.data[1]);
+    mu_assert("data[2] should not have been allocated", !pic_6.data[2]);
+    mu_assert("pix_fmt should be VMAF_PIX_FMT_YUV400P",
+              pic_6.pix_fmt == VMAF_PIX_FMT_YUV400P);
+
+    mu_assert("pic_6 should use the same data buffer as pic_2 did. "
+              "the underlying queue should be LIFO.",
+              pic_2_data_buf == pic_6.data[0]);
+
+    err |= vmaf_picture_unref(&pic_3);
+    err |= vmaf_picture_unref(&pic_4);
+    err |= vmaf_picture_unref(&pic_5);
+    err |= vmaf_picture_unref(&pic_6);
+    mu_assert("problem during vmaf_picture_unref", !err);
+
+    err = vmaf_picture_pool_close(pic_pool);
+    mu_assert("problem during vmaf_picture_pool_close", !err);
+
+    return NULL;
+}
+
+typedef struct MyThreadPoolData {
+    VmafPicturePool *pic_pool;
+    unsigned i;
+    useconds_t timeout;
+} MyThreadPoolData;
+
+
+static void request_picture_and_unref(void *data)
+{
+    MyThreadPoolData *my_thread_pool_data = data;
+    VmafPicturePool *pic_pool = my_thread_pool_data->pic_pool;
+    VmafPicture pic;
+    //fprintf(stderr, "request: %i\n", my_thread_pool_data->i);
+    vmaf_picture_pool_request_picture(pic_pool, &pic);
+    //fprintf(stderr, "usleep=%d: %i\n",
+    //        my_thread_pool_data->timeout, my_thread_pool_data->i);
+    usleep(my_thread_pool_data->timeout);
+    //fprintf(stderr, "unref: %i\n", my_thread_pool_data->i);
+    vmaf_picture_unref(&pic);
+}
+
+static char *test_picture_pool_threaded()
+{
+    int err;
+
+    MyCookie my_cookie = {
+        .data_sz = 1920*1080,
+        .pix_fmt = VMAF_PIX_FMT_YUV400P,
+    };
+
+    VmafPicturePoolConfig cfg = {
+        .pic_cnt = 4,
+        .cookie = &my_cookie,
+        .alloc_picture_callback = my_alloc_picture,
+        .free_picture_callback = my_free_picture,
+    };
+
+    VmafPicturePool *pic_pool;
+    err = vmaf_picture_pool_init(&pic_pool, cfg);
+    mu_assert("problem during vmaf_picture_pool_init", !err);
+
+    VmafThreadPool *thread_pool;
+    const unsigned n_threads = 4;
+    err = vmaf_thread_pool_create(&thread_pool, n_threads);
+    mu_assert("problem during vmaf_thread_pool_init", !err);
+
+    const unsigned n = n_threads * 8;
+    for (unsigned i = 0; i < n; i++) {
+        MyThreadPoolData my_thread_pool_data = {
+            .pic_pool = pic_pool,
+            .i = i,
+            .timeout = 100000 - (100000 * ((float)i / n)),
+        };
+        err = vmaf_thread_pool_enqueue(thread_pool, request_picture_and_unref,
+                                       &my_thread_pool_data,
+                                       sizeof(my_thread_pool_data));
+        mu_assert("problem during vmaf_thread_pool_enqueue", !err);
+    }
+
+    err = vmaf_thread_pool_wait(thread_pool);
+    mu_assert("problem during vmaf_thread_pool_wait", !err);
+    err = vmaf_thread_pool_destroy(thread_pool);
+    mu_assert("problem during vmaf_thread_pool_destroy", !err);
+
+    err = vmaf_picture_pool_close(pic_pool);
+    mu_assert("problem during vmaf_picture_pool_close", !err);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_picture_alloc_ref_and_unref);
     mu_run_test(test_picture_data_alignment);
+    mu_run_test(test_picture_pool);
+    mu_run_test(test_picture_pool_threaded);
     return NULL;
 }

--- a/libvmaf/test/test_picture.c
+++ b/libvmaf/test/test_picture.c
@@ -93,6 +93,18 @@ static int my_alloc_picture(VmafPicture *pic, void *cookie)
     return 0;
 }
 
+static int my_synchronize_picture(VmafPicture *pic, void *cookie)
+{
+    if (!pic) return -1;
+
+    MyCookie *my_cookie = cookie;
+    (void) my_cookie;
+
+    //fprintf(stderr, "my_synchronize_picture\n");
+
+    return 0;
+}
+
 static int my_free_picture(VmafPicture *pic, void *cookie)
 {
     if (!pic) return -1;
@@ -120,6 +132,7 @@ static char *test_picture_pool()
         .pic_cnt = 4,
         .cookie = &my_cookie,
         .alloc_picture_callback = my_alloc_picture,
+        .synchronize_picture_callback = my_synchronize_picture,
         .free_picture_callback = my_free_picture,
     };
 


### PR DESCRIPTION
The following PR adds a threadsafe picture pool API. This is experimental at this point but is open for comments, questions, etc. 

A `VmafPicturePool` is a place to store a queue of preallocated pictures for continual recycling. By registering a pair of custom alloc/free callbacks, the data buffers will be allocated just once and returned to the pool to be reused when fully unref'd. This is in contrast to the current workflow where each picture is newly allocated and then freed when fully unref'd. This API allows for more user control of `VmafPicture`data buffers. Hopefully this API should be generic enough to work for several usecases: this might mean sharing a decoded picture buffer, GPU memory, reusing an AVFrame data buffer instead of allocating and copying memory.

See `test_picture_pool()` for an example of API usage.