### PR TITLE
rename metrics to features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Also included in `libvmaf` are implementations of several other metrics: PSNR, P
 
 ## Documentation
 
-There is an [overview of the documentation](resource/doc/index.md) with links to specific pages, covering FAQs, available models and metrics, software usage guides, and a list of resources.
+There is an [overview of the documentation](resource/doc/index.md) with links to specific pages, covering FAQs, available models and features, software usage guides, and a list of resources.
 
 ## Usage
 
 The software package offers a number of ways to interact with the VMAF implementation.
 
-  - The command-line tool [`vmaf`](libvmaf/tools/README.md) provides a complete algorithm implementation, such that one can easily deploy VMAF in a production environment. Additionally, the `vmaf` tool provides a number of auxillary metrics such as PSNR, SSIM and MS-SSIM.
+  - The command-line tool [`vmaf`](libvmaf/tools/README.md) provides a complete algorithm implementation, such that one can easily deploy VMAF in a production environment. Additionally, the `vmaf` tool provides a number of auxillary features such as PSNR, SSIM and MS-SSIM.
   - The [C library `libvmaf`](libvmaf/README.md) provides an interface to incorporate VMAF into your code, and tools to integrate other feature extractors into the library.
   - The [Python library](resource/doc/python.md) offers a full array of wrapper classes and scripts for software testing, VMAF model training and validation, dataset processing, data visualization, etc.
   - VMAF is now included as a filter in FFmpeg, and can be configured using: `./configure --enable-libvmaf`. Refer to the [Using VMAF with FFmpeg](resource/doc/ffmpeg.md) page.

--- a/resource/doc/features.md
+++ b/resource/doc/features.md
@@ -1,8 +1,10 @@
-# Metrics
+# Features
 
-## Core metrics
+Features are individual inputs that (VMAF) models may use to fuse into a final quality metric score. Note that an existing quality metric can serve as a feature of a new quality metric. Features can also be enabled individually without fusing (e.g., when using VMAF via FFmpeg)."
 
-The following core metrics are part of the pre-trained VMAF models, and they have been introduced in the original [VMAF tech blog article](https://netflixtechblog.com/toward-a-practical-perceptual-video-quality-metric-653f208b9652) from 2016:
+## Core features
+
+The following core features are part of the pre-trained VMAF models, and they have been introduced in the original [VMAF tech blog article](https://netflixtechblog.com/toward-a-practical-perceptual-video-quality-metric-653f208b9652) from 2016:
 
 ### Visual Information Fidelity (VIF)
 
@@ -20,9 +22,9 @@ ADM was previously named Detail Loss Metric (DLM), described in S. Li, F. Zhang,
 
 DLM is an image quality metric based on the rationale of separately measuring the loss of details which affects the content visibility, and the redundant impairment which distracts viewer attention. The original metric combines both DLM and additive impairment measure (AIM) to yield a final score. In VMAF, only the DLM part is added as an elementary metric. Particular care was taken for special cases, such as black frames, where numerical calculations for the original formulation break down.
 
-## Additional metrics
+## Additional features
 
-The following additional metrics are available and explained on dedicated pages:
+The following additional features are available and explained on dedicated pages:
 
 - [CAMBI](cambi.md)
 - CIEDE2000

--- a/resource/doc/index.md
+++ b/resource/doc/index.md
@@ -6,10 +6,10 @@ This is an overview of the available documentation in the VMAF repository.
 
 - [FAQ](faq.md) – a collection of frequently asked questions
 
-## Models and Metrics
+## Models and Features
 
 - [Models](models.md) – a summary of the available pre-trained models
-- [Metrics](metrics.md) – VMAF's core metrics
+- [Features](features.md) – VMAF's core features (metrics)
 - [Datasets](datasets.md) – an overview of the two publicly available datasets for training custom models
 - [Confidence Interval](conf_interval.md) – how to use bootstrapping to provide CI estimates for VMAF scores
 - [Bad Cases](bad_cases.md) – how to report cases of VMAF not working well


### PR DESCRIPTION
"Metrics" is ambiguous. The term "features" should be consistently used.