### PR TITLE
Add command line option --skip_ref_frame

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -25,8 +25,8 @@ enum {
     ARG_CPUMASK,
     ARG_AOM_CTC,
     ARG_FRAME_CNT,
-    ARG_SKIP_REF_FRAME,
-    ARG_SKIP_DIST_FRAME,
+    ARG_FRAME_SKIP_REF,
+    ARG_FRAME_SKIP_DIST,
 };
 
 static const struct option long_opts[] = {
@@ -48,8 +48,8 @@ static const struct option long_opts[] = {
     { "cpumask",          1, NULL, ARG_CPUMASK },
     { "aom_ctc",          1, NULL, ARG_AOM_CTC },
     { "frame_cnt",        1, NULL, ARG_FRAME_CNT },
-    { "skip_ref_frame",   1, NULL, ARG_SKIP_REF_FRAME },
-    { "skip_dist_frame",  1, NULL, ARG_SKIP_DIST_FRAME },
+    { "frame_skip_ref",   1, NULL, ARG_FRAME_SKIP_REF },
+    { "frame_skip_dist",  1, NULL, ARG_FRAME_SKIP_DIST },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { "quiet",            0, NULL, 'q' },
@@ -66,31 +66,31 @@ static void usage(const char *const app, const char *const reason, ...) {
     }
     fprintf(stderr, "Usage: %s [options]\n\n", app);
     fprintf(stderr, "Supported options:\n"
-            " --reference/-r $path:       path to reference .y4m or .yuv\n"
-            " --distorted/-d $path:       path to distorted .y4m or .yuv\n"
-            " --width/-w $unsigned:       width\n"
-            " --height/-h $unsigned:      height\n"
-            " --pixel_format/-p: $string  pixel format (420/422/444)\n"
-            " --bitdepth/-b $unsigned:    bitdepth (8/10/12/16)\n"
-            " --model/-m $params:         model parameters, colon \":\" delimited\n"
-            "                             `path=` path to model file\n"
-            "                             `version=` built-in model version\n"
-            "                             `name=` name used in log (optional)\n"
-            " --output/-o $path:          output file\n"
-            " --xml:                      write output file as XML (default)\n"
-            " --json:                     write output file as JSON\n"
-            " --csv:                      write output file as CSV\n"
-            " --sub:                      write output file as subtitle\n"
-            " --threads $unsigned:        number of threads to use\n"
-            " --feature $string:          additional feature\n"
-            " --cpumask: $bitmask         restrict permitted CPU instruction sets\n"
-            " --frame_cnt $unsigned:      maximum number of frames to process\n"
-            " --skip_ref_frame $unsigned: skip the first N frames in reference\n"
-            " --skip_dist_frame $unsigned:skip the first N frames in distorted\n"
-            " --subsample: $unsigned      compute scores only every N frames\n"
-            " --quiet/-q:                 disable FPS meter when run in a TTY\n"
-            " --no_prediction/-n:         no prediction, extract features only\n"
-            " --version/-v:               print version and exit\n"
+            " --reference/-r $path:        path to reference .y4m or .yuv\n"
+            " --distorted/-d $path:        path to distorted .y4m or .yuv\n"
+            " --width/-w $unsigned:        width\n"
+            " --height/-h $unsigned:       height\n"
+            " --pixel_format/-p: $string   pixel format (420/422/444)\n"
+            " --bitdepth/-b $unsigned:     bitdepth (8/10/12/16)\n"
+            " --model/-m $params:          model parameters, colon \":\" delimited\n"
+            "                              `path=` path to model file\n"
+            "                              `version=` built-in model version\n"
+            "                              `name=` name used in log (optional)\n"
+            " --output/-o $path:           output file\n"
+            " --xml:                       write output file as XML (default)\n"
+            " --json:                      write output file as JSON\n"
+            " --csv:                       write output file as CSV\n"
+            " --sub:                       write output file as subtitle\n"
+            " --threads $unsigned:         number of threads to use\n"
+            " --feature $string:           additional feature\n"
+            " --cpumask: $bitmask          restrict permitted CPU instruction sets\n"
+            " --frame_cnt $unsigned:       maximum number of frames to process\n"
+            " --frame_skip_ref $unsigned:  skip the first N frames in reference\n"
+            " --frame_skip_dist $unsigned: skip the first N frames in distorted\n"
+            " --subsample: $unsigned       compute scores only every N frames\n"
+            " --quiet/-q:                  disable FPS meter when run in a TTY\n"
+            " --no_prediction/-n:          no prediction, extract features only\n"
+            " --version/-v:                print version and exit\n"
            );
     exit(1);
 }
@@ -406,11 +406,11 @@ void cli_parse(const int argc, char *const *const argv,
             settings->frame_cnt =
                 parse_unsigned(optarg, ARG_FRAME_CNT, argv[0]);
             break;
-        case ARG_SKIP_REF_FRAME:
-            settings->skip_ref_frame = parse_unsigned(optarg, ARG_SKIP_REF_FRAME, argv[0]);
+        case ARG_FRAME_SKIP_REF:
+            settings->frame_skip_ref = parse_unsigned(optarg, ARG_FRAME_SKIP_REF, argv[0]);
             break;
-        case ARG_SKIP_DIST_FRAME:
-            settings->skip_dist_frame = parse_unsigned(optarg, ARG_SKIP_DIST_FRAME, argv[0]);
+        case ARG_FRAME_SKIP_DIST:
+            settings->frame_skip_dist = parse_unsigned(optarg, ARG_FRAME_SKIP_DIST, argv[0]);
             break;
         case 'n':
             settings->no_prediction = true;

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -25,6 +25,7 @@ enum {
     ARG_CPUMASK,
     ARG_AOM_CTC,
     ARG_FRAME_CNT,
+    ARG_SKIP_REF_FRAME,
 };
 
 static const struct option long_opts[] = {
@@ -46,6 +47,7 @@ static const struct option long_opts[] = {
     { "cpumask",          1, NULL, ARG_CPUMASK },
     { "aom_ctc",          1, NULL, ARG_AOM_CTC },
     { "frame_cnt",        1, NULL, ARG_FRAME_CNT },
+    { "skip_ref_frame",   1, NULL, ARG_SKIP_REF_FRAME },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { "quiet",            0, NULL, 'q' },
@@ -81,6 +83,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --feature $string:         additional feature\n"
             " --cpumask: $bitmask        restrict permitted CPU instruction sets\n"
             " --frame_cnt $unsigned:     maximum number of frames to process\n"
+            " --skip_ref_frame $unsigned:skip the first N frames in reference\n"
             " --subsample: $unsigned     compute scores only every N frames\n"
             " --quiet/-q:                disable FPS meter when run in a TTY\n"
             " --no_prediction/-n:        no prediction, extract features only\n"
@@ -399,6 +402,9 @@ void cli_parse(const int argc, char *const *const argv,
         case ARG_FRAME_CNT:
             settings->frame_cnt =
                 parse_unsigned(optarg, ARG_FRAME_CNT, argv[0]);
+            break;
+        case ARG_SKIP_REF_FRAME:
+            settings->skip_ref_frame = parse_unsigned(optarg, ARG_SKIP_REF_FRAME, argv[0]);
             break;
         case 'n':
             settings->no_prediction = true;

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -26,6 +26,7 @@ enum {
     ARG_AOM_CTC,
     ARG_FRAME_CNT,
     ARG_SKIP_REF_FRAME,
+    ARG_SKIP_DIST_FRAME,
 };
 
 static const struct option long_opts[] = {
@@ -48,6 +49,7 @@ static const struct option long_opts[] = {
     { "aom_ctc",          1, NULL, ARG_AOM_CTC },
     { "frame_cnt",        1, NULL, ARG_FRAME_CNT },
     { "skip_ref_frame",   1, NULL, ARG_SKIP_REF_FRAME },
+    { "skip_dist_frame",  1, NULL, ARG_SKIP_DIST_FRAME },
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { "quiet",            0, NULL, 'q' },
@@ -64,30 +66,31 @@ static void usage(const char *const app, const char *const reason, ...) {
     }
     fprintf(stderr, "Usage: %s [options]\n\n", app);
     fprintf(stderr, "Supported options:\n"
-            " --reference/-r $path:      path to reference .y4m or .yuv\n"
-            " --distorted/-d $path:      path to distorted .y4m or .yuv\n"
-            " --width/-w $unsigned:      width\n"
-            " --height/-h $unsigned:     height\n"
-            " --pixel_format/-p: $string pixel format (420/422/444)\n"
-            " --bitdepth/-b $unsigned:   bitdepth (8/10/12/16)\n"
-            " --model/-m $params:        model parameters, colon \":\" delimited\n"
-            "                            `path=` path to model file\n"
-            "                            `version=` built-in model version\n"
-            "                            `name=` name used in log (optional)\n"
-            " --output/-o $path:         output file\n"
-            " --xml:                     write output file as XML (default)\n"
-            " --json:                    write output file as JSON\n"
-            " --csv:                     write output file as CSV\n"
-            " --sub:                     write output file as subtitle\n"
-            " --threads $unsigned:       number of threads to use\n"
-            " --feature $string:         additional feature\n"
-            " --cpumask: $bitmask        restrict permitted CPU instruction sets\n"
-            " --frame_cnt $unsigned:     maximum number of frames to process\n"
-            " --skip_ref_frame $unsigned:skip the first N frames in reference\n"
-            " --subsample: $unsigned     compute scores only every N frames\n"
-            " --quiet/-q:                disable FPS meter when run in a TTY\n"
-            " --no_prediction/-n:        no prediction, extract features only\n"
-            " --version/-v:              print version and exit\n"
+            " --reference/-r $path:       path to reference .y4m or .yuv\n"
+            " --distorted/-d $path:       path to distorted .y4m or .yuv\n"
+            " --width/-w $unsigned:       width\n"
+            " --height/-h $unsigned:      height\n"
+            " --pixel_format/-p: $string  pixel format (420/422/444)\n"
+            " --bitdepth/-b $unsigned:    bitdepth (8/10/12/16)\n"
+            " --model/-m $params:         model parameters, colon \":\" delimited\n"
+            "                             `path=` path to model file\n"
+            "                             `version=` built-in model version\n"
+            "                             `name=` name used in log (optional)\n"
+            " --output/-o $path:          output file\n"
+            " --xml:                      write output file as XML (default)\n"
+            " --json:                     write output file as JSON\n"
+            " --csv:                      write output file as CSV\n"
+            " --sub:                      write output file as subtitle\n"
+            " --threads $unsigned:        number of threads to use\n"
+            " --feature $string:          additional feature\n"
+            " --cpumask: $bitmask         restrict permitted CPU instruction sets\n"
+            " --frame_cnt $unsigned:      maximum number of frames to process\n"
+            " --skip_ref_frame $unsigned: skip the first N frames in reference\n"
+            " --skip_dist_frame $unsigned:skip the first N frames in distorted\n"
+            " --subsample: $unsigned      compute scores only every N frames\n"
+            " --quiet/-q:                 disable FPS meter when run in a TTY\n"
+            " --no_prediction/-n:         no prediction, extract features only\n"
+            " --version/-v:               print version and exit\n"
            );
     exit(1);
 }
@@ -405,6 +408,9 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case ARG_SKIP_REF_FRAME:
             settings->skip_ref_frame = parse_unsigned(optarg, ARG_SKIP_REF_FRAME, argv[0]);
+            break;
+        case ARG_SKIP_DIST_FRAME:
+            settings->skip_dist_frame = parse_unsigned(optarg, ARG_SKIP_DIST_FRAME, argv[0]);
             break;
         case 'n':
             settings->no_prediction = true;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -30,6 +30,7 @@ typedef struct {
 
 typedef struct {
     char *path_ref, *path_dist;
+    unsigned skip_ref_frame;
     unsigned frame_cnt;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -30,8 +30,8 @@ typedef struct {
 
 typedef struct {
     char *path_ref, *path_dist;
-    unsigned skip_ref_frame;
-    unsigned skip_dist_frame;
+    unsigned frame_skip_ref;
+    unsigned frame_skip_dist;
     unsigned frame_cnt;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -31,6 +31,7 @@ typedef struct {
 typedef struct {
     char *path_ref, *path_dist;
     unsigned skip_ref_frame;
+    unsigned skip_dist_frame;
     unsigned frame_cnt;
     unsigned width, height;
     enum VmafPixelFormat pix_fmt;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -306,6 +306,14 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (c.skip_ref_frame > 0) {
+        printf("reference skip %d frames\n", c.skip_ref_frame);
+        for (unsigned i = 0; i < c.skip_ref_frame; i++) {
+            VmafPicture pic_ref;
+            fetch_picture(&vid_ref, &pic_ref);
+        }
+    }
+
     float fps = 0.;
     const time_t t0 = clock();
     unsigned picture_index;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -307,10 +307,17 @@ int main(int argc, char *argv[])
     }
 
     if (c.skip_ref_frame > 0) {
-        printf("reference skip %d frames\n", c.skip_ref_frame);
+        printf("skip %d frames in reference\n", c.skip_ref_frame);
         for (unsigned i = 0; i < c.skip_ref_frame; i++) {
             VmafPicture pic_ref;
             fetch_picture(&vid_ref, &pic_ref);
+        }
+    }
+    if (c.skip_dist_frame > 0) {
+        printf("skip %d frames in distorted\n", c.skip_dist_frame);
+        for (unsigned i = 0; i < c.skip_dist_frame; i++) {
+            VmafPicture pic_dist;
+            fetch_picture(&vid_dist, &pic_dist);
         }
     }
 

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -306,16 +306,16 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (c.skip_ref_frame > 0) {
-        printf("skip %d frames in reference\n", c.skip_ref_frame);
-        for (unsigned i = 0; i < c.skip_ref_frame; i++) {
+    if (c.frame_skip_ref > 0) {
+        printf("skip %d frames in reference\n", c.frame_skip_ref);
+        for (unsigned i = 0; i < c.frame_skip_ref; i++) {
             VmafPicture pic_ref;
             fetch_picture(&vid_ref, &pic_ref);
         }
     }
-    if (c.skip_dist_frame > 0) {
-        printf("skip %d frames in distorted\n", c.skip_dist_frame);
-        for (unsigned i = 0; i < c.skip_dist_frame; i++) {
+    if (c.frame_skip_dist > 0) {
+        printf("skip %d frames in distorted\n", c.frame_skip_dist);
+        for (unsigned i = 0; i < c.frame_skip_dist; i++) {
             VmafPicture pic_dist;
             fetch_picture(&vid_dist, &pic_dist);
         }


### PR DESCRIPTION
This command line option allows skipping the first N frame of the reference (source) when calculating VMAF, PSNR and other metrics. This is useful when only a clip of a source is coded and we need to calculate metrics only for the coded clip against the source. As --frame_cnt has been in the package, this PR is to address the case that the clip is not from the beginning of the source.