### PR TITLE
integer_adm: add size check in init

### DIFF
--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -22,6 +22,7 @@
 #include "feature_extractor.h"
 #include "feature_name.h"
 #include "integer_adm.h"
+#include "log.h"
 
 #if ARCH_X86
 #include "x86/adm_avx2.h"
@@ -2579,6 +2580,14 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     AdmState *s = fex->priv;
     (void) pix_fmt;
     (void) bpc;
+
+    if (w <= 32 || h <= 32) {
+        vmaf_log(VMAF_LOG_LEVEL_ERROR,
+                 "%s: invalid size (%dx%d), "
+                 "width/height must be greater than 32\n",
+                 fex->name, w, h);
+        return -EINVAL;
+    }
 
     s->dwt2_8 = adm_dwt2_8;
 


### PR DESCRIPTION
Addresses #1035, avoids a segfault at very low resolutions. Note that ADM probably doesn't make sense as a metric at these very small patch sizes.