### PR TITLE
libvmaf: pipelined vif feature computation

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -40,16 +40,12 @@
 #endif
 
 typedef struct VifState {
-    VifBuffer buf;
-    uint16_t log2_table[65537];
+    VifPublicState public;
     bool debug;
-    double vif_enhn_gain_limit;
-    void (*filter1d_8)(VifBuffer buf, unsigned w, unsigned h);
-    void (*filter1d_16)(VifBuffer buf, unsigned w, unsigned h, int scale,
-                        int bpc);
-    void (*filter1d_rd_8)(VifBuffer buf, unsigned w, unsigned h);
-    void (*filter1d_rd_16)(VifBuffer buf, unsigned w, unsigned h, int scale,
-                           int bpc);
+    void (*subsample_rd_8)(VifBuffer buf, unsigned w, unsigned h);
+    void (*subsample_rd_16)(VifBuffer buf, unsigned w, unsigned h, int scale, int bpc);
+    void (*vif_statistic_8)(VifPublicState *s, float *num, float *den, unsigned w, unsigned h);
+    void (*vif_statistic_16)(VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale);
     VmafDictionary *feature_name_dict;
 } VifState;
 
@@ -66,7 +62,7 @@ static const VmafOption options[] = {
         .alias = "egl",
         .help = "enhancement gain imposed on vif, must be >= 1.0, "
                 "where 1.0 means the gain is completely disabled",
-        .offset = offsetof(VifState, vif_enhn_gain_limit),
+        .offset = offsetof(VifState, public.vif_enhn_gain_limit),
         .type = VMAF_OPT_TYPE_DOUBLE,
         .default_val.d = DEFAULT_VIF_ENHN_GAIN_LIMIT,
         .min = 1.0,
@@ -80,7 +76,8 @@ static FORCE_INLINE inline void
 pad_top_and_bottom(VifBuffer buf, unsigned h, int fwidth)
 {
     const unsigned fwidth_half = fwidth / 2;
-    void *ref = buf.ref; void *dis = buf.dis;
+    unsigned char *ref = buf.ref;
+    unsigned char *dis = buf.dis;
     for (unsigned i = 1; i <= fwidth_half; ++i) {
         size_t offset = buf.stride * i;
         memcpy(ref - offset, ref + offset, buf.stride);
@@ -111,42 +108,126 @@ decimate_and_pad(VifBuffer buf, unsigned w, unsigned h, int scale)
     pad_top_and_bottom(buf, h / 2, vif_filter1d_width[scale]);
 }
 
-static FORCE_INLINE inline uint16_t
-get_best16_from32(uint32_t temp, int *x)
+static void subsample_rd_8(VifBuffer buf, unsigned w, unsigned h)
 {
-    int k = __builtin_clz(temp);
-    k = 16 - k;
-    temp = temp >> k;
-    *x = -k;
-    return temp;
-}
+    const unsigned fwidth = vif_filter1d_width[1];
+    const uint16_t *vif_filt_s1 = vif_filter1d_table[1];
 
-static FORCE_INLINE inline uint16_t
-get_best16_from64(uint64_t temp, int *x)
-{
-    int k = __builtin_clzll(temp);
-    if (k > 48) {
-        k -= 48;
-        temp = temp << k;
-        *x = k;
-    } else if (k < 47) {
-        k = 48 - k;
-        temp = temp >> k;
-        *x = -k;
-    } else {
-        *x = 0;
-        if (temp >> 16) {
-            temp = temp >> 1;
-            *x = -1;
+    for (unsigned i = 0; i < h; ++i) {
+        //VERTICAL
+        for (unsigned j = 0; j < w; ++j) {
+            uint32_t accum_ref = 0;
+            uint32_t accum_dis = 0;
+            for (unsigned fi = 0; fi < fwidth; ++fi) {
+                int ii = i - fwidth / 2;
+                int ii_check = ii + fi;
+                const uint16_t fcoeff = vif_filt_s1[fi];
+                const uint8_t *ref = (uint8_t*)buf.ref;
+                const uint8_t *dis = (uint8_t*)buf.dis;
+                accum_ref += fcoeff * (uint32_t)ref[ii_check * buf.stride + j];
+                accum_dis += fcoeff * (uint32_t)dis[ii_check * buf.stride + j];
+            }
+            buf.tmp.ref_convol[j] = (accum_ref + 128) >> 8;
+            buf.tmp.dis_convol[j] = (accum_dis + 128) >> 8;
+        }
+
+        PADDING_SQ_DATA_2(buf, w, fwidth / 2);
+
+        //HORIZONTAL
+        for (unsigned j = 0; j < w; ++j) {
+            uint32_t accum_ref = 0;
+            uint32_t accum_dis = 0;
+            for (unsigned fj = 0; fj < fwidth; ++fj) {
+                int jj = j - fwidth / 2;
+                int jj_check = jj + fj;
+                const uint16_t fcoeff = vif_filt_s1[fj];
+                accum_ref += fcoeff * buf.tmp.ref_convol[jj_check];
+                accum_dis += fcoeff * buf.tmp.dis_convol[jj_check];
+            }
+            const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
+            buf.mu1[i * stride + j] = (uint16_t)((accum_ref + 32768) >> 16);
+            buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
         }
     }
-    return (uint16_t)temp;
+    decimate_and_pad(buf, w, h, 0);
 }
 
-static void filter1d_8(VifBuffer buf, unsigned w, unsigned h)
+static void subsample_rd_16(VifBuffer buf, unsigned w, unsigned h, int scale, int bpc)
 {
+    const unsigned fwidth = vif_filter1d_width[scale + 1];
+    const uint16_t *vif_filt = vif_filter1d_table[scale + 1];
+    int32_t add_shift_round_VP, shift_VP;
+
+    if (scale == 0) {
+        add_shift_round_VP = 1 << (bpc - 1);
+        shift_VP = bpc;
+    }
+    else {
+        add_shift_round_VP = 32768;
+        shift_VP = 16;
+    }
+
+    for (unsigned i = 0; i < h; ++i) {
+        //VERTICAL
+        for (unsigned j = 0; j < w; ++j) {
+            uint32_t accum_ref = 0;
+            uint32_t accum_dis = 0;
+            for (unsigned fi = 0; fi < fwidth; ++fi) {
+                int ii = i - fwidth / 2;
+                int ii_check = ii + fi;
+                const uint16_t fcoeff = vif_filt[fi];
+                const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
+                uint16_t *ref = buf.ref;
+                uint16_t *dis = buf.dis;
+                accum_ref += fcoeff * ((uint32_t)ref[ii_check * stride + j]);
+                accum_dis += fcoeff * ((uint32_t)dis[ii_check * stride + j]);
+            }
+            buf.tmp.ref_convol[j] = (uint16_t)((accum_ref + add_shift_round_VP) >> shift_VP);
+            buf.tmp.dis_convol[j] = (uint16_t)((accum_dis + add_shift_round_VP) >> shift_VP);
+        }
+
+        PADDING_SQ_DATA_2(buf, w, fwidth / 2);
+
+        //HORIZONTAL
+        for (unsigned j = 0; j < w; ++j) {
+            uint32_t accum_ref = 0;
+            uint32_t accum_dis = 0;
+            for (unsigned fj = 0; fj < fwidth; ++fj) {
+                int jj = j - fwidth / 2;
+                int jj_check = jj + fj;
+                const uint16_t fcoeff = vif_filt[fj];
+                accum_ref += fcoeff * ((uint32_t)buf.tmp.ref_convol[jj_check]);
+                accum_dis += fcoeff * ((uint32_t)buf.tmp.dis_convol[jj_check]);
+            }
+            const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
+            buf.mu1[i * stride + j] = (uint16_t)((accum_ref + 32768) >> 16);
+            buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
+        }
+    }
+    decimate_and_pad(buf, w, h, scale);
+}
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+static inline void log_generate(uint16_t *log2_table)
+{
+    for (unsigned i = 32767; i < 65536; ++i) {
+        log2_table[i] = (uint16_t)round(log2f((float)i) * 2048);
+    }
+}
+
+void vif_statistic_8(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h) {
     const unsigned fwidth = vif_filter1d_width[0];
     const uint16_t *vif_filt_s0 = vif_filter1d_table[0];
+    VifBuffer buf = s->buf;
+    int64_t accum_num_log = 0.0;
+    int64_t accum_den_log = 0.0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
+    static const int32_t sigma_nsq = 65536 << 1;
+    uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
 
     for (unsigned i = 0; i < h; ++i) {
         //VERTICAL
@@ -198,22 +279,78 @@ static void filter1d_8(VifBuffer buf, unsigned w, unsigned h)
                 accum_dis += fcoeff * ((uint64_t)buf.tmp.dis[jj_check]);
                 accum_ref_dis += fcoeff * ((uint64_t)buf.tmp.ref_dis[jj_check]);
             }
-            const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
-            buf.mu1_32[i * dst_stride + j] = accum_mu1;
-            buf.mu2_32[i * dst_stride + j] = accum_mu2;
-            buf.ref_sq[i * dst_stride + j] = (uint32_t)((accum_ref + 32768) >> 16);
-            buf.dis_sq[i * dst_stride + j] = (uint32_t)((accum_dis + 32768) >> 16);
-            buf.ref_dis[i * dst_stride + j] = (uint32_t)((accum_ref_dis + 32768) >> 16);
+
+            uint32_t mu1_val = accum_mu1;
+            uint32_t mu2_val = accum_mu2;
+            uint32_t mu1_sq_val = (uint32_t)((((uint64_t)mu1_val * mu1_val)
+                + 2147483648) >> 32);
+            uint32_t mu2_sq_val = (uint32_t)((((uint64_t)mu2_val * mu2_val)
+                + 2147483648) >> 32);
+            uint32_t mu1_mu2_val = (uint32_t)((((uint64_t)mu1_val * mu2_val)
+                + 2147483648) >> 32);
+
+            uint32_t xx_filt_val = (uint32_t)((accum_ref + 32768) >> 16);
+            uint32_t yy_filt_val = (uint32_t)((accum_dis + 32768) >> 16);
+            uint32_t xy_filt_val = (uint32_t)((accum_ref_dis + 32768) >> 16);
+
+            int32_t sigma1_sq = (int32_t)(xx_filt_val - mu1_sq_val);
+            int32_t sigma2_sq = (int32_t)(yy_filt_val - mu2_sq_val);
+            int32_t sigma12 = (int32_t)(xy_filt_val - mu1_mu2_val);
+
+            sigma2_sq = MAX(sigma2_sq, 0);
+            if (sigma1_sq >= sigma_nsq) {
+                /**
+                * log values are taken from the look-up table generated by
+                * log_generate() function which is called in integer_combo_threadfunc
+                * den_val in float is log2(1 + sigma1_sq/2)
+                * here it is converted to equivalent of log2(2+sigma1_sq) - log2(2) i.e log2(2*65536+sigma1_sq) - 17
+                * multiplied by 2048 as log_value = log2(i)*2048 i=16384 to 65535 generated using log_value
+                * x because best 16 bits are taken
+                */
+                accum_den_log += log2_32(log2_table, sigma_nsq + sigma1_sq) - 2048 * 17;
+
+                if (sigma12 > 0 && sigma2_sq > 0) {
+                    /**
+                    * In floating-point numerator = log2((1.0f + (g * g * sigma1_sq)/(sv_sq + sigma_nsq))
+                    *
+                    * In Fixed-point the above is converted to
+                    * numerator = log2((sv_sq + sigma_nsq)+(g * g * sigma1_sq))- log2(sv_sq + sigma_nsq)
+                    */
+
+                    const double eps = 65536 * 1.0e-10;
+                    double g = sigma12 / (sigma1_sq + eps); // this epsilon can go away
+                    int32_t sv_sq = sigma2_sq - g * sigma12;
+
+                    sv_sq = (uint32_t)(MAX(sv_sq, 0));
+
+                    g = MIN(g, vif_enhn_gain_limit);
+
+                    uint32_t numer1 = (sv_sq + sigma_nsq);
+                    int64_t numer1_tmp = (int64_t)((g * g * sigma1_sq)) + numer1; //numerator
+                    accum_num_log += log2_64(log2_table, numer1_tmp) - log2_64(log2_table, numer1);
+                }
+            }
+            else {
+                accum_num_non_log += sigma2_sq;
+                accum_den_non_log++;
+            }
         }
     }
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
 }
 
-static void filter1d_16(VifBuffer buf, unsigned w, unsigned h, int scale,
-                        int bpc)
-{
+void vif_statistic_16(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale) {
     const unsigned fwidth = vif_filter1d_width[scale];
     const uint16_t *vif_filt = vif_filter1d_table[scale];
-
+    VifBuffer buf = s->buf;
+    int64_t accum_num_log = 0.0;
+    int64_t accum_den_log = 0.0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
+    static const int32_t sigma_nsq = 65536 << 1;
+    uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
     int32_t add_shift_round_HP, shift_HP;
     int32_t add_shift_round_VP, shift_VP;
     int32_t add_shift_round_VP_sq, shift_VP_sq;
@@ -224,7 +361,8 @@ static void filter1d_16(VifBuffer buf, unsigned w, unsigned h, int scale,
         add_shift_round_VP = 1 << (bpc - 1);
         shift_VP_sq = (bpc - 8) * 2;
         add_shift_round_VP_sq = (bpc == 8) ? 0 : 1 << (shift_VP_sq - 1);
-    } else {
+    }
+    else {
         shift_HP = 16;
         add_shift_round_HP = 32768;
         shift_VP = 16;
@@ -284,52 +422,9 @@ static void filter1d_16(VifBuffer buf, unsigned w, unsigned h, int scale,
                 accum_dis += fcoeff * ((uint64_t)buf.tmp.dis[jj_check]);
                 accum_ref_dis += fcoeff * ((uint64_t)buf.tmp.ref_dis[jj_check]);
             }
-            const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
-            buf.mu1_32[i * dst_stride + j] = accum_mu1;
-            buf.mu2_32[i * dst_stride + j] = accum_mu2;
-            buf.ref_sq[i * dst_stride + j] = (uint32_t)((accum_ref + add_shift_round_HP) >> shift_HP);
-            buf.dis_sq[i * dst_stride + j] = (uint32_t)((accum_dis + add_shift_round_HP) >> shift_HP);
-            buf.ref_dis[i * dst_stride + j] = (uint32_t)((accum_ref_dis + add_shift_round_HP) >> shift_HP);
-        }
-    }
-}
 
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
-#define MAX(x, y) (((x) > (y)) ? (x) : (y))
-
-static void vif_statistic(VifBuffer buf, float *num, float *den,
-                          unsigned w, unsigned h, uint16_t *log2_table,
-                          double vif_enhn_gain_limit)
-{
-    uint32_t *xx_filt = buf.ref_sq;
-    uint32_t *yy_filt = buf.dis_sq;
-    uint32_t *xy_filt = buf.ref_dis;
-
-    //float equivalent of 2. (2 * 65536)
-    static const int32_t sigma_nsq = 65536 << 1;
-
-    int64_t num_val, den_val;
-    int64_t accum_x = 0, accum_x2 = 0;
-    int64_t num_accum_x = 0;
-    int64_t accum_num_log = 0.0;
-    int64_t accum_den_log = 0.0;
-    int64_t accum_num_non_log = 0;
-    int64_t accum_den_non_log = 0;
-    /**
-        * In floating-point there are two types of numerator scores and denominator scores
-        * 1. num = 1 - sigma1_sq * constant den =1  when sigma1_sq<2  here constant=4/(255*255)
-        * 2. num = log2(((sigma2_sq+2)*sigma1_sq)/((sigma2_sq+2)*sigma1_sq-sigma12*sigma12) den=log2(1+(sigma1_sq/2)) else
-        *
-        * In fixed-point separate accumulator is used for non-log score accumulations and log-based score accumulation
-        * For non-log accumulator of numerator, only sigma1_sq * constant in fixed-point is accumulated
-        * log based values are separately accumulated.
-        * While adding both accumulator values the non-log accumulator is converted such that it is equivalent to 1 - sigma1_sq * constant(1's are accumulated with non-log denominator accumulator)
-    */
-    for (unsigned i = 0; i < h; ++i) {
-        for (unsigned j = 0; j < w; ++j) {
-            const ptrdiff_t stride = buf.stride_32 / sizeof(uint32_t);
-            uint32_t mu1_val = buf.mu1_32[i * stride + j];
-            uint32_t mu2_val = buf.mu2_32[i * stride + j];
+            uint32_t mu1_val = accum_mu1;
+            uint32_t mu2_val = accum_mu2;
             uint32_t mu1_sq_val = (uint32_t)((((uint64_t)mu1_val * mu1_val)
                                     + 2147483648) >> 32);
             uint32_t mu2_sq_val = (uint32_t)((((uint64_t)mu2_val * mu2_val)
@@ -337,50 +432,16 @@ static void vif_statistic(VifBuffer buf, float *num, float *den,
             uint32_t mu1_mu2_val = (uint32_t)((((uint64_t)mu1_val * mu2_val)
                                     + 2147483648) >> 32);
 
-            uint32_t xx_filt_val = xx_filt[i * stride + j];
-            uint32_t yy_filt_val = yy_filt[i * stride + j];
-            uint32_t xy_filt_val = xy_filt[i * stride + j];
+            uint32_t xx_filt_val = (uint32_t)((accum_ref + add_shift_round_HP) >> shift_HP);
+            uint32_t yy_filt_val = (uint32_t)((accum_dis + add_shift_round_HP) >> shift_HP);
+            uint32_t xy_filt_val = (uint32_t)((accum_ref_dis + add_shift_round_HP) >> shift_HP);
 
             int32_t sigma1_sq = (int32_t)(xx_filt_val - mu1_sq_val);
             int32_t sigma2_sq = (int32_t)(yy_filt_val - mu2_sq_val);
             int32_t sigma12 = (int32_t)(xy_filt_val - mu1_mu2_val);
 
-            sigma1_sq = MAX(sigma1_sq, 0.0);
-            sigma2_sq = MAX(sigma2_sq, 0.0);
-
-            //eps is zero, an int will not be less then 1.0e-10, it can be changed to one
-            const double eps = 65536 * 1.0e-10;
-            double g = sigma12 / (sigma1_sq + eps);
-            int32_t sv_sq = sigma2_sq - g * sigma12;
-
-			sv_sq = sigma2_sq - g * sigma12;
-
-
-			if (sigma1_sq < eps) {
-			    g = 0.0;
-                sv_sq = sigma2_sq;
-                sigma1_sq = 0.0;
-			}
-
-			if (sigma2_sq < eps) {
-			    g = 0.0;
-			    sv_sq = 0.0;
-			}
-
-			if (g < 0.0) {
-			    sv_sq = sigma2_sq;
-			    g = 0.0;
-			}
-
-			sv_sq = (uint32_t)(MAX(sv_sq, eps));
-
-            g = MIN(g, vif_enhn_gain_limit);
-
+            sigma2_sq = MAX(sigma2_sq, 0);
             if (sigma1_sq >= sigma_nsq) {
-                uint32_t log_den_stage1 = (uint32_t)(sigma_nsq + sigma1_sq);
-                int x;
-                uint16_t log_den1 = get_best16_from32(log_den_stage1, &x);
-
                 /**
                 * log values are taken from the look-up table generated by
                 * log_generate() function which is called in integer_combo_threadfunc
@@ -389,224 +450,211 @@ static void vif_statistic(VifBuffer buf, float *num, float *den,
                 * multiplied by 2048 as log_value = log2(i)*2048 i=16384 to 65535 generated using log_value
                 * x because best 16 bits are taken
                 */
-                num_accum_x++;
-                accum_x += x;
-                den_val = log2_table[log_den1];
+                accum_den_log += log2_32(log2_table, sigma_nsq + sigma1_sq) - 2048 * 17;
 
-                if (sigma12 >= 0) {
-                    // num_val = log2f(1.0f + (g * g * sigma1_sq) / (sv_sq + sigma_nsq));
+                if (sigma12 > 0 && sigma2_sq > 0) {
                     /**
                     * In floating-point numerator = log2((1.0f + (g * g * sigma1_sq)/(sv_sq + sigma_nsq))
                     *
                     * In Fixed-point the above is converted to
                     * numerator = log2((sv_sq + sigma_nsq)+(g * g * sigma1_sq))- log2(sv_sq + sigma_nsq)
                     */
-                    int x1, x2;
+
+                    const double eps = 65536 * 1.0e-10;
+                    double g = sigma12 / (sigma1_sq + eps); // this epsilon can go away
+                    int32_t sv_sq = sigma2_sq - g * sigma12;
+
+                    sv_sq = (uint32_t)(MAX(sv_sq, 0));
+
+                    g = MIN(g, vif_enhn_gain_limit);
+
                     uint32_t numer1 = (sv_sq + sigma_nsq);
                     int64_t numer1_tmp = (int64_t)((g * g * sigma1_sq)) + numer1; //numerator
-                    uint16_t numlog = get_best16_from64((uint64_t)numer1_tmp, &x1);
-                    if (numer1 > 0) {
-                        uint16_t denlog = get_best16_from64((uint64_t)numer1, &x2);
-                        accum_x2 += (x2 - x1);
-                        num_val = log2_table[numlog] - log2_table[denlog];
-                        accum_num_log += num_val;
-                        accum_den_log += den_val;
-                    } else {
-                        den_val = 1;
-                        accum_num_non_log += sigma2_sq;
-                        accum_den_non_log += den_val;
-                    }
-
-                }
-                else {
-                    num_val = 0;
-                    accum_num_log += num_val;
-                    accum_den_log += den_val;
+                    accum_num_log += log2_64(log2_table, numer1_tmp) - log2_64(log2_table, numer1);
                 }
             }
             else {
-                den_val = 1;
                 accum_num_non_log += sigma2_sq;
-                accum_den_non_log += den_val;
+                accum_den_non_log++;
             }
         }
     }
-    //log has to be divided by 2048 as log_value = log2(i*2048)  i=16384 to 65535
-    //num[0] = accum_num_log / 2048.0 + (accum_den_non_log - (accum_num_non_log / 65536.0) / (255.0*255.0));
-    //den[0] = accum_den_log / 2048.0 + accum_den_non_log;
-
-    //changed calculation to increase performance
-    num[0] = accum_num_log / 2048.0  + accum_x2 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
-    den[0] = accum_den_log / 2048.0  - (accum_x + (num_accum_x * 17)) + accum_den_non_log;
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
 }
 
-static void filter1d_rd_8(VifBuffer buf, unsigned w, unsigned h)
+VifResiduals vif_compute_line_residuals(VifPublicState *s, unsigned from,
+                                        unsigned to, int bpc, int scale)
 {
-    const unsigned fwidth = vif_filter1d_width[1];
-    const uint16_t *vif_filt_s1 = vif_filter1d_table[1];
-
-    for (unsigned i = 0; i < h; ++i) {
-        //VERTICAL
-        for (unsigned j = 0; j < w; ++j) {
-            uint32_t accum_ref = 0;
-            uint32_t accum_dis = 0;
-            for (unsigned fi = 0; fi < fwidth; ++fi) {
-                int ii = i - fwidth / 2;
-                int ii_check = ii + fi;
-                const uint16_t fcoeff = vif_filt_s1[fi];
-                const uint8_t *ref = (uint8_t*)buf.ref;
-                const uint8_t *dis = (uint8_t*)buf.dis;
-                accum_ref += fcoeff * (uint32_t)ref[ii_check * buf.stride + j];
-                accum_dis += fcoeff * (uint32_t)dis[ii_check * buf.stride + j];
-            }
-            buf.tmp.ref_convol[j] = (accum_ref + 128) >> 8;
-            buf.tmp.dis_convol[j] = (accum_dis + 128) >> 8;
-        }
-
-        PADDING_SQ_DATA_2(buf, w, fwidth / 2);
-
-        //HORIZONTAL
-        for (unsigned j = 0; j < w; ++j) {
-            uint32_t accum_ref = 0;
-            uint32_t accum_dis = 0;
-            for (unsigned fj = 0; fj < fwidth; ++fj) {
-                int jj = j - fwidth / 2;
-                int jj_check = jj + fj;
-                const uint16_t fcoeff = vif_filt_s1[fj];
-                accum_ref += fcoeff * buf.tmp.ref_convol[jj_check];
-                accum_dis += fcoeff * buf.tmp.dis_convol[jj_check];
-            }
-            const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
-            buf.mu1[i * stride + j] = (uint16_t)((accum_ref + 32768) >> 16);
-            buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
-        }
-    }
-}
-
-static void filter1d_rd_16(VifBuffer buf, unsigned w, unsigned h, int scale,
-                           int bpc)
-{
-    const unsigned fwidth = vif_filter1d_width[scale + 1];
-    const uint16_t *vif_filt = vif_filter1d_table[scale + 1];
+    VifResiduals residuals = { 0 };
+    const unsigned fwidth = vif_filter1d_width[scale];
+    const uint16_t *vif_filt = vif_filter1d_table[scale];
+    VifBuffer buf = s->buf;
+    int32_t add_shift_round_HP, shift_HP;
     int32_t add_shift_round_VP, shift_VP;
+    int32_t add_shift_round_VP_sq, shift_VP_sq;
+    const uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
+    static const int32_t sigma_nsq = 65536 << 1;
 
     if (scale == 0) {
-        add_shift_round_VP = 1 << (bpc - 1);
+        shift_HP = 16;
+        add_shift_round_HP = 32768;
         shift_VP = bpc;
-    } else {
-        add_shift_round_VP = 32768;
+        add_shift_round_VP = 1 << (bpc - 1);
+        shift_VP_sq = (bpc - 8) * 2;
+        add_shift_round_VP_sq = (bpc == 8) ? 0 : 1 << (shift_VP_sq - 1);
+    }
+    else {
+        shift_HP = 16;
+        add_shift_round_HP = 32768;
         shift_VP = 16;
+        add_shift_round_VP = 32768;
+        shift_VP_sq = 16;
+        add_shift_round_VP_sq = 32768;
     }
 
-    for (unsigned i = 0; i < h; ++i) {
-        //VERTICAL
-        for (unsigned j = 0; j < w; ++j) {
-            uint32_t accum_ref = 0;
-            uint32_t accum_dis = 0;
-            for (unsigned fi = 0; fi < fwidth; ++fi) {
-                int ii = i - fwidth / 2;
-                int ii_check = ii + fi;
-                const uint16_t fcoeff = vif_filt[fi];
-                const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
-                uint16_t *ref = buf.ref;
-                uint16_t *dis = buf.dis;
-                accum_ref += fcoeff * ((uint32_t)ref[ii_check * stride + j]);
-                accum_dis += fcoeff * ((uint32_t)dis[ii_check * stride + j]);
-            }
-            buf.tmp.ref_convol[j] = (uint16_t)((accum_ref + add_shift_round_VP) >> shift_VP);
-            buf.tmp.dis_convol[j] = (uint16_t)((accum_dis + add_shift_round_VP) >> shift_VP);
+    //HORIZONTAL
+    for (unsigned j = from; j < to; ++j) {
+        uint32_t accum_mu1 = 0;
+        uint32_t accum_mu2 = 0;
+        uint64_t accum_ref = 0;
+        uint64_t accum_dis = 0;
+        uint64_t accum_ref_dis = 0;
+        for (unsigned fj = 0; fj < fwidth; ++fj) {
+            int jj = j - fwidth / 2;
+            int jj_check = jj + fj;
+            const uint16_t fcoeff = vif_filt[fj];
+            accum_mu1 += fcoeff * ((uint32_t)buf.tmp.mu1[jj_check]);
+            accum_mu2 += fcoeff * ((uint32_t)buf.tmp.mu2[jj_check]);
+            accum_ref += fcoeff * ((uint64_t)buf.tmp.ref[jj_check]);
+            accum_dis += fcoeff * ((uint64_t)buf.tmp.dis[jj_check]);
+            accum_ref_dis += fcoeff * ((uint64_t)buf.tmp.ref_dis[jj_check]);
         }
+        uint32_t mu1_val = accum_mu1;
+        uint32_t mu2_val = accum_mu2;
+        uint32_t mu1_sq_val = (uint32_t)((((uint64_t)mu1_val * mu1_val)
+            + 2147483648) >> 32);
+        uint32_t mu2_sq_val = (uint32_t)((((uint64_t)mu2_val * mu2_val)
+            + 2147483648) >> 32);
+        uint32_t mu1_mu2_val = (uint32_t)((((uint64_t)mu1_val * mu2_val)
+            + 2147483648) >> 32);
 
-        PADDING_SQ_DATA_2(buf, w, fwidth / 2);
+        uint32_t xx_filt_val = (uint32_t)((accum_ref + add_shift_round_HP) >> shift_HP);
+        uint32_t yy_filt_val = (uint32_t)((accum_dis + add_shift_round_HP) >> shift_HP);
+        uint32_t xy_filt_val = (uint32_t)((accum_ref_dis + add_shift_round_HP) >> shift_HP);
 
-        //HORIZONTAL
-        for (unsigned j = 0; j < w; ++j) {
-            uint32_t accum_ref = 0;
-            uint32_t accum_dis = 0;
-            for (unsigned fj = 0; fj < fwidth; ++fj) {
-                int jj = j - fwidth / 2;
-                int jj_check = jj + fj;
-                const uint16_t fcoeff = vif_filt[fj];
-                accum_ref += fcoeff * ((uint32_t)buf.tmp.ref_convol[jj_check]);
-                accum_dis += fcoeff * ((uint32_t)buf.tmp.dis_convol[jj_check]);
+        int32_t sigma1_sq = (int32_t)(xx_filt_val - mu1_sq_val);
+        int32_t sigma2_sq = (int32_t)(yy_filt_val - mu2_sq_val);
+        int32_t sigma12 = (int32_t)(xy_filt_val - mu1_mu2_val);
+
+        sigma2_sq = MAX(sigma2_sq, 0);
+        if (sigma1_sq >= sigma_nsq) {
+            /**
+            * log values are taken from the look-up table generated by
+            * log_generate() function which is called in integer_combo_threadfunc
+            * den_val in float is log2(1 + sigma1_sq/2)
+            * here it is converted to equivalent of log2(2+sigma1_sq) - log2(2) i.e log2(2*65536+sigma1_sq) - 17
+            * multiplied by 2048 as log_value = log2(i)*2048 i=16384 to 65535 generated using log_value
+            * x because best 16 bits are taken
+            */
+            residuals.accum_den_log += log2_32(log2_table, sigma_nsq + sigma1_sq) - 2048 * 17;
+
+            if (sigma12 > 0 && sigma2_sq > 0) {
+                /**
+                * In floating-point numerator = log2((1.0f + (g * g * sigma1_sq)/(sv_sq + sigma_nsq))
+                *
+                * In Fixed-point the above is converted to
+                * numerator = log2((sv_sq + sigma_nsq)+(g * g * sigma1_sq))- log2(sv_sq + sigma_nsq)
+                */
+
+                const double eps = 65536 * 1.0e-10;
+                double g = sigma12 / (sigma1_sq + eps); // this epsilon can go away
+                int32_t sv_sq = sigma2_sq - g * sigma12;
+
+                sv_sq = (uint32_t)(MAX(sv_sq, 0));
+
+                g = MIN(g, vif_enhn_gain_limit);
+
+                uint32_t numer1 = (sv_sq + sigma_nsq);
+                int64_t numer1_tmp = (int64_t)((g * g * sigma1_sq)) + numer1; //numerator
+                residuals.accum_num_log += log2_64(log2_table, numer1_tmp) - log2_64(log2_table, numer1);
             }
-            const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
-            buf.mu1[i * stride + j] = (uint16_t)((accum_ref + 32768) >> 16);
-            buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
+        }
+        else {
+            residuals.accum_num_non_log += sigma2_sq;
+            residuals.accum_den_non_log++;
         }
     }
+    return residuals;
 }
 
-static inline void log_generate(uint16_t *log2_table)
-{
-    for (unsigned i = 32767; i < 65536; ++i) {
-        log2_table[i] = (uint16_t)round(log2f((float)i) * 2048);
-    }
-}
 
 static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
                 unsigned bpc, unsigned w, unsigned h)
 {
     VifState *s = fex->priv;
 
-    s->filter1d_8 = filter1d_8;
-    s->filter1d_16 = filter1d_16;
-    s->filter1d_rd_8 = filter1d_rd_8;
-    s->filter1d_rd_16 = filter1d_rd_16;
+    s->subsample_rd_8 = subsample_rd_8;
+    s->subsample_rd_16 = subsample_rd_16;
+    s->vif_statistic_8 = vif_statistic_8;
+    s->vif_statistic_16 = vif_statistic_16;
 
 #if ARCH_X86
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
-        s->filter1d_8 = vif_filter1d_8_avx2;
-        s->filter1d_16 = vif_filter1d_16_avx2;
-        s->filter1d_rd_8 = vif_filter1d_rd_8_avx2;
-        s->filter1d_rd_16 = vif_filter1d_rd_16_avx2;
+        s->subsample_rd_8 = vif_subsample_rd_8_avx2;
+        s->subsample_rd_16 = vif_subsample_rd_16_avx2;
+        s->vif_statistic_8 = vif_statistic_8_avx2;
+        s->vif_statistic_16 = vif_statistic_16_avx2;
     }
+/*
 #if HAVE_AVX512
     if (flags & VMAF_X86_CPU_FLAG_AVX512) {
-        s->filter1d_8 = vif_filter1d_8_avx512;
-        s->filter1d_16 = vif_filter1d_16_avx512;
-        s->filter1d_rd_8 = vif_filter1d_rd_8_avx512;
-        s->filter1d_rd_16 = vif_filter1d_rd_16_avx512;
+        s->subsample_rd_8 = vif_subsample_rd_8_avx2;
+        s->subsample_rd_16 = vif_subsample_rd_16_avx512;
+        s->vif_statistic_8 = vif_statistic_8_avx512;
+        s->vif_statistic_16 = vif_statistic_16_avx512;
     }
 #endif
+*/
 #endif
 
-    log_generate(s->log2_table);
+    log_generate(s->public.log2_table);
 
-    (void) pix_fmt;
+    (void)pix_fmt;
     const bool hbd = bpc > 8;
 
-    s->buf.stride = ALIGN_CEIL(w << hbd);
-    s->buf.stride_16 = ALIGN_CEIL(w * sizeof(uint16_t));
-    s->buf.stride_32 = ALIGN_CEIL(w * sizeof(uint32_t));
-    s->buf.stride_tmp =
+    s->public.buf.stride = ALIGN_CEIL(w << hbd);
+    s->public.buf.stride_16 = ALIGN_CEIL(w * sizeof(uint16_t));
+    s->public.buf.stride_32 = ALIGN_CEIL(w * sizeof(uint32_t));
+    s->public.buf.stride_tmp =
         ALIGN_CEIL((MAX_ALIGN + w + MAX_ALIGN) * sizeof(uint32_t));
-    const size_t frame_size = s->buf.stride * h;
-    const size_t pad_size = s->buf.stride * 8;
+    const size_t frame_size = s->public.buf.stride * h;
+    const size_t pad_size = s->public.buf.stride * 8;
     const size_t data_sz =
-        2 * (pad_size + frame_size + pad_size) + 2 * (h * s->buf.stride_16) +
-        5 * (h * s->buf.stride_32) + 7 * s->buf.stride_tmp;
+        2 * (pad_size + frame_size + pad_size) + 2 * (h * s->public.buf.stride_16) +
+        5 * (s->public.buf.stride_32) + 7 * s->public.buf.stride_tmp;
     void *data = aligned_malloc(data_sz, MAX_ALIGN);
-    if (!data) goto fail;
+    if (!data) return -ENOMEM;
 
-    s->buf.data = data; data += pad_size;
-    s->buf.ref = data; data += frame_size + pad_size + pad_size;
-    s->buf.dis = data; data += frame_size + pad_size;
-    s->buf.mu1 = data; data += h * s->buf.stride_16;
-    s->buf.mu2 = data; data += h * s->buf.stride_16;
-    s->buf.mu1_32 = data; data += h * s->buf.stride_32;
-    s->buf.mu2_32 = data; data += h * s->buf.stride_32;
-    s->buf.ref_sq = data; data += h * s->buf.stride_32;
-    s->buf.dis_sq = data; data += h * s->buf.stride_32;
-    s->buf.ref_dis = data; data += h * s->buf.stride_32;
-    s->buf.tmp.mu1 = data; data += s->buf.stride_tmp;
-    s->buf.tmp.mu2 = data; data += s->buf.stride_tmp;
-    s->buf.tmp.ref = data; data += s->buf.stride_tmp;
-    s->buf.tmp.dis = data; data += s->buf.stride_tmp;
-    s->buf.tmp.ref_dis = data; data += s->buf.stride_tmp;
-    s->buf.tmp.ref_convol = data; data += s->buf.stride_tmp;
-    s->buf.tmp.dis_convol = data;
+    s->public.buf.data = data; data += pad_size;
+    s->public.buf.ref = data; data += frame_size + pad_size + pad_size;
+    s->public.buf.dis = data; data += frame_size + pad_size;
+    s->public.buf.mu1 = data; data += h * s->public.buf.stride_16;
+    s->public.buf.mu2 = data; data += h * s->public.buf.stride_16;
+    s->public.buf.mu1_32 = data; data += s->public.buf.stride_32;
+    s->public.buf.mu2_32 = data; data += s->public.buf.stride_32;
+    s->public.buf.ref_sq = data; data += s->public.buf.stride_32;
+    s->public.buf.dis_sq = data; data += s->public.buf.stride_32;
+    s->public.buf.ref_dis = data; data += s->public.buf.stride_32;
+    s->public.buf.tmp.mu1 = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.mu2 = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.dis = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_dis = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_convol = data; data += s->public.buf.stride_tmp;
+    s->public.buf.tmp.dis_convol = data;
 
     s->feature_name_dict =
         vmaf_feature_name_dict_from_provided_features(fex->provided_features,
@@ -713,47 +761,45 @@ static int extract(VmafFeatureExtractor *fex,
 {
     VifState *s = fex->priv;
 
-    (void) ref_pic_90;
-    (void) dist_pic_90;
+    (void)ref_pic_90;
+    (void)dist_pic_90;
 
     unsigned w = ref_pic->w[0];
     unsigned h = dist_pic->h[0];
 
-    void *ref_in = ref_pic->data[0];
-    void *dis_in = dist_pic->data[0];
-    void *ref_out = s->buf.ref;
-    void *dis_out = s->buf.dis;
+    unsigned char *ref_in = ref_pic->data[0];
+    unsigned char *dis_in = dist_pic->data[0];
+    unsigned char *ref_out = s->public.buf.ref;
+    unsigned char *dis_out = s->public.buf.dis;
 
     for (unsigned i = 0; i < h; i++) {
         memcpy(ref_out, ref_in, ref_pic->stride[0]);
         memcpy(dis_out, dis_in, dist_pic->stride[0]);
         ref_in += ref_pic->stride[0];
         dis_in += dist_pic->stride[0];
-        ref_out += s->buf.stride;
-        dis_out += s->buf.stride;
+        ref_out += s->public.buf.stride;
+        dis_out += s->public.buf.stride;
     }
-    pad_top_and_bottom(s->buf, h, vif_filter1d_width[0]);
+    pad_top_and_bottom(s->public.buf, h, vif_filter1d_width[0]);
 
     VifScore vif_score;
     for (unsigned scale = 0; scale < 4; ++scale) {
         if (scale > 0) {
             if (ref_pic->bpc == 8 && scale == 1)
-                s->filter1d_rd_8(s->buf, w, h);
+                s->subsample_rd_8(s->public.buf, w, h);
             else
-                s->filter1d_rd_16(s->buf, w, h, scale - 1, ref_pic->bpc);
+                s->subsample_rd_16(s->public.buf, w, h, scale - 1, ref_pic->bpc);
 
-            decimate_and_pad(s->buf, w, h, scale);
             w /= 2; h /= 2;
         }
 
-        if (ref_pic->bpc == 8 && scale == 0)
-            s->filter1d_8(s->buf, w, h);
-        else
-            s->filter1d_16(s->buf, w, h, scale, ref_pic->bpc);
+        if (ref_pic->bpc == 8 && scale == 0) {
+            s->vif_statistic_8(&s->public, &vif_score.scale[scale].num, &vif_score.scale[scale].den, w, h);
+        }
+        else {
+            s->vif_statistic_16(&s->public, &vif_score.scale[scale].num, &vif_score.scale[scale].den, w, h, ref_pic->bpc, scale);
+        }
 
-        vif_statistic(s->buf, &vif_score.scale[scale].num,
-                      &vif_score.scale[scale].den, w, h, s->log2_table,
-                      s->vif_enhn_gain_limit);
     }
 
     return write_scores(feature_collector, index, vif_score, s);
@@ -762,8 +808,7 @@ static int extract(VmafFeatureExtractor *fex,
 static int close(VmafFeatureExtractor *fex)
 {
     VifState *s = fex->priv;
-    if (s->buf.data) aligned_free(s->buf.data);
-    vmaf_dictionary_free(&s->feature_name_dict);
+    if (s->public.buf.data) aligned_free(s->public.buf.data);
     return 0;
 }
 

--- a/libvmaf/src/feature/x86/vif_avx2.c
+++ b/libvmaf/src/feature/x86/vif_avx2.c
@@ -20,1390 +20,517 @@
 #include <immintrin.h>
 #include <stddef.h>
 #include <stdint.h>
-
+#include <string.h>
+#include <assert.h>
 #include "feature/integer_vif.h"
-
-void vif_filter1d_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
-    const unsigned fwidth = vif_filter1d_width[0];
-    const uint16_t *vif_filt_s0 = vif_filter1d_table[0];
-    const unsigned fwidth_v = 18;
-    __m256i x = _mm256_set1_epi32(128);
-    const uint8_t *ref = (uint8_t *)buf.ref;
-    const uint8_t *dis = (uint8_t *)buf.dis;
-    const unsigned fwidth_half = fwidth >> 1;
-    const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
-
-    __m256i f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, fc0, fc1, fc2, fc3, fc4,
-        fc5, fc6, fc7, fc8;
-
-    fc0 = _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)vif_filt_s0));
-    fc1 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 2)));
-    fc2 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 4)));
-    fc3 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 6)));
-    fc4 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 8)));
-    fc5 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 10)));
-    fc6 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 12)));
-    fc7 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 14)));
-    fc8 =
-        _mm256_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 16)));
-
-    f1 = _mm256_set1_epi16(vif_filt_s0[0]);
-    f2 = _mm256_set1_epi16(vif_filt_s0[1]);
-    f3 = _mm256_set1_epi16(vif_filt_s0[2]);
-    f4 = _mm256_set1_epi16(vif_filt_s0[3]);
-    f5 = _mm256_set1_epi16(vif_filt_s0[4]);
-    f6 = _mm256_set1_epi16(vif_filt_s0[5]);
-    f7 = _mm256_set1_epi16(vif_filt_s0[6]);
-    f8 = _mm256_set1_epi16(vif_filt_s0[7]);
-    f9 = _mm256_set1_epi16(vif_filt_s0[8]);
-
-    __m256i fq1 = _mm256_set1_epi64x(vif_filt_s0[0]);
-    __m256i fq2 = _mm256_set1_epi64x(vif_filt_s0[1]);
-    __m256i fq3 = _mm256_set1_epi64x(vif_filt_s0[2]);
-    __m256i fq4 = _mm256_set1_epi64x(vif_filt_s0[3]);
-    __m256i fq5 = _mm256_set1_epi64x(vif_filt_s0[4]);
-    __m256i fq6 = _mm256_set1_epi64x(vif_filt_s0[5]);
-    __m256i fq7 = _mm256_set1_epi64x(vif_filt_s0[6]);
-    __m256i fq8 = _mm256_set1_epi64x(vif_filt_s0[7]);
-    __m256i fq9 = _mm256_set1_epi64x(vif_filt_s0[8]);
-
-#pragma loop(ivdep)
-    for (unsigned i = 0; i < h; ++i) {
-        // VERTICAL
-        int ii = i - fwidth_half;
-
-        for (unsigned j = 0; j < w; j = j + 16) {
-            __m256i accum_ref_lo, accum_ref_hi, accum_dis_lo, accum_dis_hi,
-                accum_ref_dis_lo, accum_ref_dis_hi, accum_mu2_lo, accum_mu2_hi,
-                accum_mu1_lo, accum_mu1_hi;
-            accum_ref_lo = accum_ref_hi = accum_dis_lo = accum_dis_hi =
-                accum_ref_dis_lo = accum_ref_dis_hi = accum_mu2_lo =
-                    accum_mu2_hi = accum_mu1_lo = accum_mu1_hi =
-                        _mm256_setzero_si256();
-
-            __m256i dislo, dishi, refdislo, refdishi, final_resultlo,
-                final_resulthi;
-            dislo = dishi = refdislo = refdishi = final_resultlo =
-                final_resulthi = _mm256_setzero_si256();
-
-            int ii_check = ii;
-            __m256i g0, g1, g2, g3, g4, g5, g6, g7, g8, g20, g21, g22, g23, g24,
-                g25, g26, g27, g28;
-            __m256i s0, s1, s2, s3, s4, s5, s6, s7, s8, s20, s21, s22, s23, s24,
-                s25, s26, s27, s28, sg0, sg1, sg2, sg3, sg4, sg5, sg6, sg7, sg8;
-
-            g0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + (buf.stride * ii_check) + j)));
-            g1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 1) + j)));
-            g2 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 2) + j)));
-            g3 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 3) + j)));
-            g4 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 4) + j)));
-            g5 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 5) + j)));
-            g6 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 6) + j)));
-            g7 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 7) + j)));
-
-            s0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + (buf.stride * ii_check) + j)));
-            s1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 1) + j)));
-            s2 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 2) + j)));
-            s3 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 3) + j)));
-            s4 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 4) + j)));
-            s5 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 5) + j)));
-            s6 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 6) + j)));
-            s7 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 7) + j)));
-
-            __m256i s0lo = _mm256_unpacklo_epi16(s0, s1);
-            __m256i s0hi = _mm256_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s0lo, fc0));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s0hi, fc0));
-            __m256i s1lo = _mm256_unpacklo_epi16(s2, s3);
-            __m256i s1hi = _mm256_unpackhi_epi16(s2, s3);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s1lo, fc1));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s1hi, fc1));
-            __m256i s2lo = _mm256_unpacklo_epi16(s4, s5);
-            __m256i s2hi = _mm256_unpackhi_epi16(s4, s5);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s2lo, fc2));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s2hi, fc2));
-            __m256i s3lo = _mm256_unpacklo_epi16(s6, s7);
-            __m256i s3hi = _mm256_unpackhi_epi16(s6, s7);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s3lo, fc3));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s3hi, fc3));
-
-            __m256i g0lo = _mm256_unpacklo_epi16(g0, g1);
-            __m256i g0hi = _mm256_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g0lo, fc0));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g0hi, fc0));
-            __m256i g1lo = _mm256_unpacklo_epi16(g2, g3);
-            __m256i g1hi = _mm256_unpackhi_epi16(g2, g3);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g1lo, fc1));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g1hi, fc1));
-            __m256i g2lo = _mm256_unpacklo_epi16(g4, g5);
-            __m256i g2hi = _mm256_unpackhi_epi16(g4, g5);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g2lo, fc2));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g2hi, fc2));
-            __m256i g3lo = _mm256_unpacklo_epi16(g6, g7);
-            __m256i g3hi = _mm256_unpackhi_epi16(g6, g7);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g3lo, fc3));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g3hi, fc3));
-
-            g20 = _mm256_mullo_epi16(g0, g0);
-            g21 = _mm256_mullo_epi16(g1, g1);
-            g22 = _mm256_mullo_epi16(g2, g2);
-            g23 = _mm256_mullo_epi16(g3, g3);
-            g24 = _mm256_mullo_epi16(g4, g4);
-            g25 = _mm256_mullo_epi16(g5, g5);
-            g26 = _mm256_mullo_epi16(g6, g6);
-            g27 = _mm256_mullo_epi16(g7, g7);
-
-            s20 = _mm256_mullo_epi16(s0, s0);
-            s21 = _mm256_mullo_epi16(s1, s1);
-            s22 = _mm256_mullo_epi16(s2, s2);
-            s23 = _mm256_mullo_epi16(s3, s3);
-            s24 = _mm256_mullo_epi16(s4, s4);
-            s25 = _mm256_mullo_epi16(s5, s5);
-            s26 = _mm256_mullo_epi16(s6, s6);
-            s27 = _mm256_mullo_epi16(s7, s7);
-
-            sg0 = _mm256_mullo_epi16(s0, g0);
-            sg1 = _mm256_mullo_epi16(s1, g1);
-            sg2 = _mm256_mullo_epi16(s2, g2);
-            sg3 = _mm256_mullo_epi16(s3, g3);
-            sg4 = _mm256_mullo_epi16(s4, g4);
-            sg5 = _mm256_mullo_epi16(s5, g5);
-            sg6 = _mm256_mullo_epi16(s6, g6);
-            sg7 = _mm256_mullo_epi16(s7, g7);
-
-            __m256i result2 = _mm256_mulhi_epu16(g20, f1);
-            __m256i result2lo = _mm256_mullo_epi16(g20, f1);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result2lo, result2));
-            __m256i result3 = _mm256_mulhi_epu16(g21, f2);
-            __m256i result3lo = _mm256_mullo_epi16(g21, f2);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result3lo, result3));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result3lo, result3));
-            __m256i result4 = _mm256_mulhi_epu16(g22, f3);
-            __m256i result4lo = _mm256_mullo_epi16(g22, f3);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result4lo, result4));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result4lo, result4));
-            __m256i result5 = _mm256_mulhi_epu16(g23, f4);
-            __m256i result5lo = _mm256_mullo_epi16(g23, f4);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result5lo, result5));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result5lo, result5));
-            __m256i result6 = _mm256_mulhi_epu16(g24, f5);
-            __m256i result6lo = _mm256_mullo_epi16(g24, f5);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result6lo, result6));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result6lo, result6));
-            __m256i result7 = _mm256_mulhi_epu16(g25, f6);
-            __m256i result7lo = _mm256_mullo_epi16(g25, f6);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result7lo, result7));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result7lo, result7));
-            __m256i result8 = _mm256_mulhi_epu16(g26, f7);
-            __m256i result8lo = _mm256_mullo_epi16(g26, f7);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result8lo, result8));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result8lo, result8));
-            __m256i result9 = _mm256_mulhi_epu16(g27, f8);
-            __m256i result9lo = _mm256_mullo_epi16(g27, f8);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result9lo, result9));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm256_mulhi_epu16(s20, f1);
-            result2lo = _mm256_mullo_epi16(s20, f1);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result2lo, result2));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result2lo, result2));
-            result3 = _mm256_mulhi_epu16(s21, f2);
-            result3lo = _mm256_mullo_epi16(s21, f2);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result3lo, result3));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result3lo, result3));
-            result4 = _mm256_mulhi_epu16(s22, f3);
-            result4lo = _mm256_mullo_epi16(s22, f3);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result4lo, result4));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result4lo, result4));
-            result5 = _mm256_mulhi_epu16(s23, f4);
-            result5lo = _mm256_mullo_epi16(s23, f4);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result5lo, result5));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result5lo, result5));
-            result6 = _mm256_mulhi_epu16(s24, f5);
-            result6lo = _mm256_mullo_epi16(s24, f5);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result6lo, result6));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(s25, f6);
-            result7lo = _mm256_mullo_epi16(s25, f6);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result7lo, result7));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(s26, f7);
-            result8lo = _mm256_mullo_epi16(s26, f7);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result8lo, result8));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(s27, f8);
-            result9lo = _mm256_mullo_epi16(s27, f8);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result9lo, result9));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm256_mulhi_epu16(sg0, f1);
-            result2lo = _mm256_mullo_epi16(sg0, f1);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result2lo, result2));
-
-            result3 = _mm256_mulhi_epu16(sg1, f2);
-            result3lo = _mm256_mullo_epi16(sg1, f2);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result3lo, result3));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result3lo, result3));
-
-            result4 = _mm256_mulhi_epu16(sg2, f3);
-            result4lo = _mm256_mullo_epi16(sg2, f3);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result4lo, result4));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result4lo, result4));
-            result5 = _mm256_mulhi_epu16(sg3, f4);
-            result5lo = _mm256_mullo_epi16(sg3, f4);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result5lo, result5));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result5lo, result5));
-            result6 = _mm256_mulhi_epu16(sg4, f5);
-            result6lo = _mm256_mullo_epi16(sg4, f5);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result6lo, result6));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(sg5, f6);
-            result7lo = _mm256_mullo_epi16(sg5, f6);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result7lo, result7));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(sg6, f7);
-            result8lo = _mm256_mullo_epi16(sg6, f7);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result8lo, result8));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(sg7, f8);
-            result9lo = _mm256_mullo_epi16(sg7, f8);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result9lo, result9));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result9lo, result9));
-
-            g0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 8) + j)));
-            g1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 9) + j)));
-            g2 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 10) + j)));
-            g3 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 11) + j)));
-            g4 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 12) + j)));
-            g5 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 13) + j)));
-            g6 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 14) + j)));
-            g7 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 15) + j)));
-
-            s0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 8) + j)));
-            s1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 9) + j)));
-            s2 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 10) + j)));
-            s3 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 11) + j)));
-            s4 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 12) + j)));
-            s5 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 13) + j)));
-            s6 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 14) + j)));
-            s7 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 15) + j)));
-
-            s0lo = _mm256_unpacklo_epi16(s0, s1);
-            s0hi = _mm256_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s0lo, fc4));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s0hi, fc4));
-            s1lo = _mm256_unpacklo_epi16(s2, s3);
-            s1hi = _mm256_unpackhi_epi16(s2, s3);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s1lo, fc5));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s1hi, fc5));
-            s2lo = _mm256_unpacklo_epi16(s4, s5);
-            s2hi = _mm256_unpackhi_epi16(s4, s5);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s2lo, fc6));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s2hi, fc6));
-            s3lo = _mm256_unpacklo_epi16(s6, s7);
-            s3hi = _mm256_unpackhi_epi16(s6, s7);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s3lo, fc7));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s3hi, fc7));
-
-            g0lo = _mm256_unpacklo_epi16(g0, g1);
-            g0hi = _mm256_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g0lo, fc4));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g0hi, fc4));
-            g1lo = _mm256_unpacklo_epi16(g2, g3);
-            g1hi = _mm256_unpackhi_epi16(g2, g3);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g1lo, fc5));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g1hi, fc5));
-            g2lo = _mm256_unpacklo_epi16(g4, g5);
-            g2hi = _mm256_unpackhi_epi16(g4, g5);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g2lo, fc6));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g2hi, fc6));
-            g3lo = _mm256_unpacklo_epi16(g6, g7);
-            g3hi = _mm256_unpackhi_epi16(g6, g7);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g3lo, fc7));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g3hi, fc7));
-
-            g20 = _mm256_mullo_epi16(g0, g0);
-            g21 = _mm256_mullo_epi16(g1, g1);
-            g22 = _mm256_mullo_epi16(g2, g2);
-            g23 = _mm256_mullo_epi16(g3, g3);
-            g24 = _mm256_mullo_epi16(g4, g4);
-            g25 = _mm256_mullo_epi16(g5, g5);
-            g26 = _mm256_mullo_epi16(g6, g6);
-            g27 = _mm256_mullo_epi16(g7, g7);
-
-            s20 = _mm256_mullo_epi16(s0, s0);
-            s21 = _mm256_mullo_epi16(s1, s1);
-            s22 = _mm256_mullo_epi16(s2, s2);
-            s23 = _mm256_mullo_epi16(s3, s3);
-            s24 = _mm256_mullo_epi16(s4, s4);
-            s25 = _mm256_mullo_epi16(s5, s5);
-            s26 = _mm256_mullo_epi16(s6, s6);
-            s27 = _mm256_mullo_epi16(s7, s7);
-
-            sg0 = _mm256_mullo_epi16(s0, g0);
-            sg1 = _mm256_mullo_epi16(s1, g1);
-            sg2 = _mm256_mullo_epi16(s2, g2);
-            sg3 = _mm256_mullo_epi16(s3, g3);
-            sg4 = _mm256_mullo_epi16(s4, g4);
-            sg5 = _mm256_mullo_epi16(s5, g5);
-            sg6 = _mm256_mullo_epi16(s6, g6);
-            sg7 = _mm256_mullo_epi16(s7, g7);
-
-            result2 = _mm256_mulhi_epu16(g20, f9);
-            result2lo = _mm256_mullo_epi16(g20, f9);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result2lo, result2));
-            result3 = _mm256_mulhi_epu16(g21, f8);
-            result3lo = _mm256_mullo_epi16(g21, f8);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result3lo, result3));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result3lo, result3));
-            result4 = _mm256_mulhi_epu16(g22, f7);
-            result4lo = _mm256_mullo_epi16(g22, f7);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result4lo, result4));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result4lo, result4));
-            result5 = _mm256_mulhi_epu16(g23, f6);
-            result5lo = _mm256_mullo_epi16(g23, f6);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result5lo, result5));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result5lo, result5));
-            result6 = _mm256_mulhi_epu16(g24, f5);
-            result6lo = _mm256_mullo_epi16(g24, f5);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result6lo, result6));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(g25, f4);
-            result7lo = _mm256_mullo_epi16(g25, f4);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result7lo, result7));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(g26, f3);
-            result8lo = _mm256_mullo_epi16(g26, f3);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result8lo, result8));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(g27, f2);
-            result9lo = _mm256_mullo_epi16(g27, f2);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result9lo, result9));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm256_mulhi_epu16(s20, f9);
-            result2lo = _mm256_mullo_epi16(s20, f9);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result2lo, result2));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result2lo, result2));
-            result3 = _mm256_mulhi_epu16(s21, f8);
-            result3lo = _mm256_mullo_epi16(s21, f8);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result3lo, result3));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result3lo, result3));
-            result4 = _mm256_mulhi_epu16(s22, f7);
-            result4lo = _mm256_mullo_epi16(s22, f7);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result4lo, result4));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result4lo, result4));
-            result5 = _mm256_mulhi_epu16(s23, f6);
-            result5lo = _mm256_mullo_epi16(s23, f6);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result5lo, result5));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result5lo, result5));
-            result6 = _mm256_mulhi_epu16(s24, f5);
-            result6lo = _mm256_mullo_epi16(s24, f5);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result6lo, result6));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(s25, f4);
-            result7lo = _mm256_mullo_epi16(s25, f4);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result7lo, result7));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(s26, f3);
-            result8lo = _mm256_mullo_epi16(s26, f3);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result8lo, result8));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(s27, f2);
-            result9lo = _mm256_mullo_epi16(s27, f2);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result9lo, result9));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm256_mulhi_epu16(sg0, f9);
-            result2lo = _mm256_mullo_epi16(sg0, f9);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result2lo, result2));
-            result3 = _mm256_mulhi_epu16(sg1, f8);
-            result3lo = _mm256_mullo_epi16(sg1, f8);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result3lo, result3));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result3lo, result3));
-            result4 = _mm256_mulhi_epu16(sg2, f7);
-            result4lo = _mm256_mullo_epi16(sg2, f7);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result4lo, result4));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result4lo, result4));
-            result5 = _mm256_mulhi_epu16(sg3, f6);
-            result5lo = _mm256_mullo_epi16(sg3, f6);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result5lo, result5));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result5lo, result5));
-            result6 = _mm256_mulhi_epu16(sg4, f5);
-            result6lo = _mm256_mullo_epi16(sg4, f5);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result6lo, result6));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(sg5, f4);
-            result7lo = _mm256_mullo_epi16(sg5, f4);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result7lo, result7));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(sg6, f3);
-            result8lo = _mm256_mullo_epi16(sg6, f3);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result8lo, result8));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(sg7, f2);
-            result9lo = _mm256_mullo_epi16(sg7, f2);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result9lo, result9));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result9lo, result9));
-
-            g0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 16) + j)));
-            g1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 17) + j)));
-
-            s0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 16) + j)));
-            s1 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 17) + j)));
-
-            s0lo = _mm256_unpacklo_epi16(s0, s1);
-            s0hi = _mm256_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s0lo, fc8));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s0hi, fc8));
-
-            g0lo = _mm256_unpacklo_epi16(g0, g1);
-            g0hi = _mm256_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g0lo, fc8));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g0hi, fc8));
-
-            g20 = _mm256_mullo_epi16(g0, g0);
-            s20 = _mm256_mullo_epi16(s0, s0);
-            sg0 = _mm256_mullo_epi16(s0, g0);
-
-            result2 = _mm256_mulhi_epu16(g20, f1);
-            result2lo = _mm256_mullo_epi16(g20, f1);
-            final_resultlo = _mm256_add_epi32(
-                final_resultlo, _mm256_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm256_add_epi32(
-                final_resulthi, _mm256_unpackhi_epi16(result2lo, result2));
-
-            result2 = _mm256_mulhi_epu16(s20, f1);
-            result2lo = _mm256_mullo_epi16(s20, f1);
-            dislo = _mm256_add_epi32(dislo,
-                                     _mm256_unpacklo_epi16(result2lo, result2));
-            dishi = _mm256_add_epi32(dishi,
-                                     _mm256_unpackhi_epi16(result2lo, result2));
-
-            result2 = _mm256_mulhi_epu16(sg0, f1);
-            result2lo = _mm256_mullo_epi16(sg0, f1);
-            refdislo = _mm256_add_epi32(
-                refdislo, _mm256_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm256_add_epi32(
-                refdishi, _mm256_unpackhi_epi16(result2lo, result2));
-
-            __m256i accumref_lo =
-                _mm256_permute2x128_si256(final_resultlo, final_resulthi, 0x20);
-            __m256i accumref_hi =
-                _mm256_permute2x128_si256(final_resultlo, final_resulthi, 0x31);
-            __m256i accumdis_lo = _mm256_permute2x128_si256(dislo, dishi, 0x20);
-            __m256i accumdis_hi = _mm256_permute2x128_si256(dislo, dishi, 0x31);
-            __m256i accumrefdis_lo =
-                _mm256_permute2x128_si256(refdislo, refdishi, 0x20);
-            __m256i accumrefdis_hi =
-                _mm256_permute2x128_si256(refdislo, refdishi, 0x31);
-            // __m256i x = _mm256_set1_epi32(128);
-            __m256i accumu1_lo = _mm256_add_epi32(
-                x, _mm256_permute2x128_si256(accum_mu1_lo, accum_mu1_hi, 0x20));
-            __m256i accumu1_hi = _mm256_add_epi32(
-                x, _mm256_permute2x128_si256(accum_mu1_lo, accum_mu1_hi, 0x31));
-            __m256i accumu2_lo = _mm256_add_epi32(
-                x, _mm256_permute2x128_si256(accum_mu2_lo, accum_mu2_hi, 0x20));
-            __m256i accumu2_hi = _mm256_add_epi32(
-                x, _mm256_permute2x128_si256(accum_mu2_lo, accum_mu2_hi, 0x31));
-            accumu1_lo = _mm256_srli_epi32(accumu1_lo, 0x08);
-            accumu1_hi = _mm256_srli_epi32(accumu1_hi, 0x08);
-            accumu2_lo = _mm256_srli_epi32(accumu2_lo, 0x08);
-            accumu2_hi = _mm256_srli_epi32(accumu2_hi, 0x08);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.ref + j), accumref_lo);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.ref + j + 8), accumref_hi);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.dis + j), accumdis_lo);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.dis + j + 8), accumdis_hi);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.ref_dis + j),
-                                accumrefdis_lo);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.ref_dis + j + 8),
-                                accumrefdis_hi);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.mu1 + j), accumu1_lo);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.mu1 + j + 8), accumu1_hi);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.mu2 + j), accumu2_lo);
-            _mm256_storeu_si256((__m256i *)(buf.tmp.mu2 + j + 8), accumu2_hi);
-        }
-
-        PADDING_SQ_DATA(buf, w, fwidth_half);
-
-        // HORIZONTAL
-        for (unsigned j = 0; j < w; j = j + 16) {
-            __m256i refdislo, refdishi, mu2lo, mu2hi, mu1lo, mu1hi;
-            refdislo = refdishi = mu2lo = mu2hi = mu1lo = mu1hi =
-                _mm256_setzero_si256();
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            {
-                __m256i s0 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check));
-                __m256i s1 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 1));
-                __m256i s2 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 2));
-                __m256i s3 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 3));
-                __m256i s4 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 4));
-                __m256i s5 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 5));
-                __m256i s6 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 6));
-                __m256i s7 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 7));
-                __m256i s8 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 8));
-
-                // __m256i s00 = _mm256_loadu_si256((__m256i*
-                // )(buf.tmp.mu1+jj_check+8));
-                __m256i s11 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check + 9));
-                __m256i s22 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 10));
-                __m256i s33 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 11));
-                __m256i s44 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 12));
-                __m256i s55 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 13));
-                __m256i s66 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 14));
-                __m256i s77 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 15));
-                __m256i s88 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 16));
-
-                s0 = _mm256_packus_epi32(s0, s8);
-                s1 = _mm256_packus_epi32(s1, s11);
-                s2 = _mm256_packus_epi32(s2, s22);
-                s3 = _mm256_packus_epi32(s3, s33);
-                s4 = _mm256_packus_epi32(s4, s44);
-                s5 = _mm256_packus_epi32(s5, s55);
-                s6 = _mm256_packus_epi32(s6, s66);
-                s7 = _mm256_packus_epi32(s7, s77);
-                s8 = _mm256_packus_epi32(s8, s88);
-                __m256i result2 = _mm256_mulhi_epu16(s0, f1);
-                __m256i result2lo = _mm256_mullo_epi16(s0, f1);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s1, f2);
-                result2lo = _mm256_mullo_epi16(s1, f2);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s2, f3);
-                result2lo = _mm256_mullo_epi16(s2, f3);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s3, f4);
-                result2lo = _mm256_mullo_epi16(s3, f4);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s4, f5);
-                result2lo = _mm256_mullo_epi16(s4, f5);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s5, f6);
-                result2lo = _mm256_mullo_epi16(s5, f6);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s6, f7);
-                result2lo = _mm256_mullo_epi16(s6, f7);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s7, f8);
-                result2lo = _mm256_mullo_epi16(s7, f8);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s8, f9);
-                result2lo = _mm256_mullo_epi16(s8, f9);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-
-                __m256i g0 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check));
-                __m256i g1 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 1));
-                __m256i g2 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 2));
-                __m256i g3 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 3));
-                __m256i g4 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 4));
-                __m256i g5 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 5));
-                __m256i g6 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 6));
-                __m256i g7 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 7));
-                __m256i g8 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 8));
-                // __m256i g00 = _mm256_loadu_si256((__m256i*
-                // )(buf.tmp.mu2+jj_check+16));
-                __m256i g11 =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check + 9));
-                __m256i g22 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 10));
-                __m256i g33 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 11));
-                __m256i g44 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 12));
-                __m256i g55 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 13));
-                __m256i g66 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 14));
-                __m256i g77 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 15));
-                __m256i g88 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 16));
-                //***********experiment unroll loop in width doer mu2
-                g0 = _mm256_packus_epi32(g0, g8);
-                g1 = _mm256_packus_epi32(g1, g11);
-                g2 = _mm256_packus_epi32(g2, g22);
-                g3 = _mm256_packus_epi32(g3, g33);
-                g4 = _mm256_packus_epi32(g4, g44);
-                g5 = _mm256_packus_epi32(g5, g55);
-                g6 = _mm256_packus_epi32(g6, g66);
-                g7 = _mm256_packus_epi32(g7, g77);
-                g8 = _mm256_packus_epi32(g8, g88);
-                result2 = _mm256_mulhi_epu16(g0, f1);
-                result2lo = _mm256_mullo_epi16(g0, f1);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g1, f2);
-                result2lo = _mm256_mullo_epi16(g1, f2);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g2, f3);
-                result2lo = _mm256_mullo_epi16(g2, f3);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g3, f4);
-                result2lo = _mm256_mullo_epi16(g3, f4);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g4, f5);
-                result2lo = _mm256_mullo_epi16(g4, f5);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g5, f6);
-                result2lo = _mm256_mullo_epi16(g5, f6);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g6, f7);
-                result2lo = _mm256_mullo_epi16(g6, f7);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g7, f8);
-                result2lo = _mm256_mullo_epi16(g7, f8);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g8, f9);
-                result2lo = _mm256_mullo_epi16(g8, f9);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-
-                s0 = s11;
-                s1 = s22;
-                s2 = s33;
-                s3 = s44;
-                s4 = s55;
-                s5 = s66;
-                s6 = s77;
-                s7 = s88;
-
-                __m256i s00 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 17));
-                s11 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 18));
-                s22 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 19));
-                s33 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 20));
-                s44 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 21));
-                s55 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 22));
-                s66 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 23));
-                s77 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu1 + jj_check + 24));
-
-                s0 = _mm256_packus_epi32(s0, s00);
-                s1 = _mm256_packus_epi32(s1, s11);
-                s2 = _mm256_packus_epi32(s2, s22);
-                s3 = _mm256_packus_epi32(s3, s33);
-                s4 = _mm256_packus_epi32(s4, s44);
-                s5 = _mm256_packus_epi32(s5, s55);
-                s6 = _mm256_packus_epi32(s6, s66);
-                s7 = _mm256_packus_epi32(s7, s77);
-
-                result2 = _mm256_mulhi_epu16(s0, f8);
-                result2lo = _mm256_mullo_epi16(s0, f8);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s1, f7);
-                result2lo = _mm256_mullo_epi16(s1, f7);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s2, f6);
-                result2lo = _mm256_mullo_epi16(s2, f6);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s3, f5);
-                result2lo = _mm256_mullo_epi16(s3, f5);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s4, f4);
-                result2lo = _mm256_mullo_epi16(s4, f4);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s5, f3);
-                result2lo = _mm256_mullo_epi16(s5, f3);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s6, f2);
-                result2lo = _mm256_mullo_epi16(s6, f2);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(s7, f1);
-                result2lo = _mm256_mullo_epi16(s7, f1);
-                mu1lo = _mm256_add_epi32(
-                    mu1lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm256_add_epi32(
-                    mu1hi, _mm256_unpackhi_epi16(result2lo, result2));
-
-                g0 = g11;
-                g1 = g22;
-                g2 = g33;
-                g3 = g44;
-                g4 = g55;
-                g5 = g66;
-                g6 = g77;
-                g7 = g88;
-
-                __m256i g00 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 17));
-                g11 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 18));
-                g22 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 19));
-                g33 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 20));
-                g44 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 21));
-                g55 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 22));
-                g66 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 23));
-                g77 = _mm256_loadu_si256(
-                    (__m256i *)(buf.tmp.mu2 + jj_check + 24));
-
-                //***********experiment unroll loop in width doer mu2
-                g0 = _mm256_packus_epi32(g0, g00);
-                g1 = _mm256_packus_epi32(g1, g11);
-                g2 = _mm256_packus_epi32(g2, g22);
-                g3 = _mm256_packus_epi32(g3, g33);
-                g4 = _mm256_packus_epi32(g4, g44);
-                g5 = _mm256_packus_epi32(g5, g55);
-                g6 = _mm256_packus_epi32(g6, g66);
-                g7 = _mm256_packus_epi32(g7, g77);
-                g8 = _mm256_packus_epi32(g8, g88);
-                result2 = _mm256_mulhi_epu16(g0, f8);
-                result2lo = _mm256_mullo_epi16(g0, f8);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g1, f7);
-                result2lo = _mm256_mullo_epi16(g1, f7);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g2, f6);
-                result2lo = _mm256_mullo_epi16(g2, f6);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g3, f5);
-                result2lo = _mm256_mullo_epi16(g3, f5);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g4, f4);
-                result2lo = _mm256_mullo_epi16(g4, f4);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g5, f3);
-                result2lo = _mm256_mullo_epi16(g5, f3);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g6, f2);
-                result2lo = _mm256_mullo_epi16(g6, f2);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-                result2 = _mm256_mulhi_epu16(g7, f1);
-                result2lo = _mm256_mullo_epi16(g7, f1);
-                mu2lo = _mm256_add_epi32(
-                    mu2lo, _mm256_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm256_add_epi32(
-                    mu2hi, _mm256_unpackhi_epi16(result2lo, result2));
-            }
-
-            _mm256_storeu_si256((__m256i *)(buf.mu1_32 + (dst_stride * i) + j),
-                                mu1lo);
-            _mm256_storeu_si256(
-                (__m256i *)(buf.mu1_32 + (dst_stride * i) + j + 8), mu1hi);
-            _mm256_storeu_si256((__m256i *)(buf.mu2_32 + (dst_stride * i) + j),
-                                mu2lo);
-            _mm256_storeu_si256(
-                (__m256i *)(buf.mu2_32 + (dst_stride * i) + j + 8), mu2hi);
-        }
-        for (unsigned j = 0; j < w; j = j + 8) {
-            __m256i refdislo, refdishi, reflo, refhi, dislo, dishi;
-            refdislo = refdishi = reflo = refhi = dislo = dishi =
-                _mm256_setzero_si256();
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            __m256i mask1 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
-            __m256i addnum = _mm256_set1_epi64x(32768);
-
-            __m256i s0 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check))); // 4
-            __m256i s1 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 1))); // 8
-            __m256i s2 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 2))); // 4
-            __m256i s3 = _mm256_cvtepu32_epi64(_mm_loadu_si128(
-                (__m128 *)(buf.tmp.ref + jj_check + 3))); // 8  //12
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s0, fq1));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s1, fq2));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s2, fq3));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s3, fq4));
-
-            __m256i s4 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 4)));
-            __m256i s5 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 5)));
-            __m256i s6 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 6)));
-            __m256i s7 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 7)));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s4, fq1));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s5, fq2));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s6, fq3));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s7, fq4));
-
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s4, fq5));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s5, fq6));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s6, fq7));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s7, fq8));
-
-            __m256i s8 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 8)));
-            __m256i s9 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 9)));
-            __m256i s10 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 10)));
-            __m256i s11 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 11)));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s8, fq5));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s9, fq6));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s10, fq7));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s11, fq8));
-
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s8, fq9));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s9, fq8));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s10, fq7));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s11, fq6));
-
-            __m256i s12 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 12)));
-            __m256i s13 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 13)));
-            __m256i s14 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 14)));
-            __m256i s15 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 15)));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s12, fq9));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s13, fq8));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s14, fq7));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s15, fq6));
-
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s12, fq5));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s13, fq4));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s14, fq3));
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s15, fq2));
-
-            __m256i s16 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 16)));
-            __m256i s17 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 17)));
-            __m256i s18 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 18)));
-            __m256i s19 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 19)));
-
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s16, fq5));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s17, fq4));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s18, fq3));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s19, fq2));
-
-            reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s16, fq1));
-            __m256i s20 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 20)));
-            refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s20, fq1));
-
-            __m256i g0 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check)));
-            __m256i g1 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 1)));
-            __m256i g2 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 2)));
-            __m256i g3 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 3)));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g0, fq1));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g1, fq2));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g2, fq3));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g3, fq4));
-
-            __m256i g4 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 4)));
-            __m256i g5 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 5)));
-            __m256i g6 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 6)));
-            __m256i g7 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 7)));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g4, fq1));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g5, fq2));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g6, fq3));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g7, fq4));
-
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g4, fq5));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g5, fq6));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g6, fq7));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g7, fq8));
-
-            __m256i g8 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 8)));
-            __m256i g9 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 9)));
-            __m256i g10 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 10)));
-            __m256i g11 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 11)));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g8, fq5));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g9, fq6));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g10, fq7));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g11, fq8));
-
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g8, fq9));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g9, fq8));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g10, fq7));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g11, fq6));
-
-            __m256i g12 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 12)));
-            __m256i g13 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 13)));
-            __m256i g14 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 14)));
-            __m256i g15 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 15)));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g12, fq9));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g13, fq8));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g14, fq7));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g15, fq6));
-
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g12, fq5));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g13, fq4));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g14, fq3));
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g15, fq2));
-
-            __m256i g16 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 16)));
-            __m256i g17 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 17)));
-            __m256i g18 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 18)));
-            __m256i g19 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 19)));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g16, fq5));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g17, fq4));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g18, fq3));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g19, fq2));
-
-            dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g16, fq1));
-            __m256i g20 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 20)));
-            dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g20, fq1));
-
-            __m256i sg0 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check)));
-            __m256i sg1 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 1)));
-            __m256i sg2 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 2)));
-            __m256i sg3 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 3)));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg0, fq1));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg1, fq2));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg2, fq3));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg3, fq4));
-
-            __m256i sg4 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 4)));
-            __m256i sg5 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 5)));
-            __m256i sg6 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 6)));
-            __m256i sg7 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 7)));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg4, fq1));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg5, fq2));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg6, fq3));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg7, fq4));
-
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg4, fq5));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg5, fq6));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg6, fq7));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg7, fq8));
-
-            __m256i sg8 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 8)));
-            __m256i sg9 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 9)));
-            __m256i sg10 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 10)));
-            __m256i sg11 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 11)));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg8, fq5));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg9, fq6));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg10, fq7));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg11, fq8));
-
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg8, fq9));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg9, fq8));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg10, fq7));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg11, fq6));
-
-            __m256i sg12 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 12)));
-            __m256i sg13 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 13)));
-            __m256i sg14 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 14)));
-            __m256i sg15 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 15)));
-
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg12, fq9));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg13, fq8));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg14, fq7));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg15, fq6));
-
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg12, fq5));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg13, fq4));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg14, fq3));
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg15, fq2));
-
-            __m256i sg16 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 16)));
-            __m256i sg17 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 17)));
-            __m256i sg18 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 18)));
-            __m256i sg19 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 19)));
-
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg16, fq5));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg17, fq4));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg18, fq3));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg19, fq2));
-
-            refdislo = _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg16, fq1));
-            __m256i sg20 = _mm256_cvtepu32_epi64(
-                _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check + 20)));
-            refdishi = _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg20, fq1));
-
-            reflo = _mm256_add_epi64(reflo, addnum);
-            reflo = _mm256_srli_epi64(reflo, 0x10);
-            refhi = _mm256_add_epi64(refhi, addnum);
-            refhi = _mm256_srli_epi64(refhi, 0x10);
-            refhi = _mm256_slli_si256(refhi, 4);
-            refhi = _mm256_blend_epi32(reflo, refhi, 0xAA);
-            refhi = _mm256_permutevar8x32_epi32(refhi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.ref_sq + (dst_stride * i) + j),
-                                refhi);
-            dislo = _mm256_add_epi64(dislo, addnum);
-            dislo = _mm256_srli_epi64(dislo, 0x10);
-            dishi = _mm256_add_epi64(dishi, addnum);
-            dishi = _mm256_srli_epi64(dishi, 0x10);
-            dishi = _mm256_slli_si256(dishi, 4);
-            dishi = _mm256_blend_epi32(dislo, dishi, 0xAA);
-            dishi = _mm256_permutevar8x32_epi32(dishi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.dis_sq + (dst_stride * i) + j),
-                                dishi);
-            refdislo = _mm256_add_epi64(refdislo, addnum);
-            refdislo = _mm256_srli_epi64(refdislo, 0x10);
-            refdishi = _mm256_add_epi64(refdishi, addnum);
-            refdishi = _mm256_srli_epi64(refdishi, 0x10);
-            refdishi = _mm256_slli_si256(refdishi, 4);
-            refdishi = _mm256_blend_epi32(refdislo, refdishi, 0xAA);
-            refdishi = _mm256_permutevar8x32_epi32(refdishi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.ref_dis + (dst_stride * i) + j),
-                                refdishi);
-        }
+#include "feature/common/macros.h"
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+#if defined __GNUC__
+#define ALIGNED(x) __attribute__ ((aligned (x)))
+#elif defined (_MSC_VER)  && (!defined UNDER_CE)
+#define ALIGNED(x) __declspec (align(x))
+#else
+#define ALIGNED(x)
+#endif
+
+
+static FORCE_INLINE inline void
+pad_top_and_bottom(VifBuffer buf, unsigned h, int fwidth)
+{
+    const unsigned fwidth_half = fwidth / 2;
+    unsigned char *ref = buf.ref;
+    unsigned char *dis = buf.dis;
+    for (unsigned i = 1; i <= fwidth_half; ++i) {
+        size_t offset = buf.stride * i;
+        memcpy(ref - offset, ref + offset, buf.stride);
+        memcpy(dis - offset, dis + offset, buf.stride);
+        memcpy(ref + buf.stride * (h - 1) + buf.stride * i,
+            ref + buf.stride * (h - 1) - buf.stride * i,
+            buf.stride);
+        memcpy(dis + buf.stride * (h - 1) + buf.stride * i,
+            dis + buf.stride * (h - 1) - buf.stride * i,
+            buf.stride);
     }
 }
 
