### PR TITLE
libvmaf/motion: use single-channel buffers

### DIFF
--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -287,10 +287,10 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         return 0;
     }
 
-    err |= vmaf_picture_alloc(&s->tmp, pix_fmt, 16, w, h);
-    err |= vmaf_picture_alloc(&s->blur[0], pix_fmt, 16, w, h);
-    err |= vmaf_picture_alloc(&s->blur[1], pix_fmt, 16, w, h);
-    err |= vmaf_picture_alloc(&s->blur[2], pix_fmt, 16, w, h);
+    err |= vmaf_picture_alloc(&s->tmp, VMAF_PIX_FMT_YUV400P, 16, w, h);
+    err |= vmaf_picture_alloc(&s->blur[0], VMAF_PIX_FMT_YUV400P, 16, w, h);
+    err |= vmaf_picture_alloc(&s->blur[1], VMAF_PIX_FMT_YUV400P, 16, w, h);
+    err |= vmaf_picture_alloc(&s->blur[2], VMAF_PIX_FMT_YUV400P, 16, w, h);
     if (err) goto fail;
 
     s->y_convolution = bpc == 8 ? y_convolution_8 : y_convolution_16;


### PR DESCRIPTION
Gives a ~10% memory reduction for 1080p vmaf. No speed changes.

before:
87638016  maximum resident set size

after:
79347712  maximum resident set size