### PR TITLE
test_model: fix out of tree testing

### DIFF
--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -38,7 +38,7 @@ test_model = executable('test_model',
     ['test.c', 'test_model.c', '../src/dict.c', '../src/svm.cpp', '../src/pdjson.c', '../src/read_json_model.c', '../src/log.c', json_model_c_sources],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
-    c_args : vmaf_cflags_common,
+    c_args : [vmaf_cflags_common, '-DJSON_MODEL_PATH="'+join_paths(meson.project_source_root(), '../model/')+'"'],
     cpp_args : vmaf_cflags_common,
     dependencies : thread_lib,
 )

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -70,7 +70,7 @@ static char *test_json_model()
 
     VmafModel *model_json;
     VmafModelConfig cfg_json = { 0 };
-    const char *path_json = "../../model/vmaf_v0.6.1neg.json";
+    const char *path_json = JSON_MODEL_PATH"vmaf_v0.6.1neg.json";
 
     err = vmaf_read_json_model_from_path(&model_json, &cfg_json, path_json);
     mu_assert("problem during vmaf_read_json_model", !err);
@@ -103,7 +103,7 @@ static char *test_built_in_model()
 
     VmafModel *model_file;
     VmafModelConfig cfg_file = { 0 };
-    const char *path = "../../model/vmaf_v0.6.1neg.json";
+    const char *path = JSON_MODEL_PATH"vmaf_v0.6.1neg.json";
     err = vmaf_model_load_from_path(&model_file, &cfg_file, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
 
@@ -122,7 +122,7 @@ static char *test_model_load_and_destroy()
 
     VmafModel *model;
     VmafModelConfig cfg = { 0 };
-    const char *path = "../../model/vmaf_float_v0.6.1.json";
+    const char *path = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
 
@@ -234,7 +234,7 @@ static char *test_model_check_default_behavior_unset_flags()
     VmafModelConfig cfg = {
         .name = "some_vmaf",
     };
-    const char *path = "../../model/vmaf_float_v0.6.1.json";
+    const char *path = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Model name is inconsistent.\n", !strcmp(model->name, "some_vmaf"));
@@ -258,7 +258,7 @@ static char *test_model_check_default_behavior_set_flags()
         .name = "some_vmaf",
         .flags = VMAF_MODEL_FLAGS_DEFAULT,
     };
-    const char *path = "../../model/vmaf_float_v0.6.1.json";
+    const char *path = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model, &cfg, path);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Model name is inconsistent.\n", !strcmp(model->name, "some_vmaf"));
@@ -281,7 +281,7 @@ static char *test_model_set_flags()
     VmafModelConfig cfg1 = {
         .flags = VMAF_MODEL_FLAG_ENABLE_TRANSFORM,
     };
-    const char *path1 = "../../model/vmaf_float_v0.6.1.json";
+    const char *path1 = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model1, &cfg1, path1);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Score transform must be enabled.\n",
@@ -294,7 +294,7 @@ static char *test_model_set_flags()
     VmafModelConfig cfg2 = {
         .flags = VMAF_MODEL_FLAG_DISABLE_CLIP,
     };
-    const char *path2 = "../../model/vmaf_float_v0.6.1.json";
+    const char *path2 = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model2, &cfg2, path2);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("Score transform must be disabled.\n",
@@ -305,7 +305,7 @@ static char *test_model_set_flags()
 
     VmafModel  *model3;
     VmafModelConfig  cfg3 = { 0 };
-    const char *path3 = "../../model/vmaf_float_v0.6.1.json";
+    const char *path3 = JSON_MODEL_PATH"vmaf_float_v0.6.1.json";
     err = vmaf_model_load_from_path(&model3, &cfg3, path3);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("feature[0].opts_dict must be NULL.\n",
@@ -324,7 +324,7 @@ static char *test_model_set_flags()
 
     VmafModel  *model4;
     VmafModelConfig  cfg4 = { 0 };
-    const char *path4 = "../../model/vmaf_float_v0.6.1neg.json";
+    const char *path4 = JSON_MODEL_PATH"vmaf_float_v0.6.1neg.json";
     err = vmaf_model_load_from_path(&model4, &cfg4, path4);
     mu_assert("problem during vmaf_model_load_from_path", !err);
     mu_assert("feature[0].opts_dict must not be NULL.\n",


### PR DESCRIPTION
Fixes testing out of tree (i.e.: when builddir is not subdir of libvmaf dir) by defining the path to the model dir contained in vmaf project relative to meson.project_source_root.