### PR TITLE
libvmaf/cpu: add vmaf_get_cpu_flags_arm

### DIFF
--- a/libvmaf/src/arm/cpu.c
+++ b/libvmaf/src/arm/cpu.c
@@ -1,6 +1,6 @@
 /**
  *
- *  Copyright 2016-2020 Netflix, Inc.
+ *  Copyright 2016-2022 Netflix, Inc.
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.
@@ -17,26 +17,15 @@
  */
 
 #include "config.h"
-#include "cpu.h"
 
-static unsigned flags = 0;
-static unsigned flags_mask = -1;
+#include "arm/cpu.h"
 
-void vmaf_init_cpu(void)
-{
-#if ARCH_X86
-    flags = vmaf_get_cpu_flags_x86();
-#elif ARCH_AARCH64
-    flags = vmaf_get_cpu_flags_arm();
+unsigned vmaf_get_cpu_flags_arm(void) {
+    unsigned flags = 0;
+
+#ifdef ARCH_AARCH64
+    flags |= VMAF_ARM_CPU_FLAG_NEON;
 #endif
-}
 
-void vmaf_set_cpu_flags_mask(const unsigned mask)
-{
-    flags_mask = mask;
-}
-
-unsigned vmaf_get_cpu_flags(void)
-{
-    return flags & flags_mask;
+    return flags;
 }

--- a/libvmaf/src/arm/cpu.h
+++ b/libvmaf/src/arm/cpu.h
@@ -1,6 +1,6 @@
 /**
  *
- *  Copyright 2016-2020 Netflix, Inc.
+ *  Copyright 2016-2022 Netflix, Inc.
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.
@@ -16,27 +16,13 @@
  *
  */
 
-#include "config.h"
-#include "cpu.h"
+#ifndef __VMAF_SRC_ARM_CPU_H__
+#define __VMAF_SRC_ARM_CPU_H__
 
-static unsigned flags = 0;
-static unsigned flags_mask = -1;
+enum CpuFlags {
+    VMAF_ARM_CPU_FLAG_NEON = 1 << 0,
+};
 
-void vmaf_init_cpu(void)
-{
-#if ARCH_X86
-    flags = vmaf_get_cpu_flags_x86();
-#elif ARCH_AARCH64
-    flags = vmaf_get_cpu_flags_arm();
-#endif
-}
+unsigned vmaf_get_cpu_flags_arm(void);
 
-void vmaf_set_cpu_flags_mask(const unsigned mask)
-{
-    flags_mask = mask;
-}
-
-unsigned vmaf_get_cpu_flags(void)
-{
-    return flags & flags_mask;
-}
+#endif /* __VMAF_SRC_ARM_CPU_H__ */

--- a/libvmaf/src/cpu.h
+++ b/libvmaf/src/cpu.h
@@ -27,6 +27,8 @@ extern "C" {
 
 #if ARCH_X86
 #include "x86/cpu.h"
+#elif ARCH_AARCH64
+#include "arm/cpu.h"
 #endif
 
 void vmaf_init_cpu(void);

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -2600,8 +2600,10 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         if (!(w % 8)) s->dwt2_8 = adm_dwt2_8_avx2;
     }
 #elif ARCH_AARCH64
-    if (!(w % 8))
-        s->dwt2_8 = adm_dwt2_8_neon;
+    unsigned flags = vmaf_get_cpu_flags();
+    if (flags & VMAF_ARM_CPU_FLAG_NEON) {
+        if (!(w % 8)) s->dwt2_8 = adm_dwt2_8_neon;
+    }
 #endif
 
     s->integer_stride   = ALIGN_CEIL(w * sizeof(int32_t));

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -621,10 +621,13 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 #endif
 */
 #elif ARCH_AARCH64
-    s->subsample_rd_8 = vif_subsample_rd_8_neon;
-    s->subsample_rd_16 = vif_subsample_rd_16_neon;
-    s->vif_statistic_8 = vif_statistic_8_neon;
-    s->vif_statistic_16 = vif_statistic_16_neon;
+    unsigned flags = vmaf_get_cpu_flags();
+    if (flags & VMAF_ARM_CPU_FLAG_NEON) {
+        s->subsample_rd_8 = vif_subsample_rd_8_neon;
+        s->subsample_rd_16 = vif_subsample_rd_16_neon;
+        s->vif_statistic_8 = vif_statistic_8_neon;
+        s->vif_statistic_16 = vif_statistic_16_neon;
+    }
 #endif
 
     log_generate(s->public.log2_table);

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -32,7 +32,7 @@ is_asm_enabled = get_option('enable_asm') == true
 is_avx512_enabled = get_option('enable_avx512') == true
 
 if is_asm_enabled
-    if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64') 
+    if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64')
         cdata.set10('HAVE_ASM', is_asm_enabled)
         cdata.set10('ARCH_AARCH64', host_machine.cpu_family() == 'aarch64' or host_machine.cpu() == 'arm64')
         cdata.set10('ARCH_ARM',     host_machine.cpu_family().startswith('arm') and host_machine.cpu() != 'arm64')
@@ -42,7 +42,7 @@ if is_asm_enabled
         else
             asm_format = 'elf'
         endif
-    endif    
+    endif
 
     if host_machine.cpu_family().startswith('x86')
         cdata.set10('HAVE_ASM', is_asm_enabled)
@@ -168,6 +168,12 @@ if is_asm_enabled
             src_dir + 'x86/cpu.c',
         )
     endif
+
+    if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64')
+        libvmaf_cpu_sources += files(
+            src_dir + 'arm/cpu.c',
+        )
+    endif
 endif
 
 libvmaf_include = include_directories(
@@ -187,7 +193,7 @@ libvmaf_cpu_static_lib = static_library(
 platform_specific_cpu_objects = []
 
 if is_asm_enabled
-    if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64') 
+    if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64')
         arm64_sources = [
           feature_src_dir + 'arm64/vif_neon.c',
           feature_src_dir + 'arm64/adm_neon.c',
@@ -197,11 +203,11 @@ if is_asm_enabled
           'arm64_v8',
           arm64_sources,
           include_directories : vmaf_base_include,
-          c_args : vmaf_cflags_common + ['-DARCH_AARCH64'] 
+          c_args : vmaf_cflags_common + ['-DARCH_AARCH64']
         )
 
         platform_specific_cpu_objects += arm64_static_lib.extract_all_objects()
-    endif      
+    endif
 
     if host_machine.cpu_family().startswith('x86')
       x86_avx2_sources = [


### PR DESCRIPTION
This PR adds the ability to mask arm64 NEON optimizations at runtime. This is something that we already have for x86, and it is useful for debugging/benchmarking. This feature can be tested with the following command-line:


```sh
./build/tools/vmaf \
    --reference ducks_take_off_1080p50.y4m \
    --distorted ducks_take_off_1080p50.y4m.264.y4m \
    --cpumask -1
```

fyi @RonenGvili
