### PR TITLE
Address a couple valgrind issues, use after free in predict.c::vmaf_p…

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -637,6 +637,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         5 * (s->public.buf.stride_32) + 7 * s->public.buf.stride_tmp;
     void *data = aligned_malloc(data_sz, MAX_ALIGN);
     if (!data) return -ENOMEM;
+    memset(data, 0, data_sz);
 
     s->public.buf.data = data; data += pad_size;
     s->public.buf.ref = data; data += frame_size + pad_size + pad_size;

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -284,14 +284,15 @@ int vmaf_predict_score_at_index(VmafModel *model,
         err = vmaf_feature_collector_get_score(feature_collector,
                                                feature_name, &feature_score,
                                                index);
-        free(feature_name);
 
         if (err) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,
                      "vmaf_predict_score_at_index(): no feature '%s' "
                      "at index %d\n", feature_name, index);
+            free(feature_name);
             goto free_node;
         }
+        free(feature_name);
 
         err = normalize(model, model->feature[i].slope,
                         model->feature[i].intercept, &feature_score);


### PR DESCRIPTION
Address a couple valgrind issues
- use after free in predict.c::vmaf_predict_score_at_index
- uninitialized memory in integer_vif.c::init

I am confident there are quit a few more (seems to be a log of allocs without memsets), these are just the ones exercised during my test