-void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
-                          int bpc) {
+static FORCE_INLINE inline void
+copy_and_pad(VifBuffer buf, unsigned w, unsigned h, int scale)
+{
+    uint16_t *ref = buf.ref;
+    uint16_t *dis = buf.dis;
+    const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
+    const ptrdiff_t mu_stride = buf.stride_16 / sizeof(uint16_t);
+
+    for (unsigned i = 0; i < h / 2; ++i) {
+        for (unsigned j = 0; j < w / 2; ++j) {
+            ref[i * stride + j] = buf.mu1[i * mu_stride + j];
+            dis[i * stride + j] = buf.mu2[i * mu_stride + j];
+        }
+    }
+    pad_top_and_bottom(buf, h / 2, vif_filter1d_width[scale]);
+}
+
+// multiply r0 * f and store in 32-bit accumulators (shuffled 0 1 2 3 8 9 10 11 / 4 5 6 7 12 13 14 15)
+#define multiply2(acc_left, acc_right, r0, f) \
+{ \
+__m256i zero = _mm256_setzero_si256(); \
+acc_left = _mm256_madd_epi16(_mm256_unpacklo_epi16(r0, zero), f); \
+acc_right = _mm256_madd_epi16(_mm256_unpackhi_epi16(r0, zero), f); \
+}
+
+// multiply r0 * f and r1 * f and store in 32-bit accumulators (shuffled 0 1 2 3 8 9 10 11 / 4 5 6 7 12 13 14 15)
+#define multiply2_and_accumulate(acc_left, acc_right, r0, r1, f) \
+  acc_left = _mm256_add_epi32(acc_left, _mm256_madd_epi16(_mm256_unpacklo_epi16(r0, r1), f)); \
+  acc_right = _mm256_add_epi32(acc_right, _mm256_madd_epi16(_mm256_unpackhi_epi16(r0, r1), f));
+
+
+// compute r0 * r1 * f and set 32-bit accumulators (shuffled 0 1 2 3 8 9 10 11 / 4 5 6 7 12 13 14 15)
+#define multiply3(accum_ref_left, accum_ref_right, r0, r1, f) \
+{ \
+    __m256i mul = _mm256_mullo_epi16(r0, r1); \
+    __m256i lo = _mm256_mullo_epi16(mul, f); \
+    __m256i hi = _mm256_mulhi_epu16(mul, f); \
+    accum_ref_left = _mm256_unpacklo_epi16(lo, hi); \
+    accum_ref_right = _mm256_unpackhi_epi16(lo, hi); \
+}
+
+// compute r0 * r1 * f and add to 32-bit accumulators (shuffled 0 1 2 3 8 9 10 11 / 4 5 6 7 12 13 14 15)
+#define multiply3_and_accumulate(accum_ref_left, accum_ref_right, r0, r1, f) \
+{ \
+    __m256i mul = _mm256_mullo_epi16(r0, r1); \
+    __m256i lo = _mm256_mullo_epi16(mul, f); \
+    __m256i hi = _mm256_mulhi_epu16(mul, f); \
+    __m256i left = _mm256_unpacklo_epi16(lo, hi); \
+    __m256i right = _mm256_unpackhi_epi16(lo, hi); \
+    accum_ref_left = _mm256_add_epi32(accum_ref_left, left); \
+    accum_ref_right = _mm256_add_epi32(accum_ref_right, right); \
+}
+
+#define shuffle_and_save(addr, x, y) \
+{ \
+   __m256i left = _mm256_permute2x128_si256(x, y, 0x20); \
+   __m256i right = _mm256_permute2x128_si256(x, y, 0x31); \
+   _mm256_storeu_si256((__m256i*)(addr), left); \
+   _mm256_storeu_si256(((__m256i*)(addr)) + 1, right); \
+}
+
+
+void vif_statistic_8_avx2(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h) {
+    assert(vif_filter1d_width[0] == 17);
+    static const unsigned fwidth = 17;
+    const uint16_t *vif_filt_s0 = vif_filter1d_table[0];
+    VifBuffer buf = s->buf;
+
+    //float equivalent of 2. (2 * 65536)
+    static const int32_t sigma_nsq = 65536 << 1;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
+
+    int64_t accum_num_log = 0;
+    int64_t accum_den_log = 0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
+    uint16_t *log2_table = s->log2_table;
+
+    // variables used for 16 sample block vif computation
+    ALIGNED(32) uint32_t xx[16];
+    ALIGNED(32) uint32_t yy[16];
+    ALIGNED(32) uint32_t xy[16];
+    // loop on row, each iteration produces one line of output
+    for (unsigned i = 0; i < h; ++i) {
+        // Filter vertically
+        for (unsigned jj = 0; jj < w; jj += 16) {
+            __m256i accum_ref_left, accum_ref_right;
+            __m256i accum_dis_left, accum_dis_right;
+            __m256i accum_ref_dis_left, accum_ref_dis_right;
+            __m256i accum_mu2_left, accum_mu2_right;
+            __m256i accum_mu1_left, accum_mu1_right;
+
+            __m256i f0 = _mm256_set1_epi16(vif_filt_s0[fwidth / 2]);
+            __m256i r0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * i) + jj)));
+            __m256i d0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * i) + jj)));
+
+            // filtered r,d
+            multiply2(accum_mu1_left, accum_mu1_right, r0, f0);
+            multiply2(accum_mu2_left, accum_mu2_right, d0, f0);
+
+            // filtered(r * r, d * d, r * d)
+            multiply3(accum_ref_left, accum_ref_right, r0, r0, f0);
+            multiply3(accum_dis_left, accum_dis_right, d0, d0, f0);
+            multiply3(accum_ref_dis_left, accum_ref_dis_right, d0, r0, f0);
+
+            for (unsigned int tap = 0; tap < fwidth / 2; tap++) {
+                int ii_check = i - fwidth / 2 + tap;
+                int ii_check_1 = i + fwidth / 2 - tap;
+
+                __m256i f0 = _mm256_set1_epi16(vif_filt_s0[tap]);
+                __m256i r0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * ii_check) + jj)));
+                __m256i r1 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * (ii_check_1)) + jj)));
+                __m256i d0 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * ii_check) + jj)));
+                __m256i d1 = _mm256_cvtepu8_epi16(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * (ii_check_1)) + jj)));
+
+                // accumulate filtered r,d
+                multiply2_and_accumulate(accum_mu1_left, accum_mu1_right, r0, r1, f0);
+                multiply2_and_accumulate(accum_mu2_left, accum_mu2_right, d0, d1, f0);
+
+                // accumulate filtered(r * r, d * d, r * d)
+                multiply3_and_accumulate(accum_ref_left, accum_ref_right, r0, r0, f0);
+                multiply3_and_accumulate(accum_ref_left, accum_ref_right, r1, r1, f0);
+                multiply3_and_accumulate(accum_dis_left, accum_dis_right, d0, d0, f0);
+                multiply3_and_accumulate(accum_dis_left, accum_dis_right, d1, d1, f0);
+                multiply3_and_accumulate(accum_ref_dis_left, accum_ref_dis_right, d0, r0, f0);
+                multiply3_and_accumulate(accum_ref_dis_left, accum_ref_dis_right, d1, r1, f0);
+            }
+
+            __m256i x = _mm256_set1_epi32(128);
+
+            accum_mu1_left = _mm256_add_epi32(accum_mu1_left, x);
+            accum_mu1_right = _mm256_add_epi32(accum_mu1_right, x);
+            accum_mu2_left = _mm256_add_epi32(accum_mu2_left, x);
+            accum_mu2_right = _mm256_add_epi32(accum_mu2_right, x);
+
+            accum_mu1_left = _mm256_srli_epi32(accum_mu1_left, 0x08);
+            accum_mu1_right = _mm256_srli_epi32(accum_mu1_right, 0x08);
+            accum_mu2_left = _mm256_srli_epi32(accum_mu2_left, 0x08);
+            accum_mu2_right = _mm256_srli_epi32(accum_mu2_right, 0x08);
+
+            shuffle_and_save(buf.tmp.mu1 + jj, accum_mu1_left, accum_mu1_right);
+            shuffle_and_save(buf.tmp.mu2 + jj, accum_mu2_left, accum_mu2_right);
+            shuffle_and_save(buf.tmp.ref + jj, accum_ref_left, accum_ref_right);
+            shuffle_and_save(buf.tmp.dis + jj, accum_dis_left, accum_dis_right);
+            shuffle_and_save(buf.tmp.ref_dis + jj, accum_ref_dis_left, accum_ref_dis_right);
+        }
+
+        PADDING_SQ_DATA(buf, w, fwidth / 2);
+
+        //HORIZONTAL
+        for (unsigned j = 0; j < w; j += 16) {
+            __m256i mu1_lo;
+            __m256i mu1_hi;
+            __m256i mu1sq_lo; // shuffled
+            __m256i mu1sq_hi; // shuffled
+            __m256i mu2sq_lo; // shuffled
+            __m256i mu2sq_hi; // shuffled
+            __m256i mu1mu2_lo; // shuffled
+            __m256i mu1mu2_hi; // shuffled
+
+            // compute mu1 filtered, mu1*mu1 filterd
+            {
+                __m256i fq = _mm256_set1_epi32(vif_filt_s0[fwidth / 2]);
+                mu1_lo = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j + 0)), fq);
+                mu1_hi = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j + 8)), fq);
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi32(vif_filt_s0[fj]);
+                    mu1_lo = _mm256_add_epi64(mu1_lo, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j - fwidth / 2 + fj + 0)), fq));
+                    mu1_hi = _mm256_add_epi64(mu1_hi, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j - fwidth / 2 + fj + 8)), fq));
+                    mu1_lo = _mm256_add_epi64(mu1_lo, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j + fwidth / 2 - fj + 0)), fq));
+                    mu1_hi = _mm256_add_epi64(mu1_hi, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + j + fwidth / 2 - fj + 8)), fq));
+                }
+
+                __m256i acc0_lo = _mm256_unpacklo_epi32(mu1_lo, _mm256_setzero_si256());
+                __m256i acc0_hi = _mm256_unpackhi_epi32(mu1_lo, _mm256_setzero_si256());
+                acc0_lo = _mm256_mul_epu32(acc0_lo, acc0_lo);
+                acc0_hi = _mm256_mul_epu32(acc0_hi, acc0_hi);
+                acc0_lo = _mm256_srli_epi64(_mm256_add_epi64(acc0_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc0_hi = _mm256_srli_epi64(_mm256_add_epi64(acc0_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                __m256i acc1_lo = _mm256_unpacklo_epi32(mu1_hi, _mm256_setzero_si256());
+                __m256i acc1_hi = _mm256_unpackhi_epi32(mu1_hi, _mm256_setzero_si256());
+                acc1_lo = _mm256_mul_epu32(acc1_lo, acc1_lo);
+                acc1_hi = _mm256_mul_epu32(acc1_hi, acc1_hi);
+                acc1_lo = _mm256_srli_epi64(_mm256_add_epi64(acc1_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc1_hi = _mm256_srli_epi64(_mm256_add_epi64(acc1_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+
+                __m256i acc0_sq = _mm256_blend_epi32(acc0_lo, _mm256_slli_si256(acc0_hi, 4), 0xAA);
+                __m256i acc1_sq = _mm256_blend_epi32(acc1_lo, _mm256_slli_si256(acc1_hi, 4), 0xAA);
+                mu1sq_lo = acc0_sq;
+                mu1sq_hi = acc1_sq;
+            }
+
+            // compute mu2 filtered, mu2*mu2 filtered, mu1*mu2 filtered
+            {
+                __m256i fq = _mm256_set1_epi32(vif_filt_s0[fwidth / 2]);
+                __m256i acc0 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j + 0)), fq);
+                __m256i acc1 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j + 8)), fq);
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi32(vif_filt_s0[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j - fwidth / 2 + fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j - fwidth / 2 + fj + 8)), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j + fwidth / 2 - fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + j + fwidth / 2 - fj + 8)), fq));
+                }
+
+                __m256i acc0_lo = _mm256_unpacklo_epi32(acc0, _mm256_setzero_si256());
+                __m256i acc0_hi = _mm256_unpackhi_epi32(acc0, _mm256_setzero_si256());
+
+                __m256i mu1lo_lo = _mm256_unpacklo_epi32(mu1_lo, _mm256_setzero_si256());
+                __m256i mu1lo_hi = _mm256_unpackhi_epi32(mu1_lo, _mm256_setzero_si256());
+                __m256i mu1hi_lo = _mm256_unpacklo_epi32(mu1_hi, _mm256_setzero_si256());
+                __m256i mu1hi_hi = _mm256_unpackhi_epi32(mu1_hi, _mm256_setzero_si256());
+
+
+                mu1lo_lo = _mm256_mul_epu32(mu1lo_lo, acc0_lo);
+                mu1lo_hi = _mm256_mul_epu32(mu1lo_hi, acc0_hi);
+                mu1lo_lo = _mm256_srli_epi64(_mm256_add_epi64(mu1lo_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                mu1lo_hi = _mm256_srli_epi64(_mm256_add_epi64(mu1lo_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                acc0_lo = _mm256_mul_epu32(acc0_lo, acc0_lo);
+                acc0_hi = _mm256_mul_epu32(acc0_hi, acc0_hi);
+                acc0_lo = _mm256_srli_epi64(_mm256_add_epi64(acc0_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc0_hi = _mm256_srli_epi64(_mm256_add_epi64(acc0_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+
+                __m256i acc1_lo = _mm256_unpacklo_epi32(acc1, _mm256_setzero_si256());
+                __m256i acc1_hi = _mm256_unpackhi_epi32(acc1, _mm256_setzero_si256());
+
+                mu1hi_lo = _mm256_mul_epu32(mu1hi_lo, acc1_lo);
+                mu1hi_hi = _mm256_mul_epu32(mu1hi_hi, acc1_hi);
+                mu1hi_lo = _mm256_srli_epi64(_mm256_add_epi64(mu1hi_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                mu1hi_hi = _mm256_srli_epi64(_mm256_add_epi64(mu1hi_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                acc1_lo = _mm256_mul_epu32(acc1_lo, acc1_lo);
+                acc1_hi = _mm256_mul_epu32(acc1_hi, acc1_hi);
+                acc1_lo = _mm256_srli_epi64(_mm256_add_epi64(acc1_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc1_hi = _mm256_srli_epi64(_mm256_add_epi64(acc1_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+
+                mu2sq_lo = _mm256_blend_epi32(acc0_lo, _mm256_slli_si256(acc0_hi, 4), 0xAA);
+                mu2sq_hi = _mm256_blend_epi32(acc1_lo, _mm256_slli_si256(acc1_hi, 4), 0xAA);
+
+                mu1mu2_lo = _mm256_blend_epi32(mu1lo_lo, _mm256_slli_si256(mu1lo_hi, 4), 0xAA);
+                mu1mu2_hi = _mm256_blend_epi32(mu1hi_lo, _mm256_slli_si256(mu1hi_hi, 4), 0xAA);
+            }
+
+            // compute yy, that is refsq filtered - mu1 * mu1
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fwidth / 2]);
+
+                __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 0));
+                __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 8));
+
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fj]);
+                    __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 0));
+                    __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 8));
+                    __m256i m2 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 0));
+                    __m256i m3 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 8));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m3, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m3, _mm256_setzero_si256()), fq));
+                }
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                acc0 = _mm256_blend_epi32(acc0, _mm256_slli_si256(acc1, 4), 0xAA);
+                acc1 = _mm256_blend_epi32(acc2, _mm256_slli_si256(acc3, 4), 0xAA);
+
+                //mu1sq is shuffled
+                acc0 = _mm256_sub_epi32(acc0, mu1sq_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu1sq_hi);
+
+                acc0 = _mm256_shuffle_epi32(acc0, 0xD8);
+                acc1 = _mm256_shuffle_epi32(acc1, 0xD8);
+
+                _mm256_storeu_si256((__m256i*)& xx[0], acc0);
+                _mm256_storeu_si256((__m256i*)& xx[8], acc1);
+            }
+
+            // compute yy, that is dissq filtered - mu1 * mu1
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fwidth / 2]);
+
+                __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 0));
+                __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 8));
+
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fj]);
+                    __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 0));
+                    __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 8));
+                    __m256i m2 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 0));
+                    __m256i m3 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 8));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m3, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m3, _mm256_setzero_si256()), fq));
+                }
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                acc0 = _mm256_blend_epi32(acc0, _mm256_slli_si256(acc1, 4), 0xAA);
+                acc1 = _mm256_blend_epi32(acc2, _mm256_slli_si256(acc3, 4), 0xAA);
+
+                //mu2sq is already shuffled
+                acc0 = _mm256_sub_epi32(acc0, mu2sq_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu2sq_hi);
+
+                acc0 = _mm256_shuffle_epi32(acc0, 0xD8);
+                acc1 = _mm256_shuffle_epi32(acc1, 0xD8);
+
+                _mm256_storeu_si256((__m256i*) & yy[0], _mm256_max_epi32(acc0, _mm256_setzero_si256()));
+                _mm256_storeu_si256((__m256i*) & yy[8], _mm256_max_epi32(acc1, _mm256_setzero_si256()));
+            }
+
+            // compute xy, that is ref*dis filtered - mu1 * mu2
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fwidth / 2]);
+
+                __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 0));
+                __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 8));
+
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt_s0[fj]);
+                    __m256i m0 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 0));
+                    __m256i m1 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 8));
+                    __m256i m2 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 0));
+                    __m256i m3 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 8));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m0, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m1, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m1, _mm256_setzero_si256()), fq));
+
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_unpacklo_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_unpackhi_epi32(m2, _mm256_setzero_si256()), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_unpacklo_epi32(m3, _mm256_setzero_si256()), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_unpackhi_epi32(m3, _mm256_setzero_si256()), fq));
+                }
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                acc0 = _mm256_blend_epi32(acc0, _mm256_slli_si256(acc1, 4), 0xAA);
+                acc1 = _mm256_blend_epi32(acc2, _mm256_slli_si256(acc3, 4), 0xAA);
+
+                //mu1sq is already shuffled
+                acc0 = _mm256_sub_epi32(acc0, mu1mu2_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu1mu2_hi);
+
+                acc0 = _mm256_shuffle_epi32(acc0, 0xD8);
+                acc1 = _mm256_shuffle_epi32(acc1, 0xD8);
+
+                _mm256_storeu_si256((__m256i*) & xy[0], acc0);
+                _mm256_storeu_si256((__m256i*) & xy[8], acc1);
+            }
+
+            for (unsigned int b = 0; b < 16; b++) {
+                int32_t sigma1_sq = xx[b];
+                int32_t sigma2_sq = yy[b];
+                int32_t sigma12 = xy[b];
+
+                if (sigma1_sq >= sigma_nsq) {
+                    /**
+                    * log values are taken from the look-up table generated by
+                    * log_generate() function which is called in integer_combo_threadfunc
+                    * den_val in float is log2(1 + sigma1_sq/2)
+                    * here it is converted to equivalent of log2(2+sigma1_sq) - log2(2) i.e log2(2*65536+sigma1_sq) - 17
+                    * multiplied by 2048 as log_value = log2(i)*2048 i=16384 to 65535 generated using log_value
+                    * x because best 16 bits are taken
+                    */
+                    accum_den_log += log2_32(log2_table, sigma_nsq + sigma1_sq) - 2048 * 17;
+
+                    if (sigma12 > 0 && sigma2_sq > 0)
+                    {
+                        // num_val = log2f(1.0f + (g * g * sigma1_sq) / (sv_sq + sigma_nsq));
+                        /**
+                        * In floating-point numerator = log2((1.0f + (g * g * sigma1_sq)/(sv_sq + sigma_nsq))
+                        *
+                        * In Fixed-point the above is converted to
+                        * numerator = log2((sv_sq + sigma_nsq)+(g * g * sigma1_sq))- log2(sv_sq + sigma_nsq)
+                        */
+
+                        const double eps = 65536 * 1.0e-10;
+                        double g = sigma12 / (sigma1_sq + eps); // this epsilon can go away
+                        int32_t sv_sq = sigma2_sq - g * sigma12;
+
+                        sv_sq = (uint32_t)(MAX(sv_sq, 0));
+
+                        g = MIN(g, vif_enhn_gain_limit);
+
+                        uint32_t numer1 = (sv_sq + sigma_nsq);
+                        int64_t numer1_tmp = (int64_t)((g * g * sigma1_sq)) + numer1; //numerator
+                        accum_num_log += log2_64(log2_table, numer1_tmp) - log2_64(log2_table, numer1);
+                    }
+                }
+                else {
+                    accum_num_non_log += sigma2_sq;
+                    accum_den_non_log++;
+                }
+            }
+        }
+    }
+
+    //log has to be divided by 2048 as log_value = log2(i*2048)  i=16384 to 65535
+    //num[0] = accum_num_log / 2048.0 + (accum_den_non_log - (accum_num_non_log / 65536.0) / (255.0*255.0));
+    //den[0] = accum_den_log / 2048.0 + accum_den_non_log;
+
+    //changed calculation to increase performance
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
+
+}
+
+void vif_statistic_16_avx2(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale) {
     const unsigned fwidth = vif_filter1d_width[scale];
     const uint16_t *vif_filt = vif_filter1d_table[scale];
-    const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
+    VifBuffer buf = s->buf;
     const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
     int fwidth_half = fwidth >> 1;
 
     int32_t add_shift_round_HP, shift_HP;
     int32_t add_shift_round_VP, shift_VP;
     int32_t add_shift_round_VP_sq, shift_VP_sq;
+
+    //float equivalent of 2. (2 * 65536)
+    static const int32_t sigma_nsq = 65536 << 1;
+
+    int64_t accum_num_log = 0;
+    int64_t accum_den_log = 0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
+    const uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
+
+    // variables used for 16 sample block vif computation
+    ALIGNED(32) uint32_t xx[16];
+    ALIGNED(32) uint32_t yy[16];
+    ALIGNED(32) uint32_t xy[16];
+
     if (scale == 0) {
         shift_HP = 16;
         add_shift_round_HP = 32768;
@@ -1423,16 +550,8 @@ void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
     for (unsigned i = 0; i < h; ++i) {
         // VERTICAL
         int ii = i - fwidth_half;
-        int n = w >> 4;
+        unsigned n = w >> 4;
         for (unsigned j = 0; j < n << 4; j = j + 16) {
-            uint32_t accum_mu1 = 0;
-            uint32_t accum_mu2 = 0;
-            uint64_t accum_ref = 0;
-            uint64_t accum_dis = 0;
-            uint64_t accum_ref_dis = 0;
-            __m256i mask1 = _mm256_set_epi8(15, 14, 11, 10, 7, 6, 3, 2, 13, 12,
-                                            9, 8, 5, 4, 1, 0, 15, 14, 11, 10, 7,
-                                            6, 3, 2, 13, 12, 9, 8, 5, 4, 1, 0);
             __m256i mask2 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
             int ii_check = ii;
 
@@ -1449,7 +568,6 @@ void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
                             _mm256_setzero_si256();
             __m256i addnum = _mm256_set1_epi32(add_shift_round_VP);
             for (unsigned fi = 0; fi < fwidth; ++fi, ii_check = ii + fi) {
-                const uint16_t fcoeff = vif_filt[fi];
                 __m256i f1 = _mm256_set1_epi16(vif_filt[fi]);
                 __m256i ref1 = _mm256_loadu_si256(
                     (__m256i *)(ref + (ii_check * stride) + j));
@@ -1651,149 +769,299 @@ void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
 
         PADDING_SQ_DATA(buf, w, fwidth_half);
 
-        // HORIZONTAL
-        n = w >> 3;
-        for (unsigned j = 0; j < n << 3; j = j + 8) {
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            __m256i accumdl, accumrlo, accumdlo, accumrhi, accumdhi;
-            accumrlo = accumdlo = accumrhi = accumdhi = _mm256_setzero_si256();
-#pragma unroll(4)
-            for (unsigned fj = 0; fj < fwidth; ++fj, jj_check = jj + fj) {
-                __m256i refconvol =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu1 + jj_check));
-                __m256i fcoeff = _mm256_set1_epi16(vif_filt[fj]);
-                __m256i result2 = _mm256_mulhi_epu16(refconvol, fcoeff);
-                __m256i result2lo = _mm256_mullo_epi16(refconvol, fcoeff);
-                accumrlo = _mm256_add_epi32(
-                    accumrlo, _mm256_unpacklo_epi16(result2lo, result2));
-                accumrhi = _mm256_add_epi32(
-                    accumrhi, _mm256_unpackhi_epi16(result2lo, result2));
+        //HORIZONTAL
+        for (unsigned jj = 0; jj < n << 4; jj += 16) {
+            __m256i mu1_lo;
+            __m256i mu1_hi;
+            __m256i mu1sq_lo;
+            __m256i mu1sq_hi;
+            __m256i mu2sq_lo;
+            __m256i mu2sq_hi;
+            __m256i mu1mu2_lo;
+            __m256i mu1mu2_hi;
+            {
+                __m256i fq = _mm256_set1_epi32(vif_filt[fwidth / 2]);
+                __m256i acc0 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj + 0)), fq);
+                __m256i acc1 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj + 8)), fq);
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi32(vif_filt[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj - fwidth / 2 + fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj - fwidth / 2 + fj + 8)), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj + fwidth / 2 - fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu1 + jj + fwidth / 2 - fj + 8)), fq));
+                }
 
-                __m256i disconvol =
-                    _mm256_loadu_si256((__m256i *)(buf.tmp.mu2 + jj_check));
-                result2 = _mm256_mulhi_epu16(disconvol, fcoeff);
-                result2lo = _mm256_mullo_epi16(disconvol, fcoeff);
-                accumdlo = _mm256_add_epi32(
-                    accumdlo, _mm256_unpacklo_epi16(result2lo, result2));
-                accumdhi = _mm256_add_epi32(
-                    accumdhi, _mm256_unpackhi_epi16(result2lo, result2));
+                mu1_lo = acc0;
+                mu1_hi = acc1;
+
+                __m256i acc0_lo = _mm256_unpacklo_epi32(acc0, _mm256_setzero_si256());
+                __m256i acc0_hi = _mm256_unpackhi_epi32(acc0, _mm256_setzero_si256());
+                acc0_lo = _mm256_mul_epu32(acc0_lo, acc0_lo);
+                acc0_hi = _mm256_mul_epu32(acc0_hi, acc0_hi);
+                acc0_lo = _mm256_srli_epi64(_mm256_add_epi64(acc0_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc0_hi = _mm256_srli_epi64(_mm256_add_epi64(acc0_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                __m256i acc1_lo = _mm256_unpacklo_epi32(acc1, _mm256_setzero_si256());
+                __m256i acc1_hi = _mm256_unpackhi_epi32(acc1, _mm256_setzero_si256());
+                acc1_lo = _mm256_mul_epu32(acc1_lo, acc1_lo);
+                acc1_hi = _mm256_mul_epu32(acc1_hi, acc1_hi);
+                acc1_lo = _mm256_srli_epi64(_mm256_add_epi64(acc1_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc1_hi = _mm256_srli_epi64(_mm256_add_epi64(acc1_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                __m256i acc0_sq = _mm256_blend_epi32(acc0_lo, _mm256_slli_si256(acc0_hi, 4), 0xAA);
+                acc0_sq = _mm256_shuffle_epi32(acc0_sq, 0xD8);
+                __m256i acc1_sq = _mm256_blend_epi32(acc1_lo, _mm256_slli_si256(acc1_hi, 4), 0xAA);
+                acc1_sq = _mm256_shuffle_epi32(acc1_sq, 0xD8);
+                mu1sq_lo = acc0_sq;
+                mu1sq_hi = acc1_sq;
             }
 
-            accumrhi = _mm256_slli_si256(accumrhi, 4);
-            accumrhi = _mm256_blend_epi32(accumrlo, accumrhi, 0xAA);
-            accumrhi = _mm256_shuffle_epi32(accumrhi, 0xD8);
-            _mm256_storeu_si256((__m256i *)(buf.mu1_32 + (dst_stride * i) + j),
-                                accumrhi);
+            {
+                __m256i fq = _mm256_set1_epi32(vif_filt[fwidth / 2]);
+                __m256i acc0 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj + 0)), fq);
+                __m256i acc1 = _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj + 8)), fq);
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi32(vif_filt[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj - fwidth / 2 + fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj - fwidth / 2 + fj + 8)), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj + fwidth / 2 - fj + 0)), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mullo_epi32(_mm256_loadu_si256((__m256i*)(buf.tmp.mu2 + jj + fwidth / 2 - fj + 8)), fq));
+                }
 
-            accumdhi = _mm256_slli_si256(accumdhi, 4);
-            accumdhi = _mm256_blend_epi32(accumdlo, accumdhi, 0xAA);
-            accumdhi = _mm256_shuffle_epi32(accumdhi, 0xD8);
-            _mm256_storeu_si256((__m256i *)(buf.mu2_32 + (dst_stride * i) + j),
-                                accumdhi);
+                __m256i acc0_lo = _mm256_unpacklo_epi32(acc0, _mm256_setzero_si256());
+                __m256i acc0_hi = _mm256_unpackhi_epi32(acc0, _mm256_setzero_si256());
+
+                __m256i mu1lo_lo = _mm256_unpacklo_epi32(mu1_lo, _mm256_setzero_si256());
+                __m256i mu1lo_hi = _mm256_unpackhi_epi32(mu1_lo, _mm256_setzero_si256());
+                __m256i mu1hi_lo = _mm256_unpacklo_epi32(mu1_hi, _mm256_setzero_si256());
+                __m256i mu1hi_hi = _mm256_unpackhi_epi32(mu1_hi, _mm256_setzero_si256());
+
+
+                mu1lo_lo = _mm256_mul_epu32(mu1lo_lo, acc0_lo);
+                mu1lo_hi = _mm256_mul_epu32(mu1lo_hi, acc0_hi);
+                mu1lo_lo = _mm256_srli_epi64(_mm256_add_epi64(mu1lo_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                mu1lo_hi = _mm256_srli_epi64(_mm256_add_epi64(mu1lo_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                acc0_lo = _mm256_mul_epu32(acc0_lo, acc0_lo);
+                acc0_hi = _mm256_mul_epu32(acc0_hi, acc0_hi);
+                acc0_lo = _mm256_srli_epi64(_mm256_add_epi64(acc0_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc0_hi = _mm256_srli_epi64(_mm256_add_epi64(acc0_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+
+                __m256i acc1_lo = _mm256_unpacklo_epi32(acc1, _mm256_setzero_si256());
+                __m256i acc1_hi = _mm256_unpackhi_epi32(acc1, _mm256_setzero_si256());
+
+                mu1hi_lo = _mm256_mul_epu32(mu1hi_lo, acc1_lo);
+                mu1hi_hi = _mm256_mul_epu32(mu1hi_hi, acc1_hi);
+                mu1hi_lo = _mm256_srli_epi64(_mm256_add_epi64(mu1hi_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                mu1hi_hi = _mm256_srli_epi64(_mm256_add_epi64(mu1hi_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+                acc1_lo = _mm256_mul_epu32(acc1_lo, acc1_lo);
+                acc1_hi = _mm256_mul_epu32(acc1_hi, acc1_hi);
+                acc1_lo = _mm256_srli_epi64(_mm256_add_epi64(acc1_lo, _mm256_set1_epi64x(0x80000000)), 32);
+                acc1_hi = _mm256_srli_epi64(_mm256_add_epi64(acc1_hi, _mm256_set1_epi64x(0x80000000)), 32);
+
+
+                __m256i acc0_sq = _mm256_blend_epi32(acc0_lo, _mm256_slli_si256(acc0_hi, 4), 0xAA);
+                acc0_sq = _mm256_shuffle_epi32(acc0_sq, 0xD8);
+                __m256i acc1_sq = _mm256_blend_epi32(acc1_lo, _mm256_slli_si256(acc1_hi, 4), 0xAA);
+                acc1_sq = _mm256_shuffle_epi32(acc1_sq, 0xD8);
+                mu2sq_lo = acc0_sq;
+                mu2sq_hi = acc1_sq;
+
+                mu1mu2_lo = _mm256_blend_epi32(mu1lo_lo, _mm256_slli_si256(mu1lo_hi, 4), 0xAA);
+                mu1mu2_lo = _mm256_shuffle_epi32(mu1mu2_lo, 0xD8);
+                mu1mu2_hi = _mm256_blend_epi32(mu1hi_lo, _mm256_slli_si256(mu1hi_hi, 4), 0xAA);
+                mu1mu2_hi = _mm256_shuffle_epi32(mu1mu2_hi, 0xD8);
+
+
+            }
+
+            // filter horizontally ref
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt[fwidth / 2]);
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + 0))), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + 4))), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + 8))), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + 12))), fq));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj - fwidth / 2 + fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj - fwidth / 2 + fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj - fwidth / 2 + fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj - fwidth / 2 + fj + 12))), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + fwidth / 2 - fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + fwidth / 2 - fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + fwidth / 2 - fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref + jj + fwidth / 2 - fj + 12))), fq));
+                }
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                __m256i mask1 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
+
+                // pack acc0,acc1,acc2,acc3 to acc0, acc1
+                acc1 = _mm256_slli_si256(acc1, 4);
+                acc1 = _mm256_blend_epi32(acc0, acc1, 0xAA);
+                acc0 = _mm256_permutevar8x32_epi32(acc1, mask1);
+                acc3 = _mm256_slli_si256(acc3, 4);
+                acc3 = _mm256_blend_epi32(acc2, acc3, 0xAA);
+
+                acc1 = _mm256_permutevar8x32_epi32(acc3, mask1);
+
+                acc0 = _mm256_sub_epi32(acc0, mu1sq_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu1sq_hi);
+                _mm256_storeu_si256((__m256i*) & xx[0], acc0);
+                _mm256_storeu_si256((__m256i*) & xx[8], acc1);
+            }
+
+            // filter horizontally dis
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt[fwidth / 2]);
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + 0))), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + 4))), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + 8))), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + 12))), fq));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj - fwidth / 2 + fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj - fwidth / 2 + fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj - fwidth / 2 + fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj - fwidth / 2 + fj + 12))), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + fwidth / 2 - fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + fwidth / 2 - fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + fwidth / 2 - fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.dis + jj + fwidth / 2 - fj + 12))), fq));
+                }
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                __m256i mask1 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
+
+                // pack acc0,acc1,acc2,acc3 to acc0, acc1
+                acc1 = _mm256_slli_si256(acc1, 4);
+                acc1 = _mm256_blend_epi32(acc0, acc1, 0xAA);
+                acc0 = _mm256_permutevar8x32_epi32(acc1, mask1);
+                acc3 = _mm256_slli_si256(acc3, 4);
+                acc3 = _mm256_blend_epi32(acc2, acc3, 0xAA);
+                acc1 = _mm256_permutevar8x32_epi32(acc3, mask1);
+
+                acc0 = _mm256_sub_epi32(acc0, mu2sq_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu2sq_hi);
+                _mm256_storeu_si256((__m256i*) & yy[0], _mm256_max_epi32(acc0, _mm256_setzero_si256()));
+                _mm256_storeu_si256((__m256i*) & yy[8], _mm256_max_epi32(acc1, _mm256_setzero_si256()));
+            }
+
+            // filter horizontally ref_dis, producing 16 samples
+            {
+                __m256i rounder = _mm256_set1_epi64x(0x8000);
+                __m256i fq = _mm256_set1_epi64x(vif_filt[fwidth / 2]);
+                __m256i acc0 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + 0))), fq));
+                __m256i acc1 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + 4))), fq));
+                __m256i acc2 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + 8))), fq));
+                __m256i acc3 = _mm256_add_epi64(rounder, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + 12))), fq));
+
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m256i fq = _mm256_set1_epi64x(vif_filt[fj]);
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj - fwidth / 2 + fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj - fwidth / 2 + fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj - fwidth / 2 + fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj - fwidth / 2 + fj + 12))), fq));
+                    acc0 = _mm256_add_epi64(acc0, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + fwidth / 2 - fj + 0))), fq));
+                    acc1 = _mm256_add_epi64(acc1, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + fwidth / 2 - fj + 4))), fq));
+                    acc2 = _mm256_add_epi64(acc2, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + fwidth / 2 - fj + 8))), fq));
+                    acc3 = _mm256_add_epi64(acc3, _mm256_mul_epu32(_mm256_cvtepu32_epi64(_mm_loadu_si128((__m128i*)(buf.tmp.ref_dis + jj + fwidth / 2 - fj + 12))), fq));
+                }
+
+                acc0 = _mm256_srli_epi64(acc0, 16);
+                acc1 = _mm256_srli_epi64(acc1, 16);
+                acc2 = _mm256_srli_epi64(acc2, 16);
+                acc3 = _mm256_srli_epi64(acc3, 16);
+
+                __m256i mask1 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
+
+                // pack acc0,acc1,acc2,acc3 to acc0, acc1
+                acc1 = _mm256_slli_si256(acc1, 4);
+                acc1 = _mm256_blend_epi32(acc0, acc1, 0xAA);
+                acc0 = _mm256_permutevar8x32_epi32(acc1, mask1);
+                acc3 = _mm256_slli_si256(acc3, 4);
+                acc3 = _mm256_blend_epi32(acc2, acc3, 0xAA);
+                acc1 = _mm256_permutevar8x32_epi32(acc3, mask1);
+
+                acc0 = _mm256_sub_epi32(acc0, mu1mu2_lo);
+                acc1 = _mm256_sub_epi32(acc1, mu1mu2_hi);
+                _mm256_storeu_si256((__m256i*) & xy[0], acc0);
+                _mm256_storeu_si256((__m256i*) & xy[8], acc1);
+            }
+
+            for (unsigned int j = 0; j < 16; j++) {
+                int32_t sigma1_sq = xx[j];
+                int32_t sigma2_sq = yy[j];
+                int32_t sigma12 = xy[j];
+
+                if (sigma1_sq >= sigma_nsq) {
+                    /**
+                    * log values are taken from the look-up table generated by
+                    * log_generate() function which is called in integer_combo_threadfunc
+                    * den_val in float is log2(1 + sigma1_sq/2)
+                    * here it is converted to equivalent of log2(2+sigma1_sq) - log2(2) i.e log2(2*65536+sigma1_sq) - 17
+                    * multiplied by 2048 as log_value = log2(i)*2048 i=16384 to 65535 generated using log_value
+                    * x because best 16 bits are taken
+                    */
+                    accum_den_log += log2_32(log2_table, sigma_nsq + sigma1_sq) - 2048 * 17;
+
+                    if (sigma12 > 0 && sigma2_sq > 0) {
+                        /**
+                        * In floating-point numerator = log2((1.0f + (g * g * sigma1_sq)/(sv_sq + sigma_nsq))
+                        *
+                        * In Fixed-point the above is converted to
+                        * numerator = log2((sv_sq + sigma_nsq)+(g * g * sigma1_sq))- log2(sv_sq + sigma_nsq)
+                        */
+
+                        const double eps = 65536 * 1.0e-10;
+                        double g = sigma12 / (sigma1_sq + eps); // this epsilon can go away
+                        int32_t sv_sq = sigma2_sq - g * sigma12;
+
+                        sv_sq = (uint32_t)(MAX(sv_sq, 0));
+
+                        g = MIN(g, vif_enhn_gain_limit);
+
+                        uint32_t numer1 = (sv_sq + sigma_nsq);
+                        int64_t numer1_tmp = (int64_t)((g * g * sigma1_sq)) + numer1; //numerator
+                        accum_num_log += log2_64(log2_table, numer1_tmp) - log2_64(log2_table, numer1);
+                    }
+                }
+                else {
+                    accum_num_non_log += sigma2_sq;
+                    accum_den_non_log++;
+                }
+            }
         }
 
-        for (unsigned j = 0; j < n << 3; j = j + 8) {
-            uint32_t accum_mu1 = 0;
-            uint32_t accum_mu2 = 0;
-            uint64_t accum_ref = 0;
-            uint64_t accum_dis = 0;
-            uint64_t accum_ref_dis = 0;
-            __m256i refdislo, refdishi, reflo, refhi, dislo, dishi;
-            refdislo = refdishi = reflo = refhi = dislo = dishi =
-                _mm256_setzero_si256();
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            __m256i mask1 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
-            __m256i addnum = _mm256_set1_epi64x(add_shift_round_HP);
-#pragma unroll(2)
-            for (unsigned fj = 0; fj < fwidth; fj = ++fj, jj_check = jj + fj) {
-                __m256i f1 = _mm256_set1_epi64x(vif_filt[fj]);
-                __m256i s0 = _mm256_cvtepu32_epi64(
-                    _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check)));
-                reflo = _mm256_add_epi64(reflo, _mm256_mul_epu32(s0, f1));
-                __m256i s3 = _mm256_cvtepu32_epi64(
-                    _mm_loadu_si128((__m128 *)(buf.tmp.ref + jj_check + 4)));
-                refhi = _mm256_add_epi64(refhi, _mm256_mul_epu32(s3, f1));
 
-                __m256i g0 = _mm256_cvtepu32_epi64(
-                    _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check)));
-                dislo = _mm256_add_epi64(dislo, _mm256_mul_epu32(g0, f1));
-                __m256i g3 = _mm256_cvtepu32_epi64(
-                    _mm_loadu_si128((__m128 *)(buf.tmp.dis + jj_check + 4)));
-                dishi = _mm256_add_epi64(dishi, _mm256_mul_epu32(g3, f1));
-
-                __m256i sg0 = _mm256_cvtepu32_epi64(
-                    _mm_loadu_si128((__m128 *)(buf.tmp.ref_dis + jj_check)));
-                refdislo =
-                    _mm256_add_epi64(refdislo, _mm256_mul_epu32(sg0, f1));
-                __m256i sg3 = _mm256_cvtepu32_epi64(_mm_loadu_si128(
-                    (__m128 *)(buf.tmp.ref_dis + jj_check + 4)));
-                refdishi =
-                    _mm256_add_epi64(refdishi, _mm256_mul_epu32(sg3, f1));
-            }
-
-            reflo = _mm256_add_epi64(reflo, addnum);
-            reflo = _mm256_srli_epi64(reflo, shift_HP);
-            refhi = _mm256_add_epi64(refhi, addnum);
-            refhi = _mm256_srli_epi64(refhi, shift_HP);
-            refhi = _mm256_slli_si256(refhi, 4);
-            refhi = _mm256_blend_epi32(reflo, refhi, 0xAA);
-            refhi = _mm256_permutevar8x32_epi32(refhi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.ref_sq + (dst_stride * i) + j),
-                                refhi);
-            dislo = _mm256_add_epi64(dislo, addnum);
-            dislo = _mm256_srli_epi64(dislo, shift_HP);
-            dishi = _mm256_add_epi64(dishi, addnum);
-            dishi = _mm256_srli_epi64(dishi, shift_HP);
-            dishi = _mm256_slli_si256(dishi, 4);
-            dishi = _mm256_blend_epi32(dislo, dishi, 0xAA);
-            dishi = _mm256_permutevar8x32_epi32(dishi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.dis_sq + (dst_stride * i) + j),
-                                dishi);
-            refdislo = _mm256_add_epi64(refdislo, addnum);
-            refdislo = _mm256_srli_epi64(refdislo, shift_HP);
-            refdishi = _mm256_add_epi64(refdishi, addnum);
-            refdishi = _mm256_srli_epi64(refdishi, shift_HP);
-            refdishi = _mm256_slli_si256(refdishi, 4);
-            refdishi = _mm256_blend_epi32(refdislo, refdishi, 0xAA);
-            refdishi = _mm256_permutevar8x32_epi32(refdishi, mask1);
-            _mm256_storeu_si256((__m256i *)(buf.ref_dis + (dst_stride * i) + j),
-                                refdishi);
-        }
-
-        for (unsigned j = n << 3; j < w; ++j) {
-            uint32_t accum_mu1 = 0;
-            uint32_t accum_mu2 = 0;
-            uint64_t accum_ref = 0;
-            uint64_t accum_dis = 0;
-            uint64_t accum_ref_dis = 0;
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            for (unsigned fj = 0; fj < fwidth; ++fj, jj_check = jj + fj) {
-                const uint16_t fcoeff = vif_filt[fj];
-                accum_mu1 += fcoeff * ((uint32_t)buf.tmp.mu1[jj_check]);
-                accum_mu2 += fcoeff * ((uint32_t)buf.tmp.mu2[jj_check]);
-                accum_ref += fcoeff * ((uint64_t)buf.tmp.ref[jj_check]);
-                accum_dis += fcoeff * ((uint64_t)buf.tmp.dis[jj_check]);
-                accum_ref_dis += fcoeff * ((uint64_t)buf.tmp.ref_dis[jj_check]);
-            }
-            buf.mu1_32[i * dst_stride + j] = accum_mu1;
-            buf.mu2_32[i * dst_stride + j] = accum_mu2;
-            buf.ref_sq[i * dst_stride + j] =
-                (uint32_t)((accum_ref + add_shift_round_HP) >> shift_HP);
-            buf.dis_sq[i * dst_stride + j] =
-                (uint32_t)((accum_dis + add_shift_round_HP) >> shift_HP);
-            buf.ref_dis[i * dst_stride + j] =
-                (uint32_t)((accum_ref_dis + add_shift_round_HP) >> shift_HP);
+        if ((n << 4) != w) {
+            VifResiduals residuals =
+                vif_compute_line_residuals(s, n << 4, w, bpc, scale);
+            accum_num_log += residuals.accum_num_log;
+            accum_den_log += residuals.accum_den_log;
+            accum_num_non_log += residuals.accum_num_non_log;
+            accum_den_non_log += residuals.accum_den_non_log;
         }
     }
+
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
 }
 
-void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
+void vif_subsample_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
     const unsigned fwidth = vif_filter1d_width[1];
     const uint16_t *vif_filt_s1 = vif_filter1d_table[1];
-    int fwidth_x = (fwidth % 2 == 0) ? fwidth : fwidth + 1;
     const uint8_t *ref = (uint8_t *)buf.ref;
     const uint8_t *dis = (uint8_t *)buf.dis;
     const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
@@ -1802,59 +1070,22 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
     __m256i x = _mm256_set1_epi32(128);
     int fwidth_half = fwidth >> 1;
 
-    __m256i f0, f1, f2, f3, f4, f5, f6, f7, f8;
-
-    f0 = _mm256_set_epi16(
-        vif_filt_s1[1], vif_filt_s1[0], vif_filt_s1[1], vif_filt_s1[0],
-        vif_filt_s1[1], vif_filt_s1[0], vif_filt_s1[1], vif_filt_s1[0],
-        vif_filt_s1[1], vif_filt_s1[0], vif_filt_s1[1], vif_filt_s1[0],
-        vif_filt_s1[1], vif_filt_s1[0], vif_filt_s1[1], vif_filt_s1[0]);
-
-    f1 = _mm256_set_epi16(
-        vif_filt_s1[3], vif_filt_s1[2], vif_filt_s1[3], vif_filt_s1[2],
-        vif_filt_s1[3], vif_filt_s1[2], vif_filt_s1[3], vif_filt_s1[2],
-        vif_filt_s1[3], vif_filt_s1[2], vif_filt_s1[3], vif_filt_s1[2],
-        vif_filt_s1[3], vif_filt_s1[2], vif_filt_s1[3], vif_filt_s1[2]);
-
-    f2 = _mm256_set_epi16(
-        vif_filt_s1[5], vif_filt_s1[4], vif_filt_s1[5], vif_filt_s1[4],
-        vif_filt_s1[5], vif_filt_s1[4], vif_filt_s1[5], vif_filt_s1[4],
-        vif_filt_s1[5], vif_filt_s1[4], vif_filt_s1[5], vif_filt_s1[4],
-        vif_filt_s1[5], vif_filt_s1[4], vif_filt_s1[5], vif_filt_s1[4]);
-
-    f3 = _mm256_set_epi16(
-        vif_filt_s1[7], vif_filt_s1[6], vif_filt_s1[7], vif_filt_s1[6],
-        vif_filt_s1[7], vif_filt_s1[6], vif_filt_s1[7], vif_filt_s1[6],
-        vif_filt_s1[7], vif_filt_s1[6], vif_filt_s1[7], vif_filt_s1[6],
-        vif_filt_s1[7], vif_filt_s1[6], vif_filt_s1[7], vif_filt_s1[6]);
-
-    f4 = _mm256_set_epi16(
-        vif_filt_s1[9], vif_filt_s1[8], vif_filt_s1[9], vif_filt_s1[8],
-        vif_filt_s1[9], vif_filt_s1[8], vif_filt_s1[9], vif_filt_s1[8],
-        vif_filt_s1[9], vif_filt_s1[8], vif_filt_s1[9], vif_filt_s1[8],
-        vif_filt_s1[9], vif_filt_s1[8], vif_filt_s1[9], vif_filt_s1[8]);
-
-    __m256i fcoeff = _mm256_set1_epi16(vif_filt_s1[0]);
+    __m256i fcoeff0 = _mm256_set1_epi16(vif_filt_s1[0]);
     __m256i fcoeff1 = _mm256_set1_epi16(vif_filt_s1[1]);
     __m256i fcoeff2 = _mm256_set1_epi16(vif_filt_s1[2]);
     __m256i fcoeff3 = _mm256_set1_epi16(vif_filt_s1[3]);
     __m256i fcoeff4 = _mm256_set1_epi16(vif_filt_s1[4]);
-    __m256i fcoeff5 = _mm256_set1_epi16(vif_filt_s1[5]);
-    __m256i fcoeff6 = _mm256_set1_epi16(vif_filt_s1[6]);
-    __m256i fcoeff7 = _mm256_set1_epi16(vif_filt_s1[7]);
-    __m256i fcoeff8 = _mm256_set1_epi16(vif_filt_s1[8]);
 
-    for (unsigned i = 0; i < h; ++i) {
+    for (unsigned i = 0; i < h / 2; i ++) {
         // VERTICAL
-        int n = w >> 4;
+        unsigned n = w >> 4;
         for (unsigned j = 0; j < n << 4; j = j + 16) {
-            int ii = i - fwidth_half;
+            int ii = i * 2 - fwidth_half;
             int ii_check = ii;
-            __m256i accum_mu2_lo, accum_mu1_lo, accum_mu2_hi, accum_mu1_hi;
-            accum_mu2_lo = accum_mu2_hi = accum_mu1_lo = accum_mu1_hi =
-                _mm256_setzero_si256();
-            __m256i g0, g1, g2, g3, g4, g5, g6, g7, g8, g9, g20, g21;
-            __m256i s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s20, s21, sg0, sg1;
+            __m256i accum_mu1_lo, accum_mu1_hi;
+            __m256i accum_mu2_lo, accum_mu2_hi;
+            __m256i g0, g1, g2, g3, g4, g5, g6, g7, g8;
+            __m256i s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
             g0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
                 (__m128i *)(ref + (buf.stride * ii_check) + j)));
@@ -1874,8 +1105,6 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
                 (__m128i *)(ref + buf.stride * (ii_check + 7) + j)));
             g8 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
                 (__m128i *)(ref + buf.stride * (ii_check + 8) + j)));
-            g9 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(ref + buf.stride * (ii_check + 9) + j)));
 
             s0 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
                 (__m128i *)(dis + (buf.stride * ii_check) + j)));
@@ -1895,70 +1124,18 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
                 (__m128i *)(dis + buf.stride * (ii_check + 7) + j)));
             s8 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
                 (__m128i *)(dis + buf.stride * (ii_check + 8) + j)));
-            s9 = _mm256_cvtepu8_epi16(_mm_loadu_si128(
-                (__m128i *)(dis + buf.stride * (ii_check + 9) + j)));
 
-            __m256i s0lo = _mm256_unpacklo_epi16(s0, s1);
-            __m256i s0hi = _mm256_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s0lo, f0));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s0hi, f0));
-            __m256i s1lo = _mm256_unpacklo_epi16(s2, s3);
-            __m256i s1hi = _mm256_unpackhi_epi16(s2, s3);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s1lo, f1));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s1hi, f1));
-            __m256i s2lo = _mm256_unpacklo_epi16(s4, s5);
-            __m256i s2hi = _mm256_unpackhi_epi16(s4, s5);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s2lo, f2));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s2hi, f2));
-            __m256i s3lo = _mm256_unpacklo_epi16(s6, s7);
-            __m256i s3hi = _mm256_unpackhi_epi16(s6, s7);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s3lo, f3));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s3hi, f3));
-            __m256i s4lo = _mm256_unpacklo_epi16(s8, s9);
-            __m256i s4hi = _mm256_unpackhi_epi16(s8, s9);
-            accum_mu2_lo =
-                _mm256_add_epi32(accum_mu2_lo, _mm256_madd_epi16(s4lo, f4));
-            accum_mu2_hi =
-                _mm256_add_epi32(accum_mu2_hi, _mm256_madd_epi16(s4hi, f4));
+            multiply2(accum_mu2_lo, accum_mu2_hi, s4, fcoeff4);
+            multiply2_and_accumulate(accum_mu2_lo, accum_mu2_hi, s0, s8, fcoeff0);
+            multiply2_and_accumulate(accum_mu2_lo, accum_mu2_hi, s1, s7, fcoeff1);
+            multiply2_and_accumulate(accum_mu2_lo, accum_mu2_hi, s2, s6, fcoeff2);
+            multiply2_and_accumulate(accum_mu2_lo, accum_mu2_hi, s3, s5, fcoeff3);
 
-            __m256i g0lo = _mm256_unpacklo_epi16(g0, g1);
-            __m256i g0hi = _mm256_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g0lo, f0));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g0hi, f0));
-            __m256i g1lo = _mm256_unpacklo_epi16(g2, g3);
-            __m256i g1hi = _mm256_unpackhi_epi16(g2, g3);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g1lo, f1));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g1hi, f1));
-            __m256i g2lo = _mm256_unpacklo_epi16(g4, g5);
-            __m256i g2hi = _mm256_unpackhi_epi16(g4, g5);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g2lo, f2));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g2hi, f2));
-            __m256i g3lo = _mm256_unpacklo_epi16(g6, g7);
-            __m256i g3hi = _mm256_unpackhi_epi16(g6, g7);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g3lo, f3));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g3hi, f3));
-            __m256i g4lo = _mm256_unpacklo_epi16(g8, g9);
-            __m256i g4hi = _mm256_unpackhi_epi16(g8, g9);
-            accum_mu1_lo =
-                _mm256_add_epi32(accum_mu1_lo, _mm256_madd_epi16(g4lo, f4));
-            accum_mu1_hi =
-                _mm256_add_epi32(accum_mu1_hi, _mm256_madd_epi16(g4hi, f4));
+            multiply2(accum_mu1_lo, accum_mu1_hi, g4, fcoeff4);
+            multiply2_and_accumulate(accum_mu1_lo, accum_mu1_hi, g0, g8, fcoeff0);
+            multiply2_and_accumulate(accum_mu1_lo, accum_mu1_hi, g1, g7, fcoeff1);
+            multiply2_and_accumulate(accum_mu1_lo, accum_mu1_hi, g2, g6, fcoeff2);
+            multiply2_and_accumulate(accum_mu1_lo, accum_mu1_hi, g3, g5, fcoeff3);
 
             __m256i accumu1_lo = _mm256_add_epi32(
                 x, _mm256_permute2x128_si256(accum_mu1_lo, accum_mu1_hi, 0x20));
@@ -2004,29 +1181,20 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
         for (unsigned j = 0; j < n << 3; j = j + 8) {
             int jj = j - fwidth_half;
             int jj_check = jj;
-            __m256i accumdl, accumrlo, accumdlo, accumrhi, accumdhi;
+            __m256i accumrlo, accumdlo, accumrhi, accumdhi;
             accumrlo = accumdlo = accumrhi = accumdhi = _mm256_setzero_si256();
-            __m256i refconvol =
-                _mm256_loadu_si256((__m256i *)(buf.tmp.ref_convol + jj_check));
-            __m256i refconvol1 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 1));
-            __m256i refconvol2 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 2));
-            __m256i refconvol3 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 3));
-            __m256i refconvol4 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 4));
-            __m256i refconvol5 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 5));
-            __m256i refconvol6 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 6));
-            __m256i refconvol7 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 7));
-            __m256i refconvol8 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.ref_convol + jj_check + 8));
+            __m256i refconvol0 = _mm256_loadu_si256((__m256i *)(buf.tmp.ref_convol + jj_check));
+            __m256i refconvol4 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_convol + jj_check + 4));
+            __m256i refconvol8 = _mm256_loadu_si256((__m256i*)(buf.tmp.ref_convol + jj_check + 8));
+            __m256i refconvol1 = _mm256_alignr_epi8(refconvol4, refconvol0, 4);
+            __m256i refconvol2 = _mm256_alignr_epi8(refconvol4, refconvol0, 8);
+            __m256i refconvol3 = _mm256_alignr_epi8(refconvol4, refconvol0, 12);
+            __m256i refconvol5 = _mm256_alignr_epi8(refconvol8, refconvol4, 4);
+            __m256i refconvol6 = _mm256_alignr_epi8(refconvol8, refconvol4, 8);
+            __m256i refconvol7 = _mm256_alignr_epi8(refconvol8, refconvol4, 12);
 
-            __m256i result2 = _mm256_mulhi_epu16(refconvol, fcoeff);
-            __m256i result2lo = _mm256_mullo_epi16(refconvol, fcoeff);
+            __m256i result2 = _mm256_mulhi_epu16(refconvol0, fcoeff0);
+            __m256i result2lo = _mm256_mullo_epi16(refconvol0, fcoeff0);
             accumrlo = _mm256_add_epi32(
                 accumrlo, _mm256_unpacklo_epi16(result2lo, result2));
             accumrhi = _mm256_add_epi32(
@@ -2055,51 +1223,42 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
                 accumrlo, _mm256_unpacklo_epi16(result6lo, result6));
             accumrhi = _mm256_add_epi32(
                 accumrhi, _mm256_unpackhi_epi16(result6lo, result6));
-            __m256i result7 = _mm256_mulhi_epu16(refconvol5, fcoeff5);
-            __m256i result7lo = _mm256_mullo_epi16(refconvol5, fcoeff5);
+            __m256i result7 = _mm256_mulhi_epu16(refconvol5, fcoeff3);
+            __m256i result7lo = _mm256_mullo_epi16(refconvol5, fcoeff3);
             accumrlo = _mm256_add_epi32(
                 accumrlo, _mm256_unpacklo_epi16(result7lo, result7));
             accumrhi = _mm256_add_epi32(
                 accumrhi, _mm256_unpackhi_epi16(result7lo, result7));
-            __m256i result8 = _mm256_mulhi_epu16(refconvol6, fcoeff6);
-            __m256i result8lo = _mm256_mullo_epi16(refconvol6, fcoeff6);
+            __m256i result8 = _mm256_mulhi_epu16(refconvol6, fcoeff2);
+            __m256i result8lo = _mm256_mullo_epi16(refconvol6, fcoeff2);
             accumrlo = _mm256_add_epi32(
                 accumrlo, _mm256_unpacklo_epi16(result8lo, result8));
             accumrhi = _mm256_add_epi32(
                 accumrhi, _mm256_unpackhi_epi16(result8lo, result8));
-            __m256i result9 = _mm256_mulhi_epu16(refconvol7, fcoeff7);
-            __m256i result9lo = _mm256_mullo_epi16(refconvol7, fcoeff7);
+            __m256i result9 = _mm256_mulhi_epu16(refconvol7, fcoeff1);
+            __m256i result9lo = _mm256_mullo_epi16(refconvol7, fcoeff1);
             accumrlo = _mm256_add_epi32(
                 accumrlo, _mm256_unpacklo_epi16(result9lo, result9));
             accumrhi = _mm256_add_epi32(
                 accumrhi, _mm256_unpackhi_epi16(result9lo, result9));
-            __m256i result10 = _mm256_mulhi_epu16(refconvol8, fcoeff8);
-            __m256i result10lo = _mm256_mullo_epi16(refconvol8, fcoeff8);
+            __m256i result10 = _mm256_mulhi_epu16(refconvol8, fcoeff0);
+            __m256i result10lo = _mm256_mullo_epi16(refconvol8, fcoeff0);
             accumrlo = _mm256_add_epi32(
                 accumrlo, _mm256_unpacklo_epi16(result10lo, result10));
             accumrhi = _mm256_add_epi32(
                 accumrhi, _mm256_unpackhi_epi16(result10lo, result10));
 
-            __m256i disconvol =
-                _mm256_loadu_si256((__m256i *)(buf.tmp.dis_convol + jj_check));
-            __m256i disconvol1 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 1));
-            __m256i disconvol2 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 2));
-            __m256i disconvol3 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 3));
-            __m256i disconvol4 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 4));
-            __m256i disconvol5 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 5));
-            __m256i disconvol6 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 6));
-            __m256i disconvol7 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 7));
-            __m256i disconvol8 = _mm256_loadu_si256(
-                (__m256i *)(buf.tmp.dis_convol + jj_check + 8));
-            result2 = _mm256_mulhi_epu16(disconvol, fcoeff);
-            result2lo = _mm256_mullo_epi16(disconvol, fcoeff);
+            __m256i disconvol0 =_mm256_loadu_si256((__m256i *)(buf.tmp.dis_convol + jj_check));
+            __m256i disconvol4 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis_convol + jj_check + 4));
+            __m256i disconvol8 = _mm256_loadu_si256((__m256i*)(buf.tmp.dis_convol + jj_check + 8));
+            __m256i disconvol1 = _mm256_alignr_epi8(disconvol4, disconvol0, 4);
+            __m256i disconvol2 = _mm256_alignr_epi8(disconvol4, disconvol0, 8);
+            __m256i disconvol3 = _mm256_alignr_epi8(disconvol4, disconvol0, 12);
+            __m256i disconvol5 = _mm256_alignr_epi8(disconvol8, disconvol4, 4);
+            __m256i disconvol6 = _mm256_alignr_epi8(disconvol8, disconvol4, 8);
+            __m256i disconvol7 = _mm256_alignr_epi8(disconvol8, disconvol4, 12);
+            result2 = _mm256_mulhi_epu16(disconvol0, fcoeff0);
+            result2lo = _mm256_mullo_epi16(disconvol0, fcoeff0);
             accumdlo = _mm256_add_epi32(
                 accumdlo, _mm256_unpacklo_epi16(result2lo, result2));
             accumdhi = _mm256_add_epi32(
@@ -2128,26 +1287,26 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
                 accumdlo, _mm256_unpacklo_epi16(result6lo, result6));
             accumdhi = _mm256_add_epi32(
                 accumdhi, _mm256_unpackhi_epi16(result6lo, result6));
-            result7 = _mm256_mulhi_epu16(disconvol5, fcoeff5);
-            result7lo = _mm256_mullo_epi16(disconvol5, fcoeff5);
+            result7 = _mm256_mulhi_epu16(disconvol5, fcoeff3);
+            result7lo = _mm256_mullo_epi16(disconvol5, fcoeff3);
             accumdlo = _mm256_add_epi32(
                 accumdlo, _mm256_unpacklo_epi16(result7lo, result7));
             accumdhi = _mm256_add_epi32(
                 accumdhi, _mm256_unpackhi_epi16(result7lo, result7));
-            result8 = _mm256_mulhi_epu16(disconvol6, fcoeff6);
-            result8lo = _mm256_mullo_epi16(disconvol6, fcoeff6);
+            result8 = _mm256_mulhi_epu16(disconvol6, fcoeff2);
+            result8lo = _mm256_mullo_epi16(disconvol6, fcoeff2);
             accumdlo = _mm256_add_epi32(
                 accumdlo, _mm256_unpacklo_epi16(result8lo, result8));
             accumdhi = _mm256_add_epi32(
                 accumdhi, _mm256_unpackhi_epi16(result8lo, result8));
-            result9 = _mm256_mulhi_epu16(disconvol7, fcoeff7);
-            result9lo = _mm256_mullo_epi16(disconvol7, fcoeff7);
+            result9 = _mm256_mulhi_epu16(disconvol7, fcoeff1);
+            result9lo = _mm256_mullo_epi16(disconvol7, fcoeff1);
             accumdlo = _mm256_add_epi32(
                 accumdlo, _mm256_unpacklo_epi16(result9lo, result9));
             accumdhi = _mm256_add_epi32(
                 accumdhi, _mm256_unpackhi_epi16(result9lo, result9));
-            result10 = _mm256_mulhi_epu16(disconvol8, fcoeff8);
-            result10lo = _mm256_mullo_epi16(disconvol8, fcoeff8);
+            result10 = _mm256_mulhi_epu16(disconvol8, fcoeff0);
+            result10lo = _mm256_mullo_epi16(disconvol8, fcoeff0);
             accumdlo = _mm256_add_epi32(
                 accumdlo, _mm256_unpacklo_epi16(result10lo, result10));
             accumdhi = _mm256_add_epi32(
@@ -2164,19 +1323,14 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
 
             __m256i result = _mm256_packus_epi32(accumdlo, accumdhi);
             __m256i resultd = _mm256_packus_epi32(accumrlo, accumrhi);
-            __m256i resulttmp = _mm256_srli_si256(resultd, 2);
-            resultd = _mm256_blend_epi16(resultd, resulttmp, 0xAA);
             resultd = _mm256_permutevar8x32_epi32(resultd, mask1);
-            _mm_storeu_si128((__m128i *)(buf.mu1 + i * stride + j),
-                             _mm256_castsi256_si128(resultd));
-
-            resulttmp = _mm256_srli_si256(result, 2);
-            result = _mm256_blend_epi16(result, resulttmp, 0xAA);
             result = _mm256_permutevar8x32_epi32(result, mask1);
-            _mm_storeu_si128((__m128i *)(buf.mu2 + i * stride + j),
-                             _mm256_castsi256_si128(result));
+            resultd = _mm256_packus_epi32(resultd, resultd);
+            result = _mm256_packus_epi32(result, result);
+            _mm_storel_epi64((__m128i *)(buf.mu1 + i  * stride + (j >> 1)), _mm256_castsi256_si128(resultd));
+            _mm_storel_epi64((__m128i *)(buf.mu2 + i  * stride + (j >> 1)), _mm256_castsi256_si128(result));
         }
-        for (unsigned j = n << 3; j < w; ++j) {
+        for (unsigned j = n << 3; j < w; j += 2) {
             uint32_t accum_ref = 0;
             uint32_t accum_dis = 0;
             int jj = j - fwidth_half;
@@ -2186,13 +1340,14 @@ void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h) {
                 accum_ref += fcoeff * buf.tmp.ref_convol[jj_check];
                 accum_dis += fcoeff * buf.tmp.dis_convol[jj_check];
             }
-            buf.mu1[i * stride + j] = (uint16_t)((accum_ref + 32768) >> 16);
-            buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
+            buf.mu1[i * stride + (j >> 1)] = (uint16_t)((accum_ref + 32768) >> 16);
+            buf.mu2[i * stride + (j >> 1)] = (uint16_t)((accum_dis + 32768) >> 16);
         }
     }
+    copy_and_pad(buf, w, h, 0);
 }
 
-void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
+void vif_subsample_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
                              int bpc) {
     const unsigned fwidth = vif_filter1d_width[scale + 1];
     const uint16_t *vif_filt = vif_filter1d_table[scale + 1];
@@ -2202,7 +1357,6 @@ void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
     const ptrdiff_t stride16 = buf.stride_16 / sizeof(uint16_t);
     uint16_t *ref = buf.ref;
     uint16_t *dis = buf.dis;
-    __m256i mask2 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
     __m256i mask1 = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
 
     if (scale == 0) {
@@ -2213,11 +1367,11 @@ void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
         shift_VP = 16;
     }
 
-    for (unsigned i = 0; i < h; ++i) {
+    for (unsigned i = 0; i < h / 2; i++) {
         // VERTICAL
 
-        int n = w >> 4;
-        int ii = i - fwidth_half;
+        unsigned n = w >> 4;
+        int ii = i * 2 - fwidth_half;
         for (unsigned j = 0; j < n << 4; j = j + 16) {
             int ii_check = ii;
             __m256i accumr_lo, accumr_hi, accumd_lo, accumd_hi, rmul1, rmul2,
@@ -2225,7 +1379,6 @@ void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
             accumr_lo = accumr_hi = accumd_lo = accumd_hi = rmul1 = rmul2 =
                 dmul1 = dmul2 = _mm256_setzero_si256();
             for (unsigned fi = 0; fi < fwidth; ++fi, ii_check = ii + fi) {
-                const uint16_t fcoeff = vif_filt[fi];
                 __m256i f1 = _mm256_set1_epi16(vif_filt[fi]);
                 __m256i ref1 = _mm256_loadu_si256(
                     (__m256i *)(ref + (ii_check * stride) + j));
@@ -2295,10 +1448,8 @@ void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
         for (unsigned j = 0; j < n << 3; j = j + 8) {
             int jj = j - fwidth_half;
             int jj_check = jj;
-            __m256i accumdl, accumrlo, accumdlo, accumrhi, accumdhi;
+            __m256i accumrlo, accumdlo, accumrhi, accumdhi;
             accumrlo = accumdlo = accumrhi = accumdhi = _mm256_setzero_si256();
-            const uint16_t *ref = (uint16_t *)buf.tmp.ref_convol;
-            const uint16_t *dis = (uint16_t *)buf.dis;
             for (unsigned fj = 0; fj < fwidth; ++fj, jj_check = jj + fj) {
                 __m256i refconvol = _mm256_loadu_si256(
                     (__m256i *)(buf.tmp.ref_convol + jj_check));
@@ -2358,4 +1509,15 @@ void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
             buf.mu2[i * stride16 + j] = (uint16_t)((accum_dis + 32768) >> 16);
         }
     }
+
+    ref = buf.ref;
+    dis = buf.dis;
+
+    for (unsigned i = 0; i < h / 2; ++i) {
+        for (unsigned j = 0; j < w / 2; ++j) {
+            ref[i * stride + j] = buf.mu1[i * stride16 + (j * 2)];
+            dis[i * stride + j] = buf.mu2[i * stride16 + (j * 2)];
+        }
+    }
+    pad_top_and_bottom(buf, h / 2, vif_filter1d_width[scale]);
 }

--- a/libvmaf/src/feature/x86/vif_avx2.h
+++ b/libvmaf/src/feature/x86/vif_avx2.h
@@ -23,12 +23,15 @@
 
 void vif_filter1d_8_avx2(VifBuffer buf, unsigned w, unsigned h);
 
-void vif_filter1d_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h);
+void vif_subsample_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h);
 
-void vif_filter1d_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
+void vif_subsample_rd_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
                              int bpc);
 
-void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale,
-                            int bpc);
+void vif_filter1d_16_avx2(VifBuffer buf, unsigned w, unsigned h, int scale, int bpc);
+
+void vif_statistic_8_avx2(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h);
+
+void vif_statistic_16_avx2(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale);
 
 #endif /* X86_AVX2_VIF_H_ */

--- a/libvmaf/src/feature/x86/vif_avx512.c
+++ b/libvmaf/src/feature/x86/vif_avx512.c
@@ -20,1355 +20,342 @@
 #include <stdint.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
+#include <assert.h>
 #include "stdio.h"
-
+#include "feature/common/macros.h"
 #include "feature/integer_vif.h"
 
-void vif_filter1d_8_avx512(VifBuffer buf, unsigned w, unsigned h)
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+static inline void
+pad_top_and_bottom(VifBuffer buf, unsigned h, int fwidth)
 {
+    const unsigned fwidth_half = fwidth / 2;
+    unsigned char *ref = buf.ref;
+    unsigned char *dis = buf.dis;
+    for (unsigned i = 1; i <= fwidth_half; ++i) {
+        size_t offset = buf.stride * i;
+        memcpy(ref - offset, ref + offset, buf.stride);
+        memcpy(dis - offset, dis + offset, buf.stride);
+        memcpy(ref + buf.stride * (h - 1) + buf.stride * i,
+            ref + buf.stride * (h - 1) - buf.stride * i,
+            buf.stride);
+        memcpy(dis + buf.stride * (h - 1) + buf.stride * i,
+            dis + buf.stride * (h - 1) - buf.stride * i,
+            buf.stride);
+    }
+}
+
+static inline void
+decimate_and_pad(VifBuffer buf, unsigned w, unsigned h, int scale)
+{
+    uint16_t *ref = buf.ref;
+    uint16_t *dis = buf.dis;
+    const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
+    const ptrdiff_t mu_stride = buf.stride_16 / sizeof(uint16_t);
+
+    for (unsigned i = 0; i < h / 2; ++i) {
+        for (unsigned j = 0; j < w / 2; ++j) {
+            ref[i * stride + j] = buf.mu1[(i * 2) * mu_stride + (j * 2)];
+            dis[i * stride + j] = buf.mu2[(i * 2) * mu_stride + (j * 2)];
+        }
+    }
+    pad_top_and_bottom(buf, h / 2, vif_filter1d_width[scale]);
+}
+
+typedef struct Residuals512 {
+    __m512i maccum_num_log;
+    __m512i maccum_den_log;
+    __m512i maccum_num_non_log;
+    __m512i maccum_den_non_log;
+} Residuals512;
+
+// compute VIF on a 16 pixel block from xx (ref variance), yy (clamped dis variance), xy (ref dis covariance)
+static inline void vif_statistic_avx512(Residuals512 *out, __m512i xx, __m512i xy, __m512i yy, const uint16_t *log2_table, double vif_enhn_gain_limit)
+{
+    //float equivalent of 2. (2 * 65536)
+    static const int32_t sigma_nsq = 65536 << 1;
+
+    __m512i maccum_num_log = out->maccum_num_log;
+    __m512i maccum_den_log = out->maccum_den_log;
+    __m512i maccum_num_non_log = out->maccum_num_non_log;
+    __m512i maccum_den_non_log = out->maccum_den_non_log;
+
+    const double eps = 65536 * 1.0e-10;
+
+    for (int b = 0; b < 16; b += 8) {
+        __m512i msigma1 = _mm512_cvtepi32_epi64(_mm512_castsi512_si256(xx));
+        __m512i msigma2 = _mm512_cvtepi32_epi64(_mm512_castsi512_si256(yy));
+        __m512i msigma12 = _mm512_cvtepi32_epi64(_mm512_castsi512_si256(xy));
+        xx = _mm512_castsi256_si512(_mm512_extracti64x4_epi64(xx, 1));
+        yy = _mm512_castsi256_si512(_mm512_extracti64x4_epi64(yy, 1));
+        xy = _mm512_castsi256_si512(_mm512_extracti64x4_epi64(xy, 1));
+        msigma2 = _mm512_max_epi64(msigma2, _mm512_setzero_si512());
+        msigma12 = _mm512_max_epi64(msigma12, _mm512_setzero_si512());
+
+        // log stage
+        __m512i mlog_den_stage1 = _mm512_add_epi64(msigma1, _mm512_set1_epi64(sigma_nsq));
+        __m512i mnorm = _mm512_sub_epi64(_mm512_set1_epi64(48), _mm512_lzcnt_epi64(mlog_den_stage1));
+        __m512i mlog_den1 = _mm512_srlv_epi64(mlog_den_stage1, mnorm);
+        // note: I'm getting 32 bit here, but I need just 16!
+        __m512i mden_val = _mm512_i32gather_epi64(_mm512_cvtusepi64_epi32(mlog_den1), log2_table, sizeof(*log2_table));
+        mden_val = _mm512_and_si512(mden_val, _mm512_set1_epi64(0xffff)); // we took 64 bits, we need 16
+        mden_val = _mm512_add_epi64(mden_val, _mm512_slli_epi64(mnorm, 11));
+        mden_val = _mm512_sub_epi64(mden_val, _mm512_set1_epi64(2048 * 17));
+        __mmask8 msigma1_mask = _mm512_cmpgt_epi64_mask(_mm512_set1_epi64(sigma_nsq), msigma1);
+        __mmask8 msigma2_mask = _mm512_cmpgt_epi64_mask(msigma2, _mm512_setzero_si512());
+        //msigma12 = _mm512_and_si512_(msigma2_mask, msigma12);
+        //maccum_x = _mm512_add_epi64(maccum_x, _mm512_andnot_si512(msigma1_mask, _mm512_add_epi64(mx, _mm512_set1_epi64(17))));
+        __m512d msigma1_d = _mm512_cvtepu64_pd(msigma1);
+        __m512d mg = _mm512_div_pd(_mm512_cvtepu64_pd(msigma12), _mm512_add_pd(msigma1_d, _mm512_set1_pd(eps)));
+        __m512i msv_sq = _mm512_cvttpd_epi64(_mm512_sub_pd(_mm512_cvtepi64_pd(msigma2), _mm512_mul_pd(mg, _mm512_cvtepi64_pd(msigma12))));
+        msv_sq = _mm512_max_epi64(msv_sq, _mm512_setzero_si512());
+        mg = _mm512_min_pd(mg, _mm512_set1_pd(vif_enhn_gain_limit));
+
+        __m512i mnumer1 = _mm512_add_epi64(msv_sq, _mm512_set1_epi64(sigma_nsq));
+        __m512i mnumer1_lz = _mm512_sub_epi64(_mm512_set1_epi64(48), _mm512_lzcnt_epi64(mnumer1));
+        __m512i mnumer1_mantissa = _mm512_srlv_epi64(mnumer1, mnumer1_lz);
+        __m512i mnumer1_mantissa_log = _mm512_and_si512(_mm512_set1_epi64(0xffff), _mm512_i32gather_epi64(_mm512_cvtusepi64_epi32(mnumer1_mantissa), log2_table, sizeof(*log2_table))); // we took 64 bits, we need 16
+        __m512i mnumer1_log = _mm512_add_epi64(mnumer1_mantissa_log, _mm512_slli_epi64(mnumer1_lz, 11));
+
+        __m512i mnumer1_tmp = _mm512_add_epi64(mnumer1, _mm512_cvttpd_epi64(_mm512_mul_pd(_mm512_mul_pd(mg, mg), msigma1_d)));
+        __m512i mnumer1_tmp_lz = _mm512_sub_epi64(_mm512_set1_epi64(48), _mm512_lzcnt_epi64(mnumer1_tmp));
+        __m512i mnumer1_tmp_mantissa = _mm512_srlv_epi64(mnumer1_tmp, mnumer1_tmp_lz);
+        __m512i mnumer1_tmp_mantissa_log = _mm512_and_si512(_mm512_set1_epi64(0xffff), _mm512_i32gather_epi64(_mm512_cvtusepi64_epi32(mnumer1_tmp_mantissa), log2_table, sizeof(*log2_table))); // we took 64 bits, we need 16
+        __m512i mnumer1_tmp_log = _mm512_add_epi64(mnumer1_tmp_mantissa_log, _mm512_slli_epi64(mnumer1_tmp_lz, 11));
+
+        __m512i mnum_val = _mm512_sub_epi64(mnumer1_tmp_log, mnumer1_log);
+
+        maccum_num_log = _mm512_mask_add_epi64(maccum_num_log, ~msigma1_mask, maccum_num_log, mnum_val);
+        maccum_den_log = _mm512_mask_add_epi64(maccum_den_log, ~msigma1_mask, maccum_den_log, mden_val);
+
+        // non log stage
+        maccum_num_non_log = _mm512_mask_add_epi64(maccum_num_non_log, msigma1_mask, maccum_num_non_log, msigma2);
+        maccum_den_non_log = _mm512_mask_add_epi64(maccum_den_non_log, msigma1_mask, maccum_den_non_log, _mm512_set1_epi64(1));
+    }
+
+    out->maccum_num_log = maccum_num_log;
+    out->maccum_den_log = maccum_den_log;
+    out->maccum_num_non_log = maccum_num_non_log;
+    out->maccum_den_non_log = maccum_den_non_log;
+}
+
+void vif_statistic_8_avx512(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h) {
     const unsigned fwidth = vif_filter1d_width[0];
-    const uint16_t *vif_filt_s0 = vif_filter1d_table[0];
-    __m256i x = _mm256_set1_epi32(128);
-    const uint8_t *ref = (uint8_t *)buf.ref;
-    const uint8_t *dis = (uint8_t *)buf.dis;
+    const uint16_t *vif_filt = vif_filter1d_table[0];
+    VifBuffer buf = s->buf;
+    const uint8_t *ref = (uint8_t*)buf.ref;
+    const uint8_t *dis = (uint8_t*)buf.dis;
     const unsigned fwidth_half = fwidth >> 1;
-    const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
-    __m512i mask2 = _mm512_set_epi64(11, 10, 3, 2, 9, 8, 1, 0);
-    __m512i mask3 = _mm512_set_epi64(15, 14, 7, 6, 13, 12, 5, 4);
+    const uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
 
-    __m512i f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, fc0, fc1, fc2, fc3, fc4, fc5, fc6, fc7, fc8;
+#if defined __GNUC__
+#define ALIGNED(x) __attribute__ ((aligned (x)))
+#elif defined (_MSC_VER)  && (!defined UNDER_CE)
+#define ALIGNED(x) __declspec (align(x))
+#else
+#define ALIGNED(x)
+#endif
 
-    fc0 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)vif_filt_s0));
-    fc1 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 2)));
-    fc2 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 4)));
-    fc3 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 6)));
-    fc4 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 8)));
-    fc5 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 10)));
-    fc6 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 12)));
-    fc7 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 14)));
-    fc8 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 16)));
+    //float equivalent of 2. (2 * 65536)
+    static const int32_t sigma_nsq = 65536 << 1;
 
-    f1 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)vif_filt_s0));
-    f2 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 1)));
-    f3 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 2)));
-    f4 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 3)));
-    f5 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 4)));
-    f6 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 5)));
-    f7 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 6)));
-    f8 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 7)));
-    f9 = _mm512_broadcastw_epi16(_mm_loadu_si128((__m128i *)(vif_filt_s0 + 8)));
+    int64_t accum_num_log = 0;
+    int64_t accum_den_log = 0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
 
-    __m512i fq1 = _mm512_set1_epi64(vif_filt_s0[0]);
-    __m512i fq2 = _mm512_set1_epi64(vif_filt_s0[1]);
-    __m512i fq3 = _mm512_set1_epi64(vif_filt_s0[2]);
-    __m512i fq4 = _mm512_set1_epi64(vif_filt_s0[3]);
-    __m512i fq5 = _mm512_set1_epi64(vif_filt_s0[4]);
-    __m512i fq6 = _mm512_set1_epi64(vif_filt_s0[5]);
-    __m512i fq7 = _mm512_set1_epi64(vif_filt_s0[6]);
-    __m512i fq8 = _mm512_set1_epi64(vif_filt_s0[7]);
-    __m512i fq9 = _mm512_set1_epi64(vif_filt_s0[8]);
+    __m512i round_128 = _mm512_set1_epi32(128);
+    __m512i mask2 = _mm512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
 
+    Residuals512 residuals;
+    residuals.maccum_den_log = _mm512_setzero_si512();
+    residuals.maccum_num_log = _mm512_setzero_si512();
+    residuals.maccum_den_non_log = _mm512_setzero_si512();
+    residuals.maccum_num_non_log = _mm512_setzero_si512();
     for (unsigned i = 0; i < h; ++i)
     {
         //VERTICAL
         int ii = i - fwidth_half;
+        // Filter vertically
+        for (unsigned jj = 0; jj < w; jj += 16) {
+            const uint8_t *ref = (uint8_t*)buf.ref;
+            const uint8_t *dis = (uint8_t*)buf.dis;
 
-        for (unsigned j = 0; j < w; j = j + 32)
-        {
-            __m512i accum_ref_lo, accum_ref_hi, accum_dis_lo, accum_dis_hi,
-                accum_ref_dis_lo, accum_ref_dis_hi, accum_mu2_lo,
-                accum_mu2_hi, accum_mu1_lo, accum_mu1_hi;
-            accum_ref_lo = accum_ref_hi = accum_dis_lo = accum_dis_hi =
-                accum_ref_dis_lo = accum_ref_dis_hi = accum_mu2_lo =
-                    accum_mu2_hi = accum_mu1_lo = accum_mu1_hi = _mm512_setzero_si512();
+            __m512i f0 = _mm512_set1_epi32(vif_filt[fwidth / 2]);
+            __m512i r0 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * i) + jj)));
+            __m512i d0 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * i) + jj)));
 
-            __m512i dislo, dishi, refdislo, refdishi, final_resultlo,
-                final_resulthi;
-            dislo = dishi = refdislo = refdishi = final_resultlo =
-                final_resulthi = _mm512_setzero_si512();
+            // filtered r,d
+            __m512i accum_mu1 = _mm512_mullo_epi32(r0, f0);
+            __m512i accum_mu2 = _mm512_mullo_epi32(d0, f0);
+            __m512i accum_ref = _mm512_mullo_epi32(f0, _mm512_mullo_epi32(r0, r0));
+            __m512i accum_dis = _mm512_mullo_epi32(f0, _mm512_mullo_epi32(d0, d0));
+            __m512i accum_ref_dis = _mm512_mullo_epi32(f0, _mm512_mullo_epi32(r0, d0));
 
-            int ii_check = ii;
-            __m512i g0, g1, g2, g3, g4, g5, g6, g7, g8, g20, g21, g22,
-                g23, g24, g25, g26, g27, g28;
-            __m512i s0, s1, s2, s3, s4, s5, s6, s7, s8, s20, s21, s22,
-                s23, s24, s25, s26, s27, s28, sg0, sg1, sg2, sg3, sg4, sg5, sg6, sg7, sg8;
+            for (unsigned int tap = 0; tap < fwidth / 2; tap++) {
+                int ii = i - fwidth / 2;
+                int ii_check = i - fwidth / 2 + tap;
+                int ii_check_1 = i + fwidth / 2 - tap;
+                const uint8_t *ref = (uint8_t*)buf.ref;
+                const uint8_t *dis = (uint8_t*)buf.dis;
 
-            g0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + (buf.stride * ii_check) + j)));
-            g1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 1) + j)));
-            g2 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 2) + j)));
-            g3 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 3) + j)));
-            g4 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 4) + j)));
-            g5 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 5) + j)));
-            g6 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 6) + j)));
-            g7 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 7) + j)));
+                __m512i f0 = _mm512_set1_epi32(vif_filt[tap]);
+                __m512i r0 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * ii_check) + jj)));
+                __m512i d0 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * ii_check) + jj)));
+                __m512i r1 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.ref) + (buf.stride * ii_check_1) + jj)));
+                __m512i d1 = _mm512_cvtepu8_epi32(_mm_loadu_si128((__m128i*)(((uint8_t*)buf.dis) + (buf.stride * ii_check_1) + jj)));
 
-            s0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + (buf.stride * ii_check) + j)));
-            s1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 1) + j)));
-            s2 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 2) + j)));
-            s3 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 3) + j)));
-            s4 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 4) + j)));
-            s5 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 5) + j)));
-            s6 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 6) + j)));
-            s7 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 7) + j)));
-
-            __m512i s0lo = _mm512_unpacklo_epi16(s0, s1);
-            __m512i s0hi = _mm512_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s0lo, fc0));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s0hi, fc0));
-            __m512i s1lo = _mm512_unpacklo_epi16(s2, s3);
-            __m512i s1hi = _mm512_unpackhi_epi16(s2, s3);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s1lo, fc1));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s1hi, fc1));
-            __m512i s2lo = _mm512_unpacklo_epi16(s4, s5);
-            __m512i s2hi = _mm512_unpackhi_epi16(s4, s5);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s2lo, fc2));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s2hi, fc2));
-            __m512i s3lo = _mm512_unpacklo_epi16(s6, s7);
-            __m512i s3hi = _mm512_unpackhi_epi16(s6, s7);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s3lo, fc3));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s3hi, fc3));
-
-            __m512i g0lo = _mm512_unpacklo_epi16(g0, g1);
-            __m512i g0hi = _mm512_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g0lo, fc0));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g0hi, fc0));
-            __m512i g1lo = _mm512_unpacklo_epi16(g2, g3);
-            __m512i g1hi = _mm512_unpackhi_epi16(g2, g3);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g1lo, fc1));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g1hi, fc1));
-            __m512i g2lo = _mm512_unpacklo_epi16(g4, g5);
-            __m512i g2hi = _mm512_unpackhi_epi16(g4, g5);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g2lo, fc2));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g2hi, fc2));
-            __m512i g3lo = _mm512_unpacklo_epi16(g6, g7);
-            __m512i g3hi = _mm512_unpackhi_epi16(g6, g7);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g3lo, fc3));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g3hi, fc3));
-
-            g20 = _mm512_mullo_epi16(g0, g0);
-            g21 = _mm512_mullo_epi16(g1, g1);
-            g22 = _mm512_mullo_epi16(g2, g2);
-            g23 = _mm512_mullo_epi16(g3, g3);
-            g24 = _mm512_mullo_epi16(g4, g4);
-            g25 = _mm512_mullo_epi16(g5, g5);
-            g26 = _mm512_mullo_epi16(g6, g6);
-            g27 = _mm512_mullo_epi16(g7, g7);
-
-            s20 = _mm512_mullo_epi16(s0, s0);
-            s21 = _mm512_mullo_epi16(s1, s1);
-            s22 = _mm512_mullo_epi16(s2, s2);
-            s23 = _mm512_mullo_epi16(s3, s3);
-            s24 = _mm512_mullo_epi16(s4, s4);
-            s25 = _mm512_mullo_epi16(s5, s5);
-            s26 = _mm512_mullo_epi16(s6, s6);
-            s27 = _mm512_mullo_epi16(s7, s7);
-
-            sg0 = _mm512_mullo_epi16(s0, g0);
-            sg1 = _mm512_mullo_epi16(s1, g1);
-            sg2 = _mm512_mullo_epi16(s2, g2);
-            sg3 = _mm512_mullo_epi16(s3, g3);
-            sg4 = _mm512_mullo_epi16(s4, g4);
-            sg5 = _mm512_mullo_epi16(s5, g5);
-            sg6 = _mm512_mullo_epi16(s6, g6);
-            sg7 = _mm512_mullo_epi16(s7, g7);
-
-            __m512i result2 = _mm512_mulhi_epu16(g20, f1);
-            __m512i result2lo = _mm512_mullo_epi16(g20, f1);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result2lo, result2));
-            __m512i result3 = _mm512_mulhi_epu16(g21, f2);
-            __m512i result3lo = _mm512_mullo_epi16(g21, f2);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result3lo, result3));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result3lo, result3));
-            __m512i result4 = _mm512_mulhi_epu16(g22, f3);
-            __m512i result4lo = _mm512_mullo_epi16(g22, f3);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result4lo, result4));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result4lo, result4));
-            __m512i result5 = _mm512_mulhi_epu16(g23, f4);
-            __m512i result5lo = _mm512_mullo_epi16(g23, f4);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result5lo, result5));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result5lo, result5));
-            __m512i result6 = _mm512_mulhi_epu16(g24, f5);
-            __m512i result6lo = _mm512_mullo_epi16(g24, f5);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result6lo, result6));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result6lo, result6));
-            __m512i result7 = _mm512_mulhi_epu16(g25, f6);
-            __m512i result7lo = _mm512_mullo_epi16(g25, f6);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result7lo, result7));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result7lo, result7));
-            __m512i result8 = _mm512_mulhi_epu16(g26, f7);
-            __m512i result8lo = _mm512_mullo_epi16(g26, f7);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result8lo, result8));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result8lo, result8));
-            __m512i result9 = _mm512_mulhi_epu16(g27, f8);
-            __m512i result9lo = _mm512_mullo_epi16(g27, f8);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result9lo, result9));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm512_mulhi_epu16(s20, f1);
-            result2lo = _mm512_mullo_epi16(s20, f1);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result2lo, result2));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result2lo, result2));
-            result3 = _mm512_mulhi_epu16(s21, f2);
-            result3lo = _mm512_mullo_epi16(s21, f2);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result3lo, result3));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result3lo, result3));
-            result4 = _mm512_mulhi_epu16(s22, f3);
-            result4lo = _mm512_mullo_epi16(s22, f3);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result4lo, result4));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result4lo, result4));
-            result5 = _mm512_mulhi_epu16(s23, f4);
-            result5lo = _mm512_mullo_epi16(s23, f4);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result5lo, result5));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result5lo, result5));
-            result6 = _mm512_mulhi_epu16(s24, f5);
-            result6lo = _mm512_mullo_epi16(s24, f5);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result6lo, result6));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result6lo, result6));
-            result7 = _mm512_mulhi_epu16(s25, f6);
-            result7lo = _mm512_mullo_epi16(s25, f6);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result7lo, result7));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result7lo, result7));
-            result8 = _mm512_mulhi_epu16(s26, f7);
-            result8lo = _mm512_mullo_epi16(s26, f7);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result8lo, result8));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result8lo, result8));
-            result9 = _mm512_mulhi_epu16(s27, f8);
-            result9lo = _mm512_mullo_epi16(s27, f8);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result9lo, result9));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm512_mulhi_epu16(sg0, f1);
-            result2lo = _mm512_mullo_epi16(sg0, f1);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result2lo, result2));
-
-            result3 = _mm512_mulhi_epu16(sg1, f2);
-            result3lo = _mm512_mullo_epi16(sg1, f2);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result3lo, result3));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result3lo, result3));
-
-            result4 = _mm512_mulhi_epu16(sg2, f3);
-            result4lo = _mm512_mullo_epi16(sg2, f3);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result4lo, result4));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result4lo, result4));
-            result5 = _mm512_mulhi_epu16(sg3, f4);
-            result5lo = _mm512_mullo_epi16(sg3, f4);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result5lo, result5));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result5lo, result5));
-            result6 = _mm512_mulhi_epu16(sg4, f5);
-            result6lo = _mm512_mullo_epi16(sg4, f5);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result6lo, result6));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result6lo, result6));
-            result7 = _mm512_mulhi_epu16(sg5, f6);
-            result7lo = _mm512_mullo_epi16(sg5, f6);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result7lo, result7));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result7lo, result7));
-            result8 = _mm512_mulhi_epu16(sg6, f7);
-            result8lo = _mm512_mullo_epi16(sg6, f7);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result8lo, result8));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result8lo, result8));
-            result9 = _mm512_mulhi_epu16(sg7, f8);
-            result9lo = _mm512_mullo_epi16(sg7, f8);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result9lo, result9));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result9lo, result9));
-
-            g0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 8) + j)));
-            g1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 9) + j)));
-            g2 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 10) + j)));
-            g3 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 11) + j)));
-            g4 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 12) + j)));
-            g5 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 13) + j)));
-            g6 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 14) + j)));
-            g7 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 15) + j)));
-
-            s0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 8) + j)));
-            s1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 9) + j)));
-            s2 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 10) + j)));
-            s3 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 11) + j)));
-            s4 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 12) + j)));
-            s5 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 13) + j)));
-            s6 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 14) + j)));
-            s7 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 15) + j)));
-
-            s0lo = _mm512_unpacklo_epi16(s0, s1);
-            s0hi = _mm512_unpackhi_epi16(s0, s1);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s0lo, fc4));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s0hi, fc4));
-            s1lo = _mm512_unpacklo_epi16(s2, s3);
-            s1hi = _mm512_unpackhi_epi16(s2, s3);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s1lo, fc5));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s1hi, fc5));
-            s2lo = _mm512_unpacklo_epi16(s4, s5);
-            s2hi = _mm512_unpackhi_epi16(s4, s5);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s2lo, fc6));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s2hi, fc6));
-            s3lo = _mm512_unpacklo_epi16(s6, s7);
-            s3hi = _mm512_unpackhi_epi16(s6, s7);
-            accum_mu2_lo =
-                _mm512_add_epi32(accum_mu2_lo, _mm512_madd_epi16(s3lo, fc7));
-            accum_mu2_hi =
-                _mm512_add_epi32(accum_mu2_hi, _mm512_madd_epi16(s3hi, fc7));
-
-            g0lo = _mm512_unpacklo_epi16(g0, g1);
-            g0hi = _mm512_unpackhi_epi16(g0, g1);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g0lo, fc4));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g0hi, fc4));
-            g1lo = _mm512_unpacklo_epi16(g2, g3);
-            g1hi = _mm512_unpackhi_epi16(g2, g3);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g1lo, fc5));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g1hi, fc5));
-            g2lo = _mm512_unpacklo_epi16(g4, g5);
-            g2hi = _mm512_unpackhi_epi16(g4, g5);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g2lo, fc6));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g2hi, fc6));
-            g3lo = _mm512_unpacklo_epi16(g6, g7);
-            g3hi = _mm512_unpackhi_epi16(g6, g7);
-            accum_mu1_lo =
-                _mm512_add_epi32(accum_mu1_lo, _mm512_madd_epi16(g3lo, fc7));
-            accum_mu1_hi =
-                _mm512_add_epi32(accum_mu1_hi, _mm512_madd_epi16(g3hi, fc7));
-
-            g20 = _mm512_mullo_epi16(g0, g0);
-            g21 = _mm512_mullo_epi16(g1, g1);
-            g22 = _mm512_mullo_epi16(g2, g2);
-            g23 = _mm512_mullo_epi16(g3, g3);
-            g24 = _mm512_mullo_epi16(g4, g4);
-            g25 = _mm512_mullo_epi16(g5, g5);
-            g26 = _mm512_mullo_epi16(g6, g6);
-            g27 = _mm512_mullo_epi16(g7, g7);
-
-            s20 = _mm512_mullo_epi16(s0, s0);
-            s21 = _mm512_mullo_epi16(s1, s1);
-            s22 = _mm512_mullo_epi16(s2, s2);
-            s23 = _mm512_mullo_epi16(s3, s3);
-            s24 = _mm512_mullo_epi16(s4, s4);
-            s25 = _mm512_mullo_epi16(s5, s5);
-            s26 = _mm512_mullo_epi16(s6, s6);
-            s27 = _mm512_mullo_epi16(s7, s7);
-
-            sg0 = _mm512_mullo_epi16(s0, g0);
-            sg1 = _mm512_mullo_epi16(s1, g1);
-            sg2 = _mm512_mullo_epi16(s2, g2);
-            sg3 = _mm512_mullo_epi16(s3, g3);
-            sg4 = _mm512_mullo_epi16(s4, g4);
-            sg5 = _mm512_mullo_epi16(s5, g5);
-            sg6 = _mm512_mullo_epi16(s6, g6);
-            sg7 = _mm512_mullo_epi16(s7, g7);
-
-            result2 = _mm512_mulhi_epu16(g20, f9);
-            result2lo = _mm512_mullo_epi16(g20, f9);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result2lo, result2));
-            result3 = _mm512_mulhi_epu16(g21, f8);
-            result3lo = _mm512_mullo_epi16(g21, f8);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result3lo, result3));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result3lo, result3));
-            result4 = _mm512_mulhi_epu16(g22, f7);
-            result4lo = _mm512_mullo_epi16(g22, f7);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result4lo, result4));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result4lo, result4));
-            result5 = _mm512_mulhi_epu16(g23, f6);
-            result5lo = _mm512_mullo_epi16(g23, f6);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result5lo, result5));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result5lo, result5));
-            result6 = _mm512_mulhi_epu16(g24, f5);
-            result6lo = _mm512_mullo_epi16(g24, f5);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result6lo, result6));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result6lo, result6));
-            result7 = _mm512_mulhi_epu16(g25, f4);
-            result7lo = _mm512_mullo_epi16(g25, f4);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result7lo, result7));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result7lo, result7));
-            result8 = _mm512_mulhi_epu16(g26, f3);
-            result8lo = _mm512_mullo_epi16(g26, f3);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result8lo, result8));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result8lo, result8));
-            result9 = _mm512_mulhi_epu16(g27, f2);
-            result9lo = _mm512_mullo_epi16(g27, f2);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result9lo, result9));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm512_mulhi_epu16(s20, f9);
-            result2lo = _mm512_mullo_epi16(s20, f9);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result2lo, result2));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result2lo, result2));
-            result3 = _mm512_mulhi_epu16(s21, f8);
-            result3lo = _mm512_mullo_epi16(s21, f8);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result3lo, result3));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result3lo, result3));
-            result4 = _mm512_mulhi_epu16(s22, f7);
-            result4lo = _mm512_mullo_epi16(s22, f7);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result4lo, result4));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result4lo, result4));
-            result5 = _mm512_mulhi_epu16(s23, f6);
-            result5lo = _mm512_mullo_epi16(s23, f6);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result5lo, result5));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result5lo, result5));
-            result6 = _mm512_mulhi_epu16(s24, f5);
-            result6lo = _mm512_mullo_epi16(s24, f5);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result6lo, result6));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result6lo, result6));
-            result7 = _mm512_mulhi_epu16(s25, f4);
-            result7lo = _mm512_mullo_epi16(s25, f4);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result7lo, result7));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result7lo, result7));
-            result8 = _mm512_mulhi_epu16(s26, f3);
-            result8lo = _mm512_mullo_epi16(s26, f3);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result8lo, result8));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result8lo, result8));
-            result9 = _mm512_mulhi_epu16(s27, f2);
-            result9lo = _mm512_mullo_epi16(s27, f2);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result9lo, result9));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result9lo, result9));
-
-            result2 = _mm512_mulhi_epu16(sg0, f9);
-            result2lo = _mm512_mullo_epi16(sg0, f9);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result2lo, result2));
-            result3 = _mm512_mulhi_epu16(sg1, f8);
-            result3lo = _mm512_mullo_epi16(sg1, f8);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result3lo, result3));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result3lo, result3));
-            result4 = _mm512_mulhi_epu16(sg2, f7);
-            result4lo = _mm512_mullo_epi16(sg2, f7);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result4lo, result4));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result4lo, result4));
-            result5 = _mm512_mulhi_epu16(sg3, f6);
-            result5lo = _mm512_mullo_epi16(sg3, f6);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result5lo, result5));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result5lo, result5));
-            result6 = _mm512_mulhi_epu16(sg4, f5);
-            result6lo = _mm512_mullo_epi16(sg4, f5);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result6lo, result6));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result6lo, result6));
-            result7 = _mm512_mulhi_epu16(sg5, f4);
-            result7lo = _mm512_mullo_epi16(sg5, f4);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result7lo, result7));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result7lo, result7));
-            result8 = _mm512_mulhi_epu16(sg6, f3);
-            result8lo = _mm512_mullo_epi16(sg6, f3);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result8lo, result8));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result8lo, result8));
-            result9 = _mm512_mulhi_epu16(sg7, f2);
-            result9lo = _mm512_mullo_epi16(sg7, f2);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result9lo, result9));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result9lo, result9));
-
-            g0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 16) + j)));
-            g1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(ref + buf.stride * (ii_check + 17) + j)));
-
-            s0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 16) + j)));
-            s1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256(
-                (__m256i *)(dis + buf.stride * (ii_check + 17) + j)));
-
-            s0lo = _mm512_unpacklo_epi16(s0, s1);
-            s0hi = _mm512_unpackhi_epi16(s0, s1);
-            accum_mu2_lo = _mm512_add_epi32(
-                accum_mu2_lo, _mm512_madd_epi16(s0lo, fc8));
-            accum_mu2_hi = _mm512_add_epi32(
-                accum_mu2_hi, _mm512_madd_epi16(s0hi, fc8));
-
-            g0lo = _mm512_unpacklo_epi16(g0, g1);
-            g0hi = _mm512_unpackhi_epi16(g0, g1);
-            accum_mu1_lo = _mm512_add_epi32(
-                accum_mu1_lo, _mm512_madd_epi16(g0lo, fc8));
-            accum_mu1_hi = _mm512_add_epi32(
-                accum_mu1_hi, _mm512_madd_epi16(g0hi, fc8));
-
-            g20 = _mm512_mullo_epi16(g0, g0);
-            s20 = _mm512_mullo_epi16(s0, s0);
-            sg0 = _mm512_mullo_epi16(s0, g0);
-
-            result2 = _mm512_mulhi_epu16(g20, f1);
-            result2lo = _mm512_mullo_epi16(g20, f1);
-            final_resultlo = _mm512_add_epi32(
-                final_resultlo, _mm512_unpacklo_epi16(result2lo, result2));
-            final_resulthi = _mm512_add_epi32(
-                final_resulthi, _mm512_unpackhi_epi16(result2lo, result2));
-
-            result2 = _mm512_mulhi_epu16(s20, f1);
-            result2lo = _mm512_mullo_epi16(s20, f1);
-            dislo = _mm512_add_epi32(dislo,
-                                     _mm512_unpacklo_epi16(result2lo, result2));
-            dishi = _mm512_add_epi32(dishi,
-                                     _mm512_unpackhi_epi16(result2lo, result2));
-
-            result2 = _mm512_mulhi_epu16(sg0, f1);
-            result2lo = _mm512_mullo_epi16(sg0, f1);
-            refdislo = _mm512_add_epi32(
-                refdislo, _mm512_unpacklo_epi16(result2lo, result2));
-            refdishi = _mm512_add_epi32(
-                refdishi, _mm512_unpackhi_epi16(result2lo, result2));
-
-            __m512i accumref_lo =
-                _mm512_permutex2var_epi64(final_resultlo, mask2, final_resulthi);
-            __m512i accumref_hi =
-                _mm512_permutex2var_epi64(final_resultlo, mask3, final_resulthi);
-            __m512i accumdis_lo =
-                _mm512_permutex2var_epi64(dislo, mask2, dishi);
-            __m512i accumdis_hi =
-                _mm512_permutex2var_epi64(dislo, mask3, dishi);
-            __m512i accumrefdis_lo =
-                _mm512_permutex2var_epi64(refdislo, mask2, refdishi);
-            __m512i accumrefdis_hi =
-                _mm512_permutex2var_epi64(refdislo, mask3, refdishi);
-            __m512i x = _mm512_set1_epi32(128);
-            __m512i accumu1_lo = _mm512_add_epi32(
-                x, _mm512_permutex2var_epi64(accum_mu1_lo, mask2, accum_mu1_hi));
-            __m512i accumu1_hi = _mm512_add_epi32(
-                x, _mm512_permutex2var_epi64(accum_mu1_lo, mask3, accum_mu1_hi));
-            __m512i accumu2_lo = _mm512_add_epi32(
-                x, _mm512_permutex2var_epi64(accum_mu2_lo, mask2, accum_mu2_hi));
-            __m512i accumu2_hi = _mm512_add_epi32(
-                x, _mm512_permutex2var_epi64(accum_mu2_lo, mask3, accum_mu2_hi));
-            accumu1_lo = _mm512_srli_epi32(accumu1_lo, 0x08);
-            accumu1_hi = _mm512_srli_epi32(accumu1_hi, 0x08);
-            accumu2_lo = _mm512_srli_epi32(accumu2_lo, 0x08);
-            accumu2_hi = _mm512_srli_epi32(accumu2_hi, 0x08);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.ref + j), accumref_lo);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.ref + j + 16), accumref_hi);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.dis + j), accumdis_lo);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.dis + j + 16), accumdis_hi);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.ref_dis + j), accumrefdis_lo);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.ref_dis + j + 16), accumrefdis_hi);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.mu1 + j), accumu1_lo);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.mu1 + j + 16), accumu1_hi);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.mu2 + j), accumu2_lo);
-            _mm512_storeu_si512((__m512i *)(buf.tmp.mu2 + j + 16), accumu2_hi);
+                accum_mu1 = _mm512_add_epi32(accum_mu1, _mm512_mullo_epi32(_mm512_add_epi32(r0, r1), f0));
+                accum_mu2 = _mm512_add_epi32(accum_mu2, _mm512_mullo_epi32(_mm512_add_epi32(d0, d1), f0));
+                accum_ref = _mm512_add_epi32(accum_ref, _mm512_mullo_epi32(f0, _mm512_add_epi32(_mm512_mullo_epi32(r0, r0), _mm512_mullo_epi32(r1, r1))));
+                accum_dis = _mm512_add_epi32(accum_dis, _mm512_mullo_epi32(f0, _mm512_add_epi32(_mm512_mullo_epi32(d0, d0), _mm512_mullo_epi32(d1, d1))));
+                accum_ref_dis = _mm512_add_epi32(accum_ref_dis, _mm512_mullo_epi32(f0, _mm512_add_epi32(_mm512_mullo_epi32(d0, r0), _mm512_mullo_epi32(d1, r1))));
+            }
+            accum_mu1 = _mm512_add_epi32(accum_mu1, round_128);
+            accum_mu2 = _mm512_add_epi32(accum_mu2, round_128);
+            accum_mu1 = _mm512_srli_epi32(accum_mu1, 0x08);
+            accum_mu2 = _mm512_srli_epi32(accum_mu2, 0x08);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu1 + jj), accum_mu1);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu2 + jj), accum_mu2);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref + jj), accum_ref);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.dis + jj), accum_dis);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref_dis + jj), accum_ref_dis);
         }
 
         PADDING_SQ_DATA(buf, w, fwidth_half);
-        //horizontal
 
-#pragma unroll(4)
-        for (unsigned j = 0; j < w; j = j + 32)
-        {
-            __m512i refdislo, refdishi, mu2lo, mu2hi, mu1lo, mu1hi, s2;
-            refdislo = refdishi = mu2lo = mu2hi = mu1lo = s2 = mu1hi = _mm512_setzero_si512();
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-
+        //HORIZONTAL
+        const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
+        for (unsigned j = 0; j < w; j += 16) {
+            __m512i mu1sq;
+            __m512i mu2sq;
+            __m512i mu1mu2;
+            __m512i xx;
+            __m512i yy;
+            __m512i xy;
+            __m512i mask5 = _mm512_set_epi32(30, 28, 14, 12, 26, 24, 10, 8, 22, 20, 6, 4, 18, 16, 2, 0);
+            // compute mu1sq, mu2sq, mu1mu2
             {
+                __m512i fq = _mm512_set1_epi32(vif_filt[fwidth / 2]);
+                __m512i acc0 = _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j + 0)), fq);
+                __m512i acc1 = _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j + 0)), fq);
 
-                __m512i s0 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check));
-                __m512i s1 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 1));
-                __m512i s2 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 2));
-                __m512i s3 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 3));
-                __m512i s4 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 4));
-                __m512i s5 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 5));
-                __m512i s6 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 6));
-                __m512i s7 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 7));
-                __m512i s8 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 8));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m512i fq = _mm512_set1_epi32(vif_filt[fj]);
+                    acc0 = _mm512_add_epi64(acc0, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j - fwidth / 2 + fj + 0)), fq));
+                    acc0 = _mm512_add_epi64(acc0, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j + fwidth / 2 - fj + 0)), fq));
+                    acc1 = _mm512_add_epi64(acc1, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j - fwidth / 2 + fj + 0)), fq));
+                    acc1 = _mm512_add_epi64(acc1, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j + fwidth / 2 - fj + 0)), fq));
+                }
+                __m512i mu1 = acc0;
+                __m512i acc0_lo_512 = _mm512_unpacklo_epi32(acc0, _mm512_setzero_si512());
+                __m512i acc0_hi_512 = _mm512_unpackhi_epi32(acc0, _mm512_setzero_si512());
+                acc0_lo_512 = _mm512_mul_epu32(acc0_lo_512, acc0_lo_512);
+                acc0_hi_512 = _mm512_mul_epu32(acc0_hi_512, acc0_hi_512);
+                acc0_lo_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0_lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                acc0_hi_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0_hi_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu1sq = _mm512_permutex2var_epi32(acc0_lo_512, mask5, acc0_hi_512);
 
-                __m512i s00 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 16));
-                __m512i s11 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 17));
-                __m512i s22 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 18));
-                __m512i s33 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 19));
-                __m512i s44 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 20));
-                __m512i s55 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 21));
-                __m512i s66 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 22));
-                __m512i s77 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 23));
-                __m512i s88 =
-                    _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 24));
+                __m512i acc0lo_512 = _mm512_unpacklo_epi32(acc1, _mm512_setzero_si512());
+                __m512i acc0hi_512 = _mm512_unpackhi_epi32(acc1, _mm512_setzero_si512());
+                __m512i mu1lo_512 = _mm512_unpacklo_epi32(mu1, _mm512_setzero_si512());
+                __m512i mu1hi_512 = _mm512_unpackhi_epi32(mu1, _mm512_setzero_si512());
 
-                s0 = _mm512_packus_epi32(s0, s00);
-                s1 = _mm512_packus_epi32(s1, s11);
-                s2 = _mm512_packus_epi32(s2, s22);
-                s3 = _mm512_packus_epi32(s3, s33);
-                s4 = _mm512_packus_epi32(s4, s44);
-                s5 = _mm512_packus_epi32(s5, s55);
-                s6 = _mm512_packus_epi32(s6, s66);
-                s7 = _mm512_packus_epi32(s7, s77);
-                s8 = _mm512_packus_epi32(s8, s88);
-                __m512i result2 = _mm512_mulhi_epu16(s0, f1);
-                __m512i result2lo = _mm512_mullo_epi16(s0, f1);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s1, f2);
-                result2lo = _mm512_mullo_epi16(s1, f2);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s2, f3);
-                result2lo = _mm512_mullo_epi16(s2, f3);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s3, f4);
-                result2lo = _mm512_mullo_epi16(s3, f4);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s4, f5);
-                result2lo = _mm512_mullo_epi16(s4, f5);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s5, f6);
-                result2lo = _mm512_mullo_epi16(s5, f6);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s6, f7);
-                result2lo = _mm512_mullo_epi16(s6, f7);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s7, f8);
-                result2lo = _mm512_mullo_epi16(s7, f8);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s8, f9);
-                result2lo = _mm512_mullo_epi16(s8, f9);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
+                mu1lo_512 = _mm512_mul_epu32(mu1lo_512, acc0lo_512);
+                mu1hi_512 = _mm512_mul_epu32(mu1hi_512, acc0hi_512);
+                mu1lo_512 = _mm512_srli_epi64(_mm512_add_epi64(mu1lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu1hi_512 = _mm512_srli_epi64(_mm512_add_epi64(mu1hi_512, _mm512_set1_epi64(0x80000000)), 32);
 
-                __m512i g0 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check));
-                __m512i g1 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 1));
-                __m512i g2 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 2));
-                __m512i g3 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 3));
-                __m512i g4 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 4));
-                __m512i g5 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 5));
-                __m512i g6 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 6));
-                __m512i g7 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 7));
-                __m512i g8 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 8));
-                __m512i g00 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 16));
-                __m512i g11 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 17));
-                __m512i g22 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 18));
-                __m512i g33 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 19));
-                __m512i g44 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 20));
-                __m512i g55 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 21));
-                __m512i g66 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 22));
-                __m512i g77 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 23));
-                __m512i g88 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 24));
-                //***********experiment unroll loop in width doer mu2
-                g0 = _mm512_packus_epi32(g0, g00);
-                g1 = _mm512_packus_epi32(g1, g11);
-                g2 = _mm512_packus_epi32(g2, g22);
-                g3 = _mm512_packus_epi32(g3, g33);
-                g4 = _mm512_packus_epi32(g4, g44);
-                g5 = _mm512_packus_epi32(g5, g55);
-                g6 = _mm512_packus_epi32(g6, g66);
-                g7 = _mm512_packus_epi32(g7, g77);
-                g8 = _mm512_packus_epi32(g8, g88);
-                result2 = _mm512_mulhi_epu16(g0, f1);
-                result2lo = _mm512_mullo_epi16(g0, f1);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g1, f2);
-                result2lo = _mm512_mullo_epi16(g1, f2);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g2, f3);
-                result2lo = _mm512_mullo_epi16(g2, f3);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g3, f4);
-                result2lo = _mm512_mullo_epi16(g3, f4);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g4, f5);
-                result2lo = _mm512_mullo_epi16(g4, f5);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g5, f6);
-                result2lo = _mm512_mullo_epi16(g5, f6);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g6, f7);
-                result2lo = _mm512_mullo_epi16(g6, f7);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g7, f8);
-                result2lo = _mm512_mullo_epi16(g7, f8);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g8, f9);
-                result2lo = _mm512_mullo_epi16(g8, f9);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-
-                s0 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 9));
-                s1 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 10));
-                s2 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 11));
-                s3 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 12));
-                s4 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 13));
-                s5 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 14));
-                s6 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 15));
-                s7 = s00;
-
-                s00 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 25));
-                s11 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 26));
-                s22 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 27));
-                s33 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 28));
-                s44 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 29));
-                s55 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 30));
-                s66 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 31));
-                s77 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check + 32));
-
-                s0 = _mm512_packus_epi32(s0, s00);
-                s1 = _mm512_packus_epi32(s1, s11);
-                s2 = _mm512_packus_epi32(s2, s22);
-                s3 = _mm512_packus_epi32(s3, s33);
-                s4 = _mm512_packus_epi32(s4, s44);
-                s5 = _mm512_packus_epi32(s5, s55);
-                s6 = _mm512_packus_epi32(s6, s66);
-                s7 = _mm512_packus_epi32(s7, s77);
-
-                result2 = _mm512_mulhi_epu16(s0, f8);
-                result2lo = _mm512_mullo_epi16(s0, f8);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s1, f7);
-                result2lo = _mm512_mullo_epi16(s1, f7);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s2, f6);
-                result2lo = _mm512_mullo_epi16(s2, f6);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s3, f5);
-                result2lo = _mm512_mullo_epi16(s3, f5);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s4, f4);
-                result2lo = _mm512_mullo_epi16(s4, f4);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s5, f3);
-                result2lo = _mm512_mullo_epi16(s5, f3);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s6, f2);
-                result2lo = _mm512_mullo_epi16(s6, f2);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(s7, f1);
-                result2lo = _mm512_mullo_epi16(s7, f1);
-                mu1lo = _mm512_add_epi32(
-                    mu1lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu1hi = _mm512_add_epi32(
-                    mu1hi, _mm512_unpackhi_epi16(result2lo, result2));
-
-                g0 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 9));
-                g1 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 10));
-                g2 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 11));
-                g3 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 12));
-                g4 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 13));
-                g5 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 14));
-                g6 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 15));
-                g7 = g00;
-
-                g00 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 25));
-                g11 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 26));
-                g22 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 27));
-                g33 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 28));
-                g44 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 29));
-                g55 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 30));
-                g66 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 31));
-                g77 = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check + 32));
-
-                //***********experiment unroll loop in width doer mu2
-                g0 = _mm512_packus_epi32(g0, g00);
-                g1 = _mm512_packus_epi32(g1, g11);
-                g2 = _mm512_packus_epi32(g2, g22);
-                g3 = _mm512_packus_epi32(g3, g33);
-                g4 = _mm512_packus_epi32(g4, g44);
-                g5 = _mm512_packus_epi32(g5, g55);
-                g6 = _mm512_packus_epi32(g6, g66);
-                g7 = _mm512_packus_epi32(g7, g77);
-                g8 = _mm512_packus_epi32(g8, g88);
-                result2 = _mm512_mulhi_epu16(g0, f8);
-                result2lo = _mm512_mullo_epi16(g0, f8);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g1, f7);
-                result2lo = _mm512_mullo_epi16(g1, f7);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g2, f6);
-                result2lo = _mm512_mullo_epi16(g2, f6);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g3, f5);
-                result2lo = _mm512_mullo_epi16(g3, f5);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g4, f4);
-                result2lo = _mm512_mullo_epi16(g4, f4);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g5, f3);
-                result2lo = _mm512_mullo_epi16(g5, f3);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g6, f2);
-                result2lo = _mm512_mullo_epi16(g6, f2);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
-                result2 = _mm512_mulhi_epu16(g7, f1);
-                result2lo = _mm512_mullo_epi16(g7, f1);
-                mu2lo = _mm512_add_epi32(
-                    mu2lo, _mm512_unpacklo_epi16(result2lo, result2));
-                mu2hi = _mm512_add_epi32(
-                    mu2hi, _mm512_unpackhi_epi16(result2lo, result2));
+                mu1mu2 = _mm512_permutex2var_epi32(mu1lo_512, mask5, mu1hi_512);
+                acc0lo_512 = _mm512_mul_epu32(acc0lo_512, acc0lo_512);
+                acc0hi_512 = _mm512_mul_epu32(acc0hi_512, acc0hi_512);
+                acc0lo_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                acc0hi_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0hi_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu2sq = _mm512_permutex2var_epi32(acc0lo_512, mask5, acc0hi_512);
             }
 
-            _mm512_storeu_si512((__m512i *)(buf.mu1_32 + (dst_stride * i) + j), mu1lo);
-            _mm512_storeu_si512((__m512i *)(buf.mu1_32 + (dst_stride * i) + j + 16), mu1hi);
-            _mm512_storeu_si512((__m512i *)(buf.mu2_32 + (dst_stride * i) + j), mu2lo);
-            _mm512_storeu_si512((__m512i *)(buf.mu2_32 + (dst_stride * i) + j + 16), mu2hi);
-        }
-
-#pragma unroll(4)
-        for (unsigned j = 0; j < w; j = j + 16)
-        {
-            __m512i refdislo, refdishi, reflo, refhi, dislo, dishi;
-            refdislo = refdishi = reflo = refhi = dislo = dishi = _mm512_setzero_si512();
-            int jj = j - fwidth_half;
-            int jj_check = jj;
-            __m512i addnum = _mm512_set1_epi64(32768);
+            // compute xx, yy, xy
             {
+                __m512i rounder = _mm512_set1_epi64(0x8000);
+                __m512i fq = _mm512_set1_epi64(vif_filt[fwidth / 2]);
+                __m512i s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 0))); // 4
+                __m512i s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 8))); // 4
+                __m512i refsq_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i refsq_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                __m512i s0 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check)));
-                __m512i s1 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 1)));
-                __m512i s2 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 2)));
-                __m512i s3 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 3)));
-                __m512i s4 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 4)));
-                __m512i s5 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 5)));
-                __m512i s6 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 6)));
-                __m512i s7 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 7)));
-                __m512i s8 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 8)));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s0, fq1));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s1, fq2));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s2, fq3));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s3, fq4));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s4, fq5));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s5, fq6));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s6, fq7));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s7, fq8));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s8, fq9));
+                s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 0))); // 4
+                s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 8))); // 4
+                __m512i dissq_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i dissq_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                //__m512i s9 =
-                //_mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256*)(buf.tmp.ref+jj_check+8)));
-                __m512i s10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 9)));
-                __m512i s11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 10)));
-                __m512i s12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 11)));
-                __m512i s13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 12)));
-                __m512i s14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 13)));
-                __m512i s15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 14)));
-                __m512i s16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 15)));
-                __m512i s17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 16)));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s8, fq1));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s10, fq2));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s11, fq3));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s12, fq4));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s13, fq5));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s14, fq6));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s15, fq7));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s16, fq8));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s17, fq9));
+                s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 0))); // 4
+                s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 8))); // 4
+                __m512i refdis_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i refdis_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s10, fq8));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s11, fq7));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s12, fq6));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s13, fq5));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s14, fq4));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s15, fq3));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s16, fq2));
-                reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s17, fq1));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m512i fq = _mm512_set1_epi64(vif_filt[fj]);
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 8))); // 4
+                    refsq_lo = _mm512_add_epi64(refsq_lo, _mm512_mul_epu32(s0, fq));
+                    refsq_hi = _mm512_add_epi64(refsq_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 8))); // 4
+                    refsq_lo = _mm512_add_epi64(refsq_lo, _mm512_mul_epu32(s0, fq));
+                    refsq_hi = _mm512_add_epi64(refsq_hi, _mm512_mul_epu32(s2, fq));
 
-                s10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 17)));
-                s11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 18)));
-                s12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 19)));
-                s13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 20)));
-                s14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 21)));
-                s15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 22)));
-                s16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 23)));
-                s17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref + jj_check + 24)));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s10, fq8));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s11, fq7));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s12, fq6));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s13, fq5));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s14, fq4));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s15, fq3));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s16, fq2));
-                refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s17, fq1));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 8))); // 4
+                    dissq_lo = _mm512_add_epi64(dissq_lo, _mm512_mul_epu32(s0, fq));
+                    dissq_hi = _mm512_add_epi64(dissq_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 8))); // 4
+                    dissq_lo = _mm512_add_epi64(dissq_lo, _mm512_mul_epu32(s0, fq));
+                    dissq_hi = _mm512_add_epi64(dissq_hi, _mm512_mul_epu32(s2, fq));
 
-                __m512i g0 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check)));
-                __m512i g1 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 1)));
-                __m512i g2 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 2)));
-                __m512i g3 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 3)));
-                __m512i g4 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 4)));
-                __m512i g5 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 5)));
-                __m512i g6 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 6)));
-                __m512i g7 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 7)));
-                __m512i g8 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 8)));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g0, fq1));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g1, fq2));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g2, fq3));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g3, fq4));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g4, fq5));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g5, fq6));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g6, fq7));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g7, fq8));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g8, fq9));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 8))); // 4
+                    refdis_lo = _mm512_add_epi64(refdis_lo, _mm512_mul_epu32(s0, fq));
+                    refdis_hi = _mm512_add_epi64(refdis_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 8))); // 4
+                    refdis_lo = _mm512_add_epi64(refdis_lo, _mm512_mul_epu32(s0, fq));
+                    refdis_hi = _mm512_add_epi64(refdis_hi, _mm512_mul_epu32(s2, fq));
+                }
+                refsq_lo = _mm512_srli_epi64(refsq_lo, 16);
+                refsq_hi = _mm512_srli_epi64(refsq_hi, 16);
+                __m512i refsq = _mm512_permutex2var_epi32(refsq_lo, mask2, refsq_hi);
+                xx = _mm512_sub_epi32(refsq, mu1sq);
 
-                //__m512i g9 =
-                //_mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256*)(buf.tmp.dis+jj_check+8)));
-                __m512i g10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 9)));
-                __m512i g11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 10)));
-                __m512i g12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 11)));
-                __m512i g13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 12)));
-                __m512i g14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 13)));
-                __m512i g15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 14)));
-                __m512i g16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 15)));
-                __m512i g17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 16)));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g8, fq1));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g10, fq2));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g11, fq3));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g12, fq4));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g13, fq5));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g14, fq6));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g15, fq7));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g16, fq8));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g17, fq9));
+                dissq_lo = _mm512_srli_epi64(dissq_lo, 16);
+                dissq_hi = _mm512_srli_epi64(dissq_hi, 16);
+                __m512i dissq = _mm512_permutex2var_epi32(dissq_lo, mask2, dissq_hi);
+                yy = _mm512_max_epi32(_mm512_sub_epi32(dissq, mu2sq), _mm512_setzero_si512());
 
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g10, fq8));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g11, fq7));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g12, fq6));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g13, fq5));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g14, fq4));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g15, fq3));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g16, fq2));
-                dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g17, fq1));
-
-                g10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 17)));
-                g11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 18)));
-                g12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 19)));
-                g13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 20)));
-                g14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 21)));
-                g15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 22)));
-                g16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 23)));
-                g17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.dis + jj_check + 24)));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g10, fq8));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g11, fq7));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g12, fq6));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g13, fq5));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g14, fq4));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g15, fq3));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g16, fq2));
-                dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g17, fq1));
-
-                __m512i sg0 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check)));
-                __m512i sg1 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 1)));
-                __m512i sg2 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 2)));
-                __m512i sg3 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 3)));
-                __m512i sg4 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 4)));
-                __m512i sg5 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 5)));
-                __m512i sg6 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 6)));
-                __m512i sg7 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 7)));
-                __m512i sg8 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 8)));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg0, fq1));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg1, fq2));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg2, fq3));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg3, fq4));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg4, fq5));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg5, fq6));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg6, fq7));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg7, fq8));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg8, fq9));
-
-                //__m512i  sg9 =
-                //_mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256*)(buf.tmp.ref_dis+jj_check+8)));
-                __m512i sg10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 9)));
-                __m512i sg11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 10)));
-                __m512i sg12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 11)));
-                __m512i sg13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 12)));
-                __m512i sg14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 13)));
-                __m512i sg15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 14)));
-                __m512i sg16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 15)));
-                __m512i sg17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 16)));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg8, fq1));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg10, fq2));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg11, fq3));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg12, fq4));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg13, fq5));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg14, fq6));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg15, fq7));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg16, fq8));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg17, fq9));
-
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg10, fq8));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg11, fq7));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg12, fq6));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg13, fq5));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg14, fq4));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg15, fq3));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg16, fq2));
-                refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg17, fq1));
-
-                sg10 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 17)));
-                sg11 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 18)));
-                sg12 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 19)));
-                sg13 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 20)));
-                sg14 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 21)));
-                sg15 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 22)));
-                sg16 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 23)));
-                sg17 = _mm512_cvtepu32_epi64(
-                    _mm256_loadu_si256((__m256 *)(buf.tmp.ref_dis + jj_check + 24)));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg10, fq8));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg11, fq7));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg12, fq6));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg13, fq5));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg14, fq4));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg15, fq3));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg16, fq2));
-                refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg17, fq1));
+                refdis_lo = _mm512_srli_epi64(refdis_lo, 16);
+                refdis_hi = _mm512_srli_epi64(refdis_hi, 16);
+                __m512i refdis = _mm512_permutex2var_epi32(refdis_lo, mask2, refdis_hi);
+                xy = _mm512_sub_epi32(refdis, mu1mu2);
             }
-            reflo = _mm512_add_epi64(reflo, addnum);
-            reflo = _mm512_srli_epi64(reflo, 0x10);
-            refhi = _mm512_add_epi64(refhi, addnum);
-            refhi = _mm512_srli_epi64(refhi, 0x10);
-
-            __m512i mask5 = _mm512_set_epi32(30, 28, 26, 24, 22, 20, 18,
-                                             16, 14, 12, 10, 8, 6, 4, 2, 0);
-            _mm512_storeu_si512((__m512i *)(buf.ref_sq + (dst_stride * i) + j),
-                                _mm512_permutex2var_epi32(reflo, mask5, refhi));
-
-            dislo = _mm512_add_epi64(dislo, addnum);
-            dislo = _mm512_srli_epi64(dislo, 0x10);
-            dishi = _mm512_add_epi64(dishi, addnum);
-            dishi = _mm512_srli_epi64(dishi, 0x10);
-
-            _mm512_storeu_si512((__m512i *)(buf.dis_sq + (dst_stride * i) + j),
-                                _mm512_permutex2var_epi32(dislo, mask5, dishi));
-
-            refdislo = _mm512_add_epi64(refdislo, addnum);
-            refdislo = _mm512_srli_epi64(refdislo, 0x10);
-            refdishi = _mm512_add_epi64(refdishi, addnum);
-            refdishi = _mm512_srli_epi64(refdishi, 0x10);
-
-            _mm512_storeu_si512((__m512i *)(buf.ref_dis + (dst_stride * i) + j),
-                                _mm512_permutex2var_epi32(refdislo, mask5, refdishi));
+            vif_statistic_avx512(&residuals, xx, xy, yy, log2_table, vif_enhn_gain_limit);
         }
     }
+    accum_num_log = _mm512_reduce_add_epi64(residuals.maccum_num_log);
+    accum_den_log = _mm512_reduce_add_epi64(residuals.maccum_den_log);
+    accum_num_non_log = _mm512_reduce_add_epi64(residuals.maccum_num_non_log);
+    accum_den_non_log = _mm512_reduce_add_epi64(residuals.maccum_den_non_log);
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
 }
 
-void vif_filter1d_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
-                            int bpc)
-{
+void vif_statistic_16_avx512(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale) {
     const unsigned fwidth = vif_filter1d_width[scale];
     const uint16_t *vif_filt = vif_filter1d_table[scale];
+    VifBuffer buf = s->buf;
     const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
     const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
     int fwidth_half = fwidth >> 1;
@@ -1376,6 +363,23 @@ void vif_filter1d_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
     int32_t add_shift_round_HP, shift_HP;
     int32_t add_shift_round_VP, shift_VP;
     int32_t add_shift_round_VP_sq, shift_VP_sq;
+    const uint16_t *log2_table = s->log2_table;
+    double vif_enhn_gain_limit = s->vif_enhn_gain_limit;
+    __m512i mask2 = _mm512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+
+    //float equivalent of 2. (2 * 65536)
+    static const int32_t sigma_nsq = 65536 << 1;
+
+    Residuals512 residuals;
+    residuals.maccum_den_log = _mm512_setzero_si512();
+    residuals.maccum_num_log = _mm512_setzero_si512();
+    residuals.maccum_den_non_log = _mm512_setzero_si512();
+    residuals.maccum_num_non_log = _mm512_setzero_si512();
+
+    int64_t accum_num_log = 0;
+    int64_t accum_den_log = 0;
+    int64_t accum_num_non_log = 0;
+    int64_t accum_den_non_log = 0;
 
     if (scale == 0)
     {
@@ -1399,308 +403,337 @@ void vif_filter1d_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
     __m512i addnum = _mm512_set1_epi32(add_shift_round_VP);
     uint16_t *ref = buf.ref;
     uint16_t *dis = buf.dis;
-    __m512i mask2 = _mm512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
 
+    for (unsigned i = 0; i < h; ++i)
     {
-        for (unsigned i = 0; i < h; ++i)
+        //VERTICAL
+        int ii = i - fwidth_half;
+        int n = w >> 5;
+        for (unsigned j = 0; j < n << 5; j = j + 32)
         {
-            //VERTICAL
-            int ii = i - fwidth_half;
-            int n = w >> 5;
-            for (unsigned j = 0; j < n << 5; j = j + 32)
+
+            __m512i mask3 = _mm512_set_epi64(11, 10, 3, 2, 9, 8, 1, 0);   //first half of 512
+            __m512i mask4 = _mm512_set_epi64(15, 14, 7, 6, 13, 12, 5, 4); //second half of 512
+            int ii_check = ii;
+            __m512i accumr_lo, accumr_hi, accumd_lo, accumd_hi, rmul1, rmul2,
+                dmul1, dmul2, accumref1, accumref2, accumref3, accumref4,
+                accumrefdis1, accumrefdis2, accumrefdis3, accumrefdis4,
+                accumdis1, accumdis2, accumdis3, accumdis4;
+            accumr_lo = accumr_hi = accumd_lo = accumd_hi = rmul1 = rmul2 = dmul1 = dmul2 = accumref1 = accumref2 = accumref3 = accumref4 = accumrefdis1 = accumrefdis2 = accumrefdis3 =
+                accumrefdis4 = accumdis1 = accumdis2 = accumdis3 = accumdis4 = _mm512_setzero_si512();
+
+            for (unsigned fi = 0; fi < fwidth; ++fi, ii_check = ii + fi)
             {
 
-                __m512i mask3 = _mm512_set_epi64(11, 10, 3, 2, 9, 8, 1, 0);   //first half of 512
-                __m512i mask4 = _mm512_set_epi64(15, 14, 7, 6, 13, 12, 5, 4); //second half of 512
-                int ii_check = ii;
-                __m512i accumr_lo, accumr_hi, accumd_lo, accumd_hi, rmul1, rmul2,
-                    dmul1, dmul2, accumref1, accumref2, accumref3, accumref4,
-                    accumrefdis1, accumrefdis2, accumrefdis3, accumrefdis4,
-                    accumdis1, accumdis2, accumdis3, accumdis4;
-                accumr_lo = accumr_hi = accumd_lo = accumd_hi = rmul1 = rmul2 = dmul1 = dmul2 = accumref1 = accumref2 = accumref3 = accumref4 = accumrefdis1 = accumrefdis2 = accumrefdis3 =
-                    accumrefdis4 = accumdis1 = accumdis2 = accumdis3 = accumdis4 = _mm512_setzero_si512();
+                const uint16_t fcoeff = vif_filt[fi];
+                __m512i f1 = _mm512_set1_epi16(vif_filt[fi]);
+                __m512i ref1 = _mm512_loadu_si512(
+                    (__m512i*)(ref + (ii_check * stride) + j));
+                __m512i dis1 = _mm512_loadu_si512(
+                    (__m512i*)(dis + (ii_check * stride) + j));
+                __m512i result2 = _mm512_mulhi_epu16(ref1, f1);
+                __m512i result2lo = _mm512_mullo_epi16(ref1, f1);
+                __m512i rmult1 = _mm512_unpacklo_epi16(result2lo, result2);
+                __m512i rmult2 = _mm512_unpackhi_epi16(result2lo, result2);
+                rmul1 = _mm512_permutex2var_epi64(rmult1, mask3, rmult2);
+                rmul2 = _mm512_permutex2var_epi64(rmult1, mask4, rmult2);
+                accumr_lo = _mm512_add_epi32(accumr_lo, rmul1);
+                accumr_hi = _mm512_add_epi32(accumr_hi, rmul2);
+                __m512i d0 = _mm512_mulhi_epu16(dis1, f1);
+                __m512i d0lo = _mm512_mullo_epi16(dis1, f1);
+                __m512i dmult1 = _mm512_unpacklo_epi16(d0lo, d0);
+                __m512i dmult2 = _mm512_unpackhi_epi16(d0lo, d0);
+                dmul1 = _mm512_permutex2var_epi64(dmult1, mask3, dmult2);
+                dmul2 = _mm512_permutex2var_epi64(dmult1, mask4, dmult2);
+                accumd_lo = _mm512_add_epi32(accumd_lo, dmul1);
+                accumd_hi = _mm512_add_epi32(accumd_hi, dmul2);
 
-                for (unsigned fi = 0; fi < fwidth; ++fi, ii_check = ii + fi)
-                {
+                __m512i sg0 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(rmul1));
+                __m512i sg1 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(rmul1, 1));
+                __m512i sg2 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(rmul2));
+                __m512i sg3 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(rmul2, 1));
+                __m128i l0 = _mm512_castsi512_si128(ref1);
+                __m128i l1 = _mm512_extracti32x4_epi32(ref1, 1);
+                __m128i l2 = _mm512_extracti32x4_epi32(ref1, 2);
+                __m128i l3 = _mm512_extracti32x4_epi32(ref1, 3);
+                accumref1 = _mm512_add_epi64(accumref1,
+                    _mm512_mul_epu32(sg0, _mm512_cvtepu16_epi64(l0)));
+                accumref2 = _mm512_add_epi64(accumref2,
+                    _mm512_mul_epu32(sg2, _mm512_cvtepu16_epi64(l2)));
+                accumref3 = _mm512_add_epi64(accumref3,
+                    _mm512_mul_epu32(sg1, _mm512_cvtepu16_epi64(l1)));
+                accumref4 = _mm512_add_epi64(accumref4,
+                    _mm512_mul_epu32(sg3, _mm512_cvtepu16_epi64(l3)));
+                l0 = _mm512_castsi512_si128(dis1);
+                l1 = _mm512_extracti32x4_epi32(dis1, 1);
+                l2 = _mm512_extracti32x4_epi32(dis1, 2);
+                l3 = _mm512_extracti32x4_epi32(dis1, 3);
 
-                    const uint16_t fcoeff = vif_filt[fi];
-                    __m512i f1 = _mm512_set1_epi16(vif_filt[fi]);
-                    __m512i ref1 = _mm512_loadu_si512(
-                        (__m512i *)(ref + (ii_check * stride) + j));
-                    __m512i dis1 = _mm512_loadu_si512(
-                        (__m512i *)(dis + (ii_check * stride) + j));
-                    __m512i result2 = _mm512_mulhi_epu16(ref1, f1);
-                    __m512i result2lo = _mm512_mullo_epi16(ref1, f1);
-                    __m512i rmult1 = _mm512_unpacklo_epi16(result2lo, result2);
-                    __m512i rmult2 = _mm512_unpackhi_epi16(result2lo, result2);
-                    rmul1 = _mm512_permutex2var_epi64(rmult1, mask3, rmult2);
-                    rmul2 = _mm512_permutex2var_epi64(rmult1, mask4, rmult2);
-                    accumr_lo = _mm512_add_epi32(accumr_lo, rmul1);
-                    accumr_hi = _mm512_add_epi32(accumr_hi, rmul2);
-                    __m512i d0 = _mm512_mulhi_epu16(dis1, f1);
-                    __m512i d0lo = _mm512_mullo_epi16(dis1, f1);
-                    __m512i dmult1 = _mm512_unpacklo_epi16(d0lo, d0);
-                    __m512i dmult2 = _mm512_unpackhi_epi16(d0lo, d0);
-                    dmul1 = _mm512_permutex2var_epi64(dmult1, mask3, dmult2);
-                    dmul2 = _mm512_permutex2var_epi64(dmult1, mask4, dmult2);
-                    accumd_lo = _mm512_add_epi32(accumd_lo, dmul1);
-                    accumd_hi = _mm512_add_epi32(accumd_hi, dmul2);
-
-                    __m512i sg0 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(rmul1));
-                    __m512i sg1 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(rmul1, 1));
-                    __m512i sg2 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(rmul2));
-                    __m512i sg3 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(rmul2, 1));
-                    __m128i l0 = _mm512_castsi512_si128(ref1);
-                    __m128i l1 = _mm512_extracti32x4_epi32(ref1, 1);
-                    __m128i l2 = _mm512_extracti32x4_epi32(ref1, 2);
-                    __m128i l3 = _mm512_extracti32x4_epi32(ref1, 3);
-                    accumref1 = _mm512_add_epi64(accumref1,
-                                                 _mm512_mul_epu32(sg0, _mm512_cvtepu16_epi64(l0)));
-                    accumref2 = _mm512_add_epi64(accumref2,
-                                                 _mm512_mul_epu32(sg2, _mm512_cvtepu16_epi64(l2)));
-                    accumref3 = _mm512_add_epi64(accumref3,
-                                                 _mm512_mul_epu32(sg1, _mm512_cvtepu16_epi64(l1)));
-                    accumref4 = _mm512_add_epi64(accumref4,
-                                                 _mm512_mul_epu32(sg3, _mm512_cvtepu16_epi64(l3)));
-                    l0 = _mm512_castsi512_si128(dis1);
-                    l1 = _mm512_extracti32x4_epi32(dis1, 1);
-                    l2 = _mm512_extracti32x4_epi32(dis1, 2);
-                    l3 = _mm512_extracti32x4_epi32(dis1, 3);
-
-                    accumrefdis1 = _mm512_add_epi64(accumrefdis1,
-                                                    _mm512_mul_epu32(sg0, _mm512_cvtepu16_epi64(l0)));
-                    accumrefdis2 = _mm512_add_epi64(accumrefdis2,
-                                                    _mm512_mul_epu32(sg2, _mm512_cvtepu16_epi64(l2)));
-                    accumrefdis3 = _mm512_add_epi64(accumrefdis3,
-                                                    _mm512_mul_epu32(sg1, _mm512_cvtepu16_epi64(l1)));
-                    accumrefdis4 = _mm512_add_epi64(accumrefdis4,
-                                                    _mm512_mul_epu32(sg3, _mm512_cvtepu16_epi64(l3)));
-                    __m512i sd0 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(dmul1));
-                    __m512i sd1 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(dmul1, 1));
-                    __m512i sd2 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(dmul2));
-                    __m512i sd3 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(dmul2, 1));
-                    accumdis1 = _mm512_add_epi64(accumdis1,
-                                                 _mm512_mul_epu32(sd0, _mm512_cvtepu16_epi64(l0)));
-                    accumdis2 = _mm512_add_epi64(accumdis2,
-                                                 _mm512_mul_epu32(sd2, _mm512_cvtepu16_epi64(l2)));
-                    accumdis3 = _mm512_add_epi64(accumdis3,
-                                                 _mm512_mul_epu32(sd1, _mm512_cvtepu16_epi64(l1)));
-                    accumdis4 = _mm512_add_epi64(accumdis4,
-                                                 _mm512_mul_epu32(sd3, _mm512_cvtepu16_epi64(l3)));
-                }
-                accumr_lo = _mm512_add_epi32(accumr_lo, addnum);
-                accumr_hi = _mm512_add_epi32(accumr_hi, addnum);
-                accumr_lo = _mm512_srli_epi32(accumr_lo, shift_VP);
-                accumr_hi = _mm512_srli_epi32(accumr_hi, shift_VP);
-                _mm512_storeu_si512((__m512i *)(buf.tmp.mu1 + j), accumr_lo);
-                _mm512_storeu_si512((__m512i *)(buf.tmp.mu1 + j + 16), accumr_hi);
-
-                accumd_lo = _mm512_add_epi32(accumd_lo, addnum);
-                accumd_hi = _mm512_add_epi32(accumd_hi, addnum);
-                accumd_lo = _mm512_srli_epi32(accumd_lo, shift_VP);
-                accumd_hi = _mm512_srli_epi32(accumd_hi, shift_VP);
-                _mm512_storeu_si512((__m512i *)(buf.tmp.mu2 + j), accumd_lo);
-                _mm512_storeu_si512((__m512i *)(buf.tmp.mu2 + j + 16), accumd_hi);
-
-                accumref1 = _mm512_add_epi64(accumref1, addnum64);
-                accumref2 = _mm512_add_epi64(accumref2, addnum64);
-                accumref3 = _mm512_add_epi64(accumref3, addnum64);
-                accumref4 = _mm512_add_epi64(accumref4, addnum64);
-                accumref1 = _mm512_srli_epi64(accumref1, shift_VP_sq);
-                accumref2 = _mm512_srli_epi64(accumref2, shift_VP_sq);
-                accumref3 = _mm512_srli_epi64(accumref3, shift_VP_sq);
-                accumref4 = _mm512_srli_epi64(accumref4, shift_VP_sq);
-
-                _mm512_storeu_si512((__m512i *)(buf.tmp.ref + j),
-                                    _mm512_permutex2var_epi32(accumref1, mask2, accumref3));
-                _mm512_storeu_si512((__m512i *)(buf.tmp.ref + 16 + j),
-                                    _mm512_permutex2var_epi32(accumref2, mask2, accumref4));
-
-                accumrefdis1 = _mm512_add_epi64(accumrefdis1, addnum64);
-                accumrefdis2 = _mm512_add_epi64(accumrefdis2, addnum64);
-                accumrefdis3 = _mm512_add_epi64(accumrefdis3, addnum64);
-                accumrefdis4 = _mm512_add_epi64(accumrefdis4, addnum64);
-                accumrefdis1 = _mm512_srli_epi64(accumrefdis1, shift_VP_sq);
-                accumrefdis2 = _mm512_srli_epi64(accumrefdis2, shift_VP_sq);
-                accumrefdis3 = _mm512_srli_epi64(accumrefdis3, shift_VP_sq);
-                accumrefdis4 = _mm512_srli_epi64(accumrefdis4, shift_VP_sq);
-
-                _mm512_storeu_si512((__m512i *)(buf.tmp.ref_dis + j),
-                                    _mm512_permutex2var_epi32(accumrefdis1, mask2, accumrefdis3));
-                _mm512_storeu_si512((__m512i *)(buf.tmp.ref_dis + 16 + j),
-                                    _mm512_permutex2var_epi32(accumrefdis2, mask2, accumrefdis4));
-
-                accumdis1 = _mm512_add_epi64(accumdis1, addnum64);
-                accumdis2 = _mm512_add_epi64(accumdis2, addnum64);
-                accumdis3 = _mm512_add_epi64(accumdis3, addnum64);
-                accumdis4 = _mm512_add_epi64(accumdis4, addnum64);
-                accumdis1 = _mm512_srli_epi64(accumdis1, shift_VP_sq);
-                accumdis2 = _mm512_srli_epi64(accumdis2, shift_VP_sq);
-                accumdis3 = _mm512_srli_epi64(accumdis3, shift_VP_sq);
-                accumdis4 = _mm512_srli_epi64(accumdis4, shift_VP_sq);
-
-                _mm512_storeu_si512((__m512i *)(buf.tmp.dis + j),
-                                    _mm512_permutex2var_epi32(accumdis1, mask2, accumdis3));
-                _mm512_storeu_si512((__m512i *)(buf.tmp.dis + 16 + j),
-                                    _mm512_permutex2var_epi32(accumdis2, mask2, accumdis4));
+                accumrefdis1 = _mm512_add_epi64(accumrefdis1,
+                    _mm512_mul_epu32(sg0, _mm512_cvtepu16_epi64(l0)));
+                accumrefdis2 = _mm512_add_epi64(accumrefdis2,
+                    _mm512_mul_epu32(sg2, _mm512_cvtepu16_epi64(l2)));
+                accumrefdis3 = _mm512_add_epi64(accumrefdis3,
+                    _mm512_mul_epu32(sg1, _mm512_cvtepu16_epi64(l1)));
+                accumrefdis4 = _mm512_add_epi64(accumrefdis4,
+                    _mm512_mul_epu32(sg3, _mm512_cvtepu16_epi64(l3)));
+                __m512i sd0 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(dmul1));
+                __m512i sd1 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(dmul1, 1));
+                __m512i sd2 = _mm512_cvtepu32_epi64(_mm512_castsi512_si256(dmul2));
+                __m512i sd3 = _mm512_cvtepu32_epi64(_mm512_extracti64x4_epi64(dmul2, 1));
+                accumdis1 = _mm512_add_epi64(accumdis1,
+                    _mm512_mul_epu32(sd0, _mm512_cvtepu16_epi64(l0)));
+                accumdis2 = _mm512_add_epi64(accumdis2,
+                    _mm512_mul_epu32(sd2, _mm512_cvtepu16_epi64(l2)));
+                accumdis3 = _mm512_add_epi64(accumdis3,
+                    _mm512_mul_epu32(sd1, _mm512_cvtepu16_epi64(l1)));
+                accumdis4 = _mm512_add_epi64(accumdis4,
+                    _mm512_mul_epu32(sd3, _mm512_cvtepu16_epi64(l3)));
             }
+            accumr_lo = _mm512_add_epi32(accumr_lo, addnum);
+            accumr_hi = _mm512_add_epi32(accumr_hi, addnum);
+            accumr_lo = _mm512_srli_epi32(accumr_lo, shift_VP);
+            accumr_hi = _mm512_srli_epi32(accumr_hi, shift_VP);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu1 + j), accumr_lo);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu1 + j + 16), accumr_hi);
 
-            for (unsigned j = n << 5; j < w; ++j)
+            accumd_lo = _mm512_add_epi32(accumd_lo, addnum);
+            accumd_hi = _mm512_add_epi32(accumd_hi, addnum);
+            accumd_lo = _mm512_srli_epi32(accumd_lo, shift_VP);
+            accumd_hi = _mm512_srli_epi32(accumd_hi, shift_VP);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu2 + j), accumd_lo);
+            _mm512_storeu_si512((__m512i*)(buf.tmp.mu2 + j + 16), accumd_hi);
+
+            accumref1 = _mm512_add_epi64(accumref1, addnum64);
+            accumref2 = _mm512_add_epi64(accumref2, addnum64);
+            accumref3 = _mm512_add_epi64(accumref3, addnum64);
+            accumref4 = _mm512_add_epi64(accumref4, addnum64);
+            accumref1 = _mm512_srli_epi64(accumref1, shift_VP_sq);
+            accumref2 = _mm512_srli_epi64(accumref2, shift_VP_sq);
+            accumref3 = _mm512_srli_epi64(accumref3, shift_VP_sq);
+            accumref4 = _mm512_srli_epi64(accumref4, shift_VP_sq);
+
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref + j),
+                _mm512_permutex2var_epi32(accumref1, mask2, accumref3));
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref + 16 + j),
+                _mm512_permutex2var_epi32(accumref2, mask2, accumref4));
+
+            accumrefdis1 = _mm512_add_epi64(accumrefdis1, addnum64);
+            accumrefdis2 = _mm512_add_epi64(accumrefdis2, addnum64);
+            accumrefdis3 = _mm512_add_epi64(accumrefdis3, addnum64);
+            accumrefdis4 = _mm512_add_epi64(accumrefdis4, addnum64);
+            accumrefdis1 = _mm512_srli_epi64(accumrefdis1, shift_VP_sq);
+            accumrefdis2 = _mm512_srli_epi64(accumrefdis2, shift_VP_sq);
+            accumrefdis3 = _mm512_srli_epi64(accumrefdis3, shift_VP_sq);
+            accumrefdis4 = _mm512_srli_epi64(accumrefdis4, shift_VP_sq);
+
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref_dis + j),
+                _mm512_permutex2var_epi32(accumrefdis1, mask2, accumrefdis3));
+            _mm512_storeu_si512((__m512i*)(buf.tmp.ref_dis + 16 + j),
+                _mm512_permutex2var_epi32(accumrefdis2, mask2, accumrefdis4));
+
+            accumdis1 = _mm512_add_epi64(accumdis1, addnum64);
+            accumdis2 = _mm512_add_epi64(accumdis2, addnum64);
+            accumdis3 = _mm512_add_epi64(accumdis3, addnum64);
+            accumdis4 = _mm512_add_epi64(accumdis4, addnum64);
+            accumdis1 = _mm512_srli_epi64(accumdis1, shift_VP_sq);
+            accumdis2 = _mm512_srli_epi64(accumdis2, shift_VP_sq);
+            accumdis3 = _mm512_srli_epi64(accumdis3, shift_VP_sq);
+            accumdis4 = _mm512_srli_epi64(accumdis4, shift_VP_sq);
+
+            _mm512_storeu_si512((__m512i*)(buf.tmp.dis + j),
+                _mm512_permutex2var_epi32(accumdis1, mask2, accumdis3));
+            _mm512_storeu_si512((__m512i*)(buf.tmp.dis + 16 + j),
+                _mm512_permutex2var_epi32(accumdis2, mask2, accumdis4));
+        }
+
+        for (unsigned j = n << 5; j < w; ++j)
+        {
+            uint32_t accum_mu1 = 0;
+            uint32_t accum_mu2 = 0;
+            uint64_t accum_ref = 0;
+            uint64_t accum_dis = 0;
+            uint64_t accum_ref_dis = 0;
+            for (unsigned fi = 0; fi < fwidth; ++fi)
             {
-                uint32_t accum_mu1 = 0;
-                uint32_t accum_mu2 = 0;
-                uint64_t accum_ref = 0;
-                uint64_t accum_dis = 0;
-                uint64_t accum_ref_dis = 0;
-                for (unsigned fi = 0; fi < fwidth; ++fi)
-                {
-                    int ii = i - fwidth / 2;
-                    int ii_check = ii + fi;
-                    const uint16_t fcoeff = vif_filt[fi];
-                    const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
-                    uint16_t *ref = buf.ref;
-                    uint16_t *dis = buf.dis;
-                    uint16_t imgcoeff_ref = ref[ii_check * stride + j];
-                    uint16_t imgcoeff_dis = dis[ii_check * stride + j];
-                    uint32_t img_coeff_ref = fcoeff * (uint32_t)imgcoeff_ref;
-                    uint32_t img_coeff_dis = fcoeff * (uint32_t)imgcoeff_dis;
-                    accum_mu1 += img_coeff_ref;
-                    accum_mu2 += img_coeff_dis;
-                    accum_ref += img_coeff_ref * (uint64_t)imgcoeff_ref;
-                    accum_dis += img_coeff_dis * (uint64_t)imgcoeff_dis;
-                    accum_ref_dis += img_coeff_ref * (uint64_t)imgcoeff_dis;
-                }
-                buf.tmp.mu1[j] = (uint16_t)((accum_mu1 + add_shift_round_VP) >> shift_VP);
-                buf.tmp.mu2[j] = (uint16_t)((accum_mu2 + add_shift_round_VP) >> shift_VP);
-                buf.tmp.ref[j] = (uint32_t)((accum_ref + add_shift_round_VP_sq) >> shift_VP_sq);
-                buf.tmp.dis[j] = (uint32_t)((accum_dis + add_shift_round_VP_sq) >> shift_VP_sq);
-                buf.tmp.ref_dis[j] = (uint32_t)((accum_ref_dis + add_shift_round_VP_sq) >> shift_VP_sq);
+                int ii = i - fwidth / 2;
+                int ii_check = ii + fi;
+                const uint16_t fcoeff = vif_filt[fi];
+                const ptrdiff_t stride = buf.stride / sizeof(uint16_t);
+                uint16_t *ref = buf.ref;
+                uint16_t *dis = buf.dis;
+                uint16_t imgcoeff_ref = ref[ii_check * stride + j];
+                uint16_t imgcoeff_dis = dis[ii_check * stride + j];
+                uint32_t img_coeff_ref = fcoeff * (uint32_t)imgcoeff_ref;
+                uint32_t img_coeff_dis = fcoeff * (uint32_t)imgcoeff_dis;
+                accum_mu1 += img_coeff_ref;
+                accum_mu2 += img_coeff_dis;
+                accum_ref += img_coeff_ref * (uint64_t)imgcoeff_ref;
+                accum_dis += img_coeff_dis * (uint64_t)imgcoeff_dis;
+                accum_ref_dis += img_coeff_ref * (uint64_t)imgcoeff_dis;
             }
+            buf.tmp.mu1[j] = (uint16_t)((accum_mu1 + add_shift_round_VP) >> shift_VP);
+            buf.tmp.mu2[j] = (uint16_t)((accum_mu2 + add_shift_round_VP) >> shift_VP);
+            buf.tmp.ref[j] = (uint32_t)((accum_ref + add_shift_round_VP_sq) >> shift_VP_sq);
+            buf.tmp.dis[j] = (uint32_t)((accum_dis + add_shift_round_VP_sq) >> shift_VP_sq);
+            buf.tmp.ref_dis[j] = (uint32_t)((accum_ref_dis + add_shift_round_VP_sq) >> shift_VP_sq);
+        }
 
-            PADDING_SQ_DATA(buf, w, fwidth_half);
+        PADDING_SQ_DATA(buf, w, fwidth_half);
 
-            //HORIZONTAL
-            n = w >> 4;
-            for (unsigned j = 0; j < n << 4; j = j + 16)
+        //HORIZONTAL
+        n = w >> 4;
+        for (unsigned j = 0; j < n << 4; j = j + 16)
+        {
+            __m512i mu1sq;
+            __m512i mu2sq;
+            __m512i mu1mu2;
+            __m512i xx;
+            __m512i yy;
+            __m512i xy;
+            __m512i mask5 = _mm512_set_epi32(30, 28, 14, 12, 26, 24, 10, 8, 22, 20, 6, 4, 18, 16, 2, 0);
+            // compute mu1sq, mu2sq, mu1mu2
             {
-                int jj = j - fwidth_half;
-                int jj_check = jj;
-                __m512i accumdl, accumrlo, accumdlo, accumrhi, accumdhi;
-                accumrlo = accumdlo = accumrhi = accumdhi = _mm512_setzero_si512();
-                __m512i mask2 = _mm512_set_epi32(30, 28, 14, 12, 26, 24, 10, 8, 22, 20, 6, 4, 18, 16, 2, 0);
-#pragma unroll(4)
-                for (unsigned fj = 0; fj < fwidth; ++fj, jj_check = jj + fj)
-                {
+                __m512i fq = _mm512_set1_epi32(vif_filt[fwidth / 2]);
+                __m512i acc0 = _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j + 0)), fq);
+                __m512i acc1 = _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j + 0)), fq);
 
-                    __m512i refconvol = _mm512_loadu_si512((__m512i *)(buf.tmp.mu1 + jj_check));
-                    __m512i fcoeff = _mm512_set1_epi16(vif_filt[fj]);
-                    __m512i result2 = _mm512_mulhi_epu16(refconvol, fcoeff);
-                    __m512i result2lo = _mm512_mullo_epi16(refconvol, fcoeff);
-                    accumrlo = _mm512_add_epi32(accumrlo, _mm512_unpacklo_epi16(result2lo, result2));
-                    accumrhi = _mm512_add_epi32(accumrhi, _mm512_unpackhi_epi16(result2lo, result2));
-
-                    __m512i disconvol = _mm512_loadu_si512((__m512i *)(buf.tmp.mu2 + jj_check));
-                    result2 = _mm512_mulhi_epu16(disconvol, fcoeff);
-                    result2lo = _mm512_mullo_epi16(disconvol, fcoeff);
-                    accumdlo = _mm512_add_epi32(accumdlo,
-                                                _mm512_unpacklo_epi16(result2lo, result2));
-                    accumdhi = _mm512_add_epi32(accumdhi,
-                                                _mm512_unpackhi_epi16(result2lo, result2));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m512i fq = _mm512_set1_epi32(vif_filt[fj]);
+                    acc0 = _mm512_add_epi64(acc0, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j - fwidth / 2 + fj + 0)), fq));
+                    acc0 = _mm512_add_epi64(acc0, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu1 + j + fwidth / 2 - fj + 0)), fq));
+                    acc1 = _mm512_add_epi64(acc1, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j - fwidth / 2 + fj + 0)), fq));
+                    acc1 = _mm512_add_epi64(acc1, _mm512_mullo_epi32(_mm512_loadu_si512((__m512i*)(buf.tmp.mu2 + j + fwidth / 2 - fj + 0)), fq));
                 }
+                __m512i mu1 = acc0;
+                __m512i acc0_lo_512 = _mm512_unpacklo_epi32(acc0, _mm512_setzero_si512());
+                __m512i acc0_hi_512 = _mm512_unpackhi_epi32(acc0, _mm512_setzero_si512());
+                acc0_lo_512 = _mm512_mul_epu32(acc0_lo_512, acc0_lo_512);
+                acc0_hi_512 = _mm512_mul_epu32(acc0_hi_512, acc0_hi_512);
+                acc0_lo_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0_lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                acc0_hi_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0_hi_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu1sq = _mm512_permutex2var_epi32(acc0_lo_512, mask5, acc0_hi_512);
 
-                _mm512_storeu_si512((__m512i *)(buf.mu1_32 + (dst_stride * i) + j),
-                                    _mm512_permutex2var_epi32(accumrlo, mask2, accumrhi));
-                _mm512_storeu_si512((__m512i *)(buf.mu2_32 + (dst_stride * i) + j),
-                                    _mm512_permutex2var_epi32(accumdlo, mask2, accumdhi));
+                __m512i acc0lo_512 = _mm512_unpacklo_epi32(acc1, _mm512_setzero_si512());
+                __m512i acc0hi_512 = _mm512_unpackhi_epi32(acc1, _mm512_setzero_si512());
+                __m512i mu1lo_512 = _mm512_unpacklo_epi32(mu1, _mm512_setzero_si512());
+                __m512i mu1hi_512 = _mm512_unpackhi_epi32(mu1, _mm512_setzero_si512());
+
+                mu1lo_512 = _mm512_mul_epu32(mu1lo_512, acc0lo_512);
+                mu1hi_512 = _mm512_mul_epu32(mu1hi_512, acc0hi_512);
+                mu1lo_512 = _mm512_srli_epi64(_mm512_add_epi64(mu1lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu1hi_512 = _mm512_srli_epi64(_mm512_add_epi64(mu1hi_512, _mm512_set1_epi64(0x80000000)), 32);
+
+                mu1mu2 = _mm512_permutex2var_epi32(mu1lo_512, mask5, mu1hi_512);
+                acc0lo_512 = _mm512_mul_epu32(acc0lo_512, acc0lo_512);
+                acc0hi_512 = _mm512_mul_epu32(acc0hi_512, acc0hi_512);
+                acc0lo_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0lo_512, _mm512_set1_epi64(0x80000000)), 32);
+                acc0hi_512 = _mm512_srli_epi64(_mm512_add_epi64(acc0hi_512, _mm512_set1_epi64(0x80000000)), 32);
+                mu2sq = _mm512_permutex2var_epi32(acc0lo_512, mask5, acc0hi_512);
             }
 
-            for (unsigned j = 0; j < n << 4; j = j + 16)
+            // compute xx, yy, xy
             {
+                __m512i rounder = _mm512_set1_epi64(0x8000);
+                __m512i fq = _mm512_set1_epi64(vif_filt[fwidth / 2]);
+                __m512i s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 0))); // 4
+                __m512i s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + 8))); // 4
+                __m512i refsq_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i refsq_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                __m512i refdislo, refdishi, reflo, refhi, dislo, dishi;
-                refdislo = refdishi = reflo = refhi = dislo = dishi = _mm512_setzero_si512();
-                int jj = j - fwidth_half;
-                int jj_check = jj;
-                __m512i addnum = _mm512_set1_epi64(add_shift_round_HP);
-#pragma unroll(2)
-                for (unsigned fj = 0; fj < fwidth; fj = ++fj, jj_check = jj + fj)
-                {
+                s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 0))); // 4
+                s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + 8))); // 4
+                __m512i dissq_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i dissq_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                    __m512i f1 = _mm512_set1_epi64(vif_filt[fj]);
-                    __m512i s0 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.ref + jj_check)));
-                    reflo = _mm512_add_epi64(reflo, _mm512_mul_epu32(s0, f1));
-                    __m512i s3 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.ref + jj_check + 8)));
-                    refhi = _mm512_add_epi64(refhi, _mm512_mul_epu32(s3, f1));
+                s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 0))); // 4
+                s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + 8))); // 4
+                __m512i refdis_lo = _mm512_add_epi64(rounder, _mm512_mul_epu32(s0, fq));
+                __m512i refdis_hi = _mm512_add_epi64(rounder, _mm512_mul_epu32(s2, fq));
 
-                    __m512i g0 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.dis + jj_check)));
-                    dislo = _mm512_add_epi64(dislo, _mm512_mul_epu32(g0, f1));
-                    __m512i g3 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.dis + jj_check + 8)));
-                    dishi = _mm512_add_epi64(dishi, _mm512_mul_epu32(g3, f1));
+                for (unsigned fj = 0; fj < fwidth / 2; ++fj) {
+                    __m512i fq = _mm512_set1_epi64(vif_filt[fj]);
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j - fwidth / 2 + fj + 8))); // 4
+                    refsq_lo = _mm512_add_epi64(refsq_lo, _mm512_mul_epu32(s0, fq));
+                    refsq_hi = _mm512_add_epi64(refsq_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref + j + fwidth / 2 - fj + 8))); // 4
+                    refsq_lo = _mm512_add_epi64(refsq_lo, _mm512_mul_epu32(s0, fq));
+                    refsq_hi = _mm512_add_epi64(refsq_hi, _mm512_mul_epu32(s2, fq));
 
-                    __m512i sg0 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.ref_dis + jj_check)));
-                    refdislo = _mm512_add_epi64(refdislo, _mm512_mul_epu32(sg0, f1));
-                    __m512i sg3 = _mm512_cvtepu32_epi64(
-                        _mm256_loadu_si256((__m256i *)(buf.tmp.ref_dis + jj_check + 8)));
-                    refdishi = _mm512_add_epi64(refdishi, _mm512_mul_epu32(sg3, f1));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j - fwidth / 2 + fj + 8))); // 4
+                    dissq_lo = _mm512_add_epi64(dissq_lo, _mm512_mul_epu32(s0, fq));
+                    dissq_hi = _mm512_add_epi64(dissq_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.dis + j + fwidth / 2 - fj + 8))); // 4
+                    dissq_lo = _mm512_add_epi64(dissq_lo, _mm512_mul_epu32(s0, fq));
+                    dissq_hi = _mm512_add_epi64(dissq_hi, _mm512_mul_epu32(s2, fq));
+
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j - fwidth / 2 + fj + 8))); // 4
+                    refdis_lo = _mm512_add_epi64(refdis_lo, _mm512_mul_epu32(s0, fq));
+                    refdis_hi = _mm512_add_epi64(refdis_hi, _mm512_mul_epu32(s2, fq));
+                    s0 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 0))); // 4
+                    s2 = _mm512_cvtepu32_epi64(_mm256_loadu_si256((__m256i*)(buf.tmp.ref_dis + j + fwidth / 2 - fj + 8))); // 4
+                    refdis_lo = _mm512_add_epi64(refdis_lo, _mm512_mul_epu32(s0, fq));
+                    refdis_hi = _mm512_add_epi64(refdis_hi, _mm512_mul_epu32(s2, fq));
                 }
-                reflo = _mm512_add_epi64(reflo, addnum);
-                reflo = _mm512_srli_epi64(reflo, 0x10);
-                refhi = _mm512_add_epi64(refhi, addnum);
-                refhi = _mm512_srli_epi64(refhi, 0x10);
+                refsq_lo = _mm512_srli_epi64(refsq_lo, 16);
+                refsq_hi = _mm512_srli_epi64(refsq_hi, 16);
+                __m512i refsq = _mm512_permutex2var_epi32(refsq_lo, mask2, refsq_hi);
+                xx = _mm512_sub_epi32(refsq, mu1sq);
 
-                _mm512_storeu_si512((__m512i *)(buf.ref_sq + (dst_stride * i) + j),
-                                    _mm512_permutex2var_epi32(reflo, mask2, refhi));
+                dissq_lo = _mm512_srli_epi64(dissq_lo, 16);
+                dissq_hi = _mm512_srli_epi64(dissq_hi, 16);
+                __m512i dissq = _mm512_permutex2var_epi32(dissq_lo, mask2, dissq_hi);
+                yy = _mm512_max_epi32(_mm512_sub_epi32(dissq, mu2sq), _mm512_setzero_si512());
 
-                dislo = _mm512_add_epi64(dislo, addnum);
-                dislo = _mm512_srli_epi64(dislo, 0x10);
-                dishi = _mm512_add_epi64(dishi, addnum);
-                dishi = _mm512_srli_epi64(dishi, 0x10);
-                _mm512_storeu_si512((__m512i *)(buf.dis_sq + (dst_stride * i) + j),
-                                    _mm512_permutex2var_epi32(dislo, mask2, dishi));
-
-                refdislo = _mm512_add_epi64(refdislo, addnum);
-                refdislo = _mm512_srli_epi64(refdislo, 0x10);
-                refdishi = _mm512_add_epi64(refdishi, addnum);
-                refdishi = _mm512_srli_epi64(refdishi, 0x10);
-                _mm512_storeu_si512((__m512i *)(buf.ref_dis + (dst_stride * i) + j),
-                                    _mm512_permutex2var_epi32(refdislo, mask2, refdishi));
+                refdis_lo = _mm512_srli_epi64(refdis_lo, 16);
+                refdis_hi = _mm512_srli_epi64(refdis_hi, 16);
+                __m512i refdis = _mm512_permutex2var_epi32(refdis_lo, mask2, refdis_hi);
+                xy = _mm512_sub_epi32(refdis, mu1mu2);
             }
+            vif_statistic_avx512(&residuals, xx, xy, yy, log2_table, vif_enhn_gain_limit);
+        }
 
-            for (unsigned j = n << 4; j < w; ++j)
-            {
-                uint32_t accum_mu1 = 0;
-                uint32_t accum_mu2 = 0;
-                uint64_t accum_ref = 0;
-                uint64_t accum_dis = 0;
-                uint64_t accum_ref_dis = 0;
-                int jj = j - fwidth_half;
-                int jj_check = jj;
-                for (unsigned fj = 0; fj < fwidth; ++fj, jj_check = jj + fj)
-                {
-                    const uint16_t fcoeff = vif_filt[fj];
-                    accum_mu1 += fcoeff * ((uint32_t)buf.tmp.mu1[jj_check]);
-                    accum_mu2 += fcoeff * ((uint32_t)buf.tmp.mu2[jj_check]);
-                    accum_ref += fcoeff * ((uint64_t)buf.tmp.ref[jj_check]);
-                    accum_dis += fcoeff * ((uint64_t)buf.tmp.dis[jj_check]);
-                    accum_ref_dis += fcoeff * ((uint64_t)buf.tmp.ref_dis[jj_check]);
-                }
-                const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
-                buf.mu1_32[i * dst_stride + j] = accum_mu1;
-                buf.mu2_32[i * dst_stride + j] = accum_mu2;
-                buf.ref_sq[i * dst_stride + j] = (uint32_t)((accum_ref + add_shift_round_HP) >> shift_HP);
-                buf.dis_sq[i * dst_stride + j] = (uint32_t)((accum_dis + add_shift_round_HP) >> shift_HP);
-                buf.ref_dis[i * dst_stride + j] = (uint32_t)((accum_ref_dis + add_shift_round_HP) >> shift_HP);
-            }
+        if ((n << 4) != w) {
+            VifResiduals residuals =
+                vif_compute_line_residuals(s, n << 4, w, bpc, scale);
+            accum_num_log += residuals.accum_num_log;
+            accum_den_log += residuals.accum_den_log;
+            accum_num_non_log += residuals.accum_num_non_log;
+            accum_den_non_log += residuals.accum_den_non_log;
         }
     }
+
+    accum_num_log += _mm512_reduce_add_epi64(residuals.maccum_num_log);
+    accum_den_log += _mm512_reduce_add_epi64(residuals.maccum_den_log);
+    accum_num_non_log += _mm512_reduce_add_epi64(residuals.maccum_num_non_log);
+    accum_den_non_log += _mm512_reduce_add_epi64(residuals.maccum_den_non_log);
+
+
+    /**
+        * In floating-point there are two types of numerator scores and denominator scores
+        * 1. num = 1 - sigma1_sq * constant den =1  when sigma1_sq<2  here constant=4/(255*255)
+        * 2. num = log2(((sigma2_sq+2)*sigma1_sq)/((sigma2_sq+2)*sigma1_sq-sigma12*sigma12) den=log2(1+(sigma1_sq/2)) else
+        *
+        * In fixed-point separate accumulator is used for non-log score accumulations and log-based score accumulation
+        * For non-log accumulator of numerator, only sigma1_sq * constant in fixed-point is accumulated
+        * log based values are separately accumulated.
+        * While adding both accumulator values the non-log accumulator is converted such that it is equivalent to 1 - sigma1_sq * constant(1's are accumulated with non-log denominator accumulator)
+    */
+    //log has to be divided by 2048 as log_value = log2(i*2048)  i=16384 to 65535
+    //num[0] = accum_num_log / 2048.0 + (accum_den_non_log - (accum_num_non_log / 65536.0) / (255.0*255.0));
+    //den[0] = accum_den_log / 2048.0 + accum_den_non_log;
+
+    //changed calculation to increase performance
+    num[0] = accum_num_log / 2048.0 + (accum_den_non_log - ((accum_num_non_log) / 16384.0) / (65025.0));
+    den[0] = accum_den_log / 2048.0 + accum_den_non_log;
 }
 
-void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
+void vif_subsample_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
 {
     const unsigned fwidth = vif_filter1d_width[1];
     const uint16_t *vif_filt_s1 = vif_filter1d_table[1];
@@ -1709,14 +742,21 @@ void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
     const uint8_t *dis = (uint8_t *)buf.dis;
     const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
     __m512i addnum = _mm512_set1_epi32(32768);
-    __m512i mask1 = _mm512_set_epi16(60, 56, 28, 24, 52, 48, 20, 16, 44,
-                                     40, 12, 8, 36, 32, 4, 0, 60, 56, 28, 24,
-                                     52, 48, 20, 16, 44, 40, 12, 8, 36, 32, 4, 0);
+
+    // __m512i mask1 = _mm512_set_epi16(60, 56, 28, 24, 52, 48, 20, 16, 44,
+    //                                  40, 12, 8, 36, 32, 4, 0, 60, 56, 28, 24,
+    //                                  52, 48, 20, 16, 44, 40, 12, 8, 36, 32, 4, 0);
+    const int M = 1 << 16;
+    __m512i mask1 = _mm512_set_epi32(60 * M + 56, 28 * M + 24, 52 * M + 48, 20 * M + 16,
+                                     44 * M + 40, 12 * M +  8, 36 * M + 32,  4 * M +  0,
+                                     60 * M + 56, 28 * M + 24, 52 * M + 48, 20 * M + 16,
+                                     44 * M + 40, 12 * M +  8, 36 * M + 32,  4 * M +  0);
+
     __m512i x = _mm512_set1_epi32(128);
     __m512i mask2 = _mm512_set_epi64(11, 10, 3, 2, 9, 8, 1, 0);
     __m512i mask3 = _mm512_set_epi64(15, 14, 7, 6, 13, 12, 5, 4);
     int fwidth_half = fwidth >> 1;
-    __m512i f0, f1, f2, f3, f4, f5, f6, f7, f8;
+    __m512i f0, f1, f2, f3, f4;
 
     f0 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)vif_filt_s1));
     f1 = _mm512_broadcastd_epi32(_mm_loadu_si128((__m128i *)(vif_filt_s1 + 2)));
@@ -1743,8 +783,8 @@ void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
             accum_mu2_lo = accum_mu2_hi = accum_mu1_lo = accum_mu1_hi = _mm512_setzero_si512();
 
             {
-                __m512i g0, g1, g2, g3, g4, g5, g6, g7, g8, g9, g20, g21;
-                __m512i s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s20, s21, sg0, sg1;
+                __m512i g0, g1, g2, g3, g4, g5, g6, g7, g8, g9;
+                __m512i s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
                 g0 = _mm512_cvtepu8_epi16(_mm256_loadu_si256((__m256i *)(ref + (buf.stride * ii_check) + j)));
                 g1 = _mm512_cvtepu8_epi16(_mm256_loadu_si256((__m256i *)(ref + buf.stride * (ii_check) + buf.stride + j)));
@@ -1873,9 +913,8 @@ void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
         {
             int jj = j - fwidth_half;
             int jj_check = jj;
-            __m512i accumdl, accumrlo, accumdlo, accumrhi, accumdhi, padzero;
+            __m512i accumrlo, accumdlo, accumrhi, accumdhi, padzero;
             accumrlo = accumdlo = accumrhi = accumdhi = padzero = _mm512_setzero_si512();
-
             {
 
                 __m512i refconvol = _mm512_loadu_si512((__m512i *)(buf.tmp.ref_convol + jj_check));
@@ -2038,9 +1077,10 @@ void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h)
             buf.mu2[i * stride + j] = (uint16_t)((accum_dis + 32768) >> 16);
         }
     }
+    decimate_and_pad(buf, w, h, 0);
 }
 
-void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
+void vif_subsample_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
                                int bpc)
 {
     const unsigned fwidth = vif_filter1d_width[scale + 1];
@@ -2051,8 +1091,6 @@ void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
     const ptrdiff_t stride16 = buf.stride_16 / sizeof(uint16_t);
     uint16_t *ref = buf.ref;
     uint16_t *dis = buf.dis;
-    __m256i mask2 = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
-    __m256i mask1 = _mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0);
 
     if (scale == 0)
     {
@@ -2144,7 +1182,7 @@ void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
         {
             int jj = j - fwidth_half;
             int jj_check = jj;
-            __m512i accumdl, accumrlo, accumdlo, accumrhi, accumdhi;
+            __m512i accumrlo, accumdlo, accumrhi, accumdhi;
             accumrlo = accumdlo = accumrhi = accumdhi = _mm512_setzero_si512();
             const uint16_t *ref = (uint16_t *)buf.tmp.ref_convol;
             const uint16_t *dis = (uint16_t *)buf.dis;
@@ -2174,10 +1212,15 @@ void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
             accumrlo = _mm512_srli_epi32(accumrlo, 0x10);
             accumrhi = _mm512_srli_epi32(accumrhi, 0x10);
 
-            __m512i mask2 = _mm512_set_epi16(60, 56, 28, 24, 52, 48, 20, 16,
-                                             44, 40, 12, 8, 36, 32, 4, 0, 60,
-                                             56, 28, 24, 52, 48, 20, 16, 44,
-                                             40, 12, 8, 36, 32, 4, 0);
+            // __m512i mask2 = _mm512_set_epi16(60, 56, 28, 24, 52, 48, 20, 16, 44,
+            //                                  40, 12, 8, 36, 32, 4, 0, 60, 56, 28, 24,
+            //                                  52, 48, 20, 16, 44, 40, 12, 8, 36, 32, 4, 0);
+            const int M = 1 << 16;
+            __m512i mask2 = _mm512_set_epi32(60 * M + 56, 28 * M + 24, 52 * M + 48, 20 * M + 16,
+                                             44 * M + 40, 12 * M +  8, 36 * M + 32,  4 * M +  0,
+                                             60 * M + 56, 28 * M + 24, 52 * M + 48, 20 * M + 16,
+                                             44 * M + 40, 12 * M +  8, 36 * M + 32,  4 * M +  0);
+
             _mm256_storeu_si256((__m256i *)(buf.mu1 + (stride16 * i) + j),
                                 _mm512_castsi512_si256(_mm512_permutex2var_epi16(accumrlo, mask2, accumrhi)));
             _mm256_storeu_si256((__m256i *)(buf.mu2 + (stride16 * i) + j),
@@ -2200,4 +1243,5 @@ void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
             buf.mu2[i * stride16 + j] = (uint16_t)((accum_dis + 32768) >> 16);
         }
     }
+    decimate_and_pad(buf, w, h, scale);
 }

--- a/libvmaf/src/feature/x86/vif_avx512.h
+++ b/libvmaf/src/feature/x86/vif_avx512.h
@@ -21,14 +21,13 @@
 
 #include "feature/integer_vif.h"
 
-void vif_filter1d_8_avx512(VifBuffer buf, unsigned w, unsigned h);
+void vif_subsample_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h);
 
-void vif_filter1d_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h);
-
-void vif_filter1d_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
+void vif_subsample_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
                              int bpc);
 
-void vif_filter1d_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
-                            int bpc);
+void vif_statistic_8_avx512(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h);
+
+void vif_statistic_16_avx512(struct VifPublicState *s, float *num, float *den, unsigned w, unsigned h, int bpc, int scale);
 
 #endif /* X86_AVX512_VIF_H_ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -203,8 +203,8 @@ if is_asm_enabled
             'x86_avx512',
             x86_avx512_sources,
             include_directories : vmaf_base_include,
-            c_args : ['-mavx512f', '-mavx512dq', '-mavx512bw',
-                      '-mavx512vbmi', '-mavx512vbmi2', '-mavx512vl'] +
+            c_args : ['-mavx512f', '-mavx512dq', '-mavx512bw', '-mavx512cd', '-mavx512dq',
+                      '-mavx512vbmi', '-mavx512vl'] +
                      vmaf_cflags_common,
         )
 


### PR DESCRIPTION
This is a cleaned up, rebased and squashed version of #944. This performance bottleneck fix was identified and implemented by @foosoftsrl. Instead of a two-pass operation (filter, stats) now both operations have been pipelined and a costly second pass is not required. This is a significant contribution and the performance results speak for themselves. With AVX2 enabled, there is a **~16.6%** speedup over the master branch. The overall memory use is down by **~45%**. These gains come with no loss of numerical precision or inaccuracies. The following command was used to benchmark these changes. This is a 1920x1080 source with 130 frames. Thank you to @nilfm for the initial clean-up as well as very thoroughly testing the changes.

```
./build/tools/vmaf \
    --reference Sniper_1920x1080P_30fps_8bit.y4m \
    --distorted Sniper_1920x1080P_30fps_8bit.y4m.264.y4m
```
## CPU
| Command | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `./master.sh` | 13.014 ± 0.058 | 12.936 | 13.138 |
| `./vif_pipeline.sh` | 10.865 ± 0.032 | 10.823 | 10.925 |


## Memory
```
./master.sh: 133234688  maximum resident set size 
./vif_pipeline.sh: 87543808  maximum resident set size
```

## AVX-512
In addition to the AVX2 optimizations benchmarked above, there are also AVX-512 optimizations included in this PR. At the moment there have been some rare mismatches observed. Until those can mismatches can be addressed these optimizations have been disabled by default.

