### PR TITLE
CUDA api updates, introduce vmaf_cuda_state.h

### DIFF
--- a/libvmaf/include/libvmaf/vmaf_cuda.h
+++ b/libvmaf/include/libvmaf/vmaf_cuda.h
@@ -21,7 +21,6 @@
 
 #include "libvmaf/libvmaf.h"
 
-#if HAVE_CUDA
 #include <cuda.h>
 
 #ifdef __cplusplus
@@ -86,8 +85,6 @@ int vmaf_cuda_fetch_preallocated_picture(VmafContext *vmaf, VmafPicture* pic);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif
 
 #endif /* __VMAF_CUDA_H__ */

--- a/libvmaf/include/libvmaf/vmaf_cuda.h
+++ b/libvmaf/include/libvmaf/vmaf_cuda.h
@@ -21,8 +21,6 @@
 
 #include "libvmaf/libvmaf.h"
 
-#include <cuda.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -45,11 +43,7 @@ typedef struct VmafCudaConfiguration {
     int stream_priority;
 } VmafCudaConfiguration;
 
-typedef struct VmafCudaState {
-    CUcontext ctx;
-    CUstream str;
-    CUdevice dev;
-} VmafCudaState;
+typedef struct VmafCudaState VmafCudaState;
 
 /**
  * Initialize and provide access to VmafCudaState.

--- a/libvmaf/include/libvmaf/vmaf_cuda_state.h
+++ b/libvmaf/include/libvmaf/vmaf_cuda_state.h
@@ -1,0 +1,38 @@
+/**
+ *
+ *  Copyright 2016-2022 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_CUDA_STATE_H__
+#define __VMAF_CUDA_STATE_H__
+
+#include <cuda.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VmafCudaState {
+    CUcontext ctx;
+    CUstream str;
+    CUdevice dev;
+} VmafCudaState;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __VMAF_CUDA_STATE_H__ */

--- a/libvmaf/src/cuda/common.c
+++ b/libvmaf/src/cuda/common.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "common.h"
+#include "libvmaf/vmaf_cuda_state.h"
 #include "log.h"
 
 int vmaf_cuda_state_init(VmafCudaState *cu_state, int prio, int device_id)

--- a/libvmaf/src/cuda/picture_cuda.c
+++ b/libvmaf/src/cuda/picture_cuda.c
@@ -20,8 +20,10 @@
 #include "mem.h"
 #include "picture_cuda.h"
 #include "common.h"
+#include "libvmaf/vmaf_cuda_state.h"
 #include "log.h"
 
+#include <cuda.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/libvmaf/src/feature/integer_adm_cuda.c
+++ b/libvmaf/src/feature/integer_adm_cuda.c
@@ -19,9 +19,10 @@
 
 #include "common.h"
 #include <stdio.h>
-#define HAVE_CUDA
+
 #include "cuda_helper.cuh"
 #include "mem.h"
+#include "libvmaf/vmaf_cuda_state.h"
 
 #include "feature_collector.h"
 #include "feature_extractor.h"

--- a/libvmaf/src/feature/integer_motion_cuda.c
+++ b/libvmaf/src/feature/integer_motion_cuda.c
@@ -28,6 +28,7 @@
 #include "feature_name.h"
 #include "integer_motion_cuda.h"
 #include "integer_motion_kernels.h"
+#include "libvmaf/vmaf_cuda_state.h"
 #include "mem.h"
 #include "picture.h"
 #include "picture_cuda.h"

--- a/libvmaf/src/feature/integer_vif_cuda.h
+++ b/libvmaf/src/feature/integer_vif_cuda.h
@@ -21,8 +21,10 @@
 #define FEATURE_VIF_CUDA_H_
 
 #include <stdint.h>
+#include "libvmaf/vmaf_cuda_state.h"
 #include "integer_vif.h"
 #include "common.h"
+
 
 /* Enhancement gain imposed on vif, must be >= 1.0, where 1.0 means the gain is completely disabled */
 #ifndef DEFAULT_VIF_ENHN_GAIN_LIMIT

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -48,6 +48,7 @@
 
 #ifdef HAVE_CUDA
 #include "libvmaf/vmaf_cuda.h"
+#include "libvmaf/vmaf_cuda_state.h"
 #include "cuda/cuda_helper.cuh"
 #include "cuda/picture_cuda.h"
 #include "cuda/common.h"

--- a/libvmaf/src/picture.h
+++ b/libvmaf/src/picture.h
@@ -20,6 +20,7 @@
 #define __VMAF_SRC_PICTURE_H__
 
 #ifdef HAVE_CUDA
+#include <cuda.h>
 #include "libvmaf/vmaf_cuda.h"
 #endif
 #include "libvmaf/picture.h"

--- a/libvmaf/test/test_ring_buffer.c
+++ b/libvmaf/test/test_ring_buffer.c
@@ -26,6 +26,7 @@
 #include "test.h"
 #include "ring_buffer.h"
 #include "libvmaf/vmaf_cuda.h"
+#include "libvmaf/vmaf_cuda_state.h"
 #include "thread_pool.h"
 #include "cuda/common.h"
 #include "cuda/picture_cuda.h"


### PR DESCRIPTION
Two small updates:

- 3597d3665b473955979c8026ac3867fdf68eb341 avoids an unnecessary HAVE_CUDA macro
-   292598df547ed9e7a947e70767b497bac7f9a9b0 moves VmafCudaState to a separate header, this makes it possible to use cuda features without the inclusion of the `<cuda.h>` header, which complicates integration in some applications.