### PR TITLE
libvmaf/psnr_hvs: add bitdepth check during init

### DIFF
--- a/libvmaf/src/feature/third_party/xiph/psnr_hvs.c
+++ b/libvmaf/src/feature/third_party/xiph/psnr_hvs.c
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "feature_collector.h"
 #include "feature_extractor.h"
+#include "log.h"
 
 typedef int32_t od_coeff;
 
@@ -348,6 +349,14 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     (void) bpc;
     (void) w;
     (void) h;
+
+    if (bpc > 12) {
+        vmaf_log(VMAF_LOG_LEVEL_ERROR,
+                 "%s: invalid bitdepth (%d), "
+                 "bpc must be less than or equal to 12\n",
+                 fex->name, bpc);
+        return -EINVAL;
+    }
 
     if (pix_fmt == VMAF_PIX_FMT_YUV400P)
         return -EINVAL;


### PR DESCRIPTION
The xiph DCTs used in psnr_hvs were not designed for 16-bit input, and will overflow. This commit adds a check to fail for all bitdepths greater than 12. It may be possible to fix this with a different DCT, but in the meantime we will at least be guarded from bogus results. Partially addresses #1032.