### PR TITLE
fix memory leak by freeing frame when one stream ends before the other

### DIFF
--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -334,10 +334,12 @@ int main(int argc, char *argv[])
         } else if (ret1) {
             fprintf(stderr, "\n\"%s\" ended before \"%s\".\n",
                     c.path_ref, c.path_dist);
+            int err = vmaf_picture_unref(&pic_dist);
             break;
         } else if (ret2) {
             fprintf(stderr, "\n\"%s\" ended before \"%s\".\n",
                     c.path_dist, c.path_ref);
+            int err = vmaf_picture_unref(&pic_ref);
             break;
         }
 


### PR DESCRIPTION
During the process of developing and testing another feature extractor we encountered a memory leak in valgrind in cases where two inputs have unequal number of frames.

Co-authored-by: RakshithGB <luckydudefeelinggreat@gmail.com>