### PR TITLE
libvmaf/cuda: gpumask logic, enable parallel cpu/gpu feature extraction

### DIFF
--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -159,13 +159,12 @@ int vmaf_model_feature_overload(VmafModel *model, const char *feature_name,
 
     for (unsigned i = 0; i < model->n_features; i++) {
         VmafFeatureExtractor *fex =
-            vmaf_get_feature_extractor_by_feature_name(model->feature[i].name , 1); //FIXME
+            vmaf_get_feature_extractor_by_feature_name(model->feature[i].name, 0);
         if (!fex) continue;
         if (strcmp(feature_name, fex->name)) continue;
         VmafDictionary *d =
             vmaf_dictionary_merge((VmafDictionary**)&model->feature[i].opts_dict,
-                                  (VmafDictionary**)&opts_dict,
-                                  0);
+                                  (VmafDictionary**)&opts_dict, 0);
         if (!d) return -ENOMEM;
         err = vmaf_dictionary_free(&model->feature[i].opts_dict);
         if (err) goto exit;

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -240,7 +240,7 @@ int vmaf_predict_score_at_index(VmafModel *model,
 
     for (unsigned i = 0; i < model->n_features; i++) {
         VmafFeatureExtractor *fex =
-            vmaf_get_feature_extractor_by_feature_name(model->feature[i].name, 1);
+            vmaf_get_feature_extractor_by_feature_name(model->feature[i].name, 0);
 
         if (!fex) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "config.h"
 #include "dict.h"
 #include "feature/feature_extractor.h"
 #include "feature/feature_collector.h"
@@ -35,10 +36,18 @@ static char *test_get_feature_extractor_by_name_and_feature_name()
     mu_assert("problem vmaf_get_feature_extractor_by_name",
               !strcmp(fex->name, "vif"));
 
-    fex =
-        vmaf_get_feature_extractor_by_feature_name("VMAF_integer_feature_adm2_score" , 0);
+    fex = vmaf_get_feature_extractor_by_feature_name(
+            "VMAF_integer_feature_adm2_score", 0);
     mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
               fex && !strcmp(fex->name, "adm"));
+
+#if HAVE_CUDA
+    unsigned flags = VMAF_FEATURE_EXTRACTOR_CUDA;
+    fex = vmaf_get_feature_extractor_by_feature_name(
+            "VMAF_integer_feature_adm2_score", flags);
+    mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
+              fex && !strcmp(fex->name, "adm_cuda"));
+#endif
 
     return NULL;
 }

--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -23,6 +23,7 @@ enum {
     ARG_FEATURE,
     ARG_SUBSAMPLE,
     ARG_CPUMASK,
+    ARG_GPUMASK,
     ARG_AOM_CTC,
     ARG_FRAME_CNT,
     ARG_FRAME_SKIP_REF,
@@ -46,6 +47,7 @@ static const struct option long_opts[] = {
     { "feature",          1, NULL, ARG_FEATURE },
     { "subsample",        1, NULL, ARG_SUBSAMPLE },
     { "cpumask",          1, NULL, ARG_CPUMASK },
+    { "gpumask",          1, NULL, ARG_GPUMASK },
     { "aom_ctc",          1, NULL, ARG_AOM_CTC },
     { "frame_cnt",        1, NULL, ARG_FRAME_CNT },
     { "frame_skip_ref",   1, NULL, ARG_FRAME_SKIP_REF },
@@ -53,7 +55,6 @@ static const struct option long_opts[] = {
     { "no_prediction",    0, NULL, 'n' },
     { "version",          0, NULL, 'v' },
     { "quiet",            0, NULL, 'q' },
-    { "cuda",             0, NULL, 'c' },
     { NULL,               0, NULL, 0 },
 };
 
@@ -85,6 +86,7 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --threads $unsigned:         number of threads to use\n"
             " --feature $string:           additional feature\n"
             " --cpumask: $bitmask          restrict permitted CPU instruction sets\n"
+            " --gpumask: $bitmask          restrict permitted GPU instruction sets\n"
             " --frame_cnt $unsigned:       maximum number of frames to process\n"
             " --frame_skip_ref $unsigned:  skip the first N frames in reference\n"
             " --frame_skip_dist $unsigned: skip the first N frames in distorted\n"
@@ -92,7 +94,6 @@ static void usage(const char *const app, const char *const reason, ...) {
             " --quiet/-q:                  disable FPS meter when run in a TTY\n"
             " --no_prediction/-n:          no prediction, extract features only\n"
             " --version/-v:                print version and exit\n"
-            " --cuda/-c:                   activate gpu processing\n"
            );
     exit(1);
 }
@@ -401,6 +402,9 @@ void cli_parse(const int argc, char *const *const argv,
         case ARG_CPUMASK:
             settings->cpumask = parse_unsigned(optarg, 'c', argv[0]);
             break;
+        case ARG_GPUMASK:
+            settings->gpumask = parse_unsigned(optarg, ARG_GPUMASK, argv[0]);
+            break;
         case ARG_AOM_CTC:
             parse_aom_ctc(settings, optarg, argv[0]);
             break;
@@ -416,9 +420,6 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'n':
             settings->no_prediction = true;
-            break;
-        case 'c':
-            settings->cuda = true;
             break;
         case 'q':
             settings->quiet = true;

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -48,8 +48,8 @@ typedef struct {
     unsigned thread_cnt;
     bool no_prediction;
     bool quiet;
-    bool cuda;
     unsigned cpumask;
+    unsigned gpumask;
 } CLISettings;
 
 void cli_parse(const int argc, char *const *const argv,

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -23,3 +23,5 @@ vmaf = executable(
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
     install : true,
 )
+
+subdir('test')

--- a/libvmaf/tools/test/meson.build
+++ b/libvmaf/tools/test/meson.build
@@ -1,0 +1,2 @@
+test_vmaf_cuda_gpumask = find_program('test_vmaf_cuda_gpumask.sh')
+test('test_vmaf_cuda_gpumask', test_vmaf_cuda_gpumask)

--- a/libvmaf/tools/test/test_vmaf_cuda_gpumask.sh
+++ b/libvmaf/tools/test/test_vmaf_cuda_gpumask.sh
@@ -1,0 +1,37 @@
+#!/bin/sh -x
+set -e
+
+# no gpumask: use cuda
+./tools/vmaf \
+    --reference /dev/zero \
+    --distorted /dev/zero \
+    --width 1920 --height 1080 --pixel_format 420 --bitdepth 8 \
+    --frame_cnt 2 \
+    --gpumask 0
+
+# gpumask: use cpu
+./tools/vmaf \
+    --reference /dev/zero \
+    --distorted /dev/zero \
+    --width 1920 --height 1080 --pixel_format 420 --bitdepth 8 \
+    --frame_cnt 2 \
+    --gpumask -1
+
+# no gpumask: use cuda for vmaf features, cpu for psnr
+./tools/vmaf \
+    --reference /dev/zero \
+    --distorted /dev/zero \
+    --width 1920 --height 1080 --pixel_format 420 --bitdepth 8 \
+    --frame_cnt 2 \
+    --gpumask 0 \
+    --feature psnr \
+    --output /dev/stdout
+
+# gpumask: use cpu for vmaf features and psnr
+./tools/vmaf \
+    --reference /dev/zero \
+    --distorted /dev/zero \
+    --width 1920 --height 1080 --pixel_format 420 --bitdepth 8 \
+    --frame_cnt 2 \
+    --gpumask -1 \
+    --feature psnr

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
         .n_threads = c.thread_cnt,
         .n_subsample = c.subsample,
         .cpumask = c.cpumask,
-        .gpumask = c.cuda,
+        .gpumask = c.gpumask,
     };
 
     VmafContext *vmaf;
@@ -315,18 +315,12 @@ int main(int argc, char *argv[])
     }
 
 #ifdef HAVE_CUDA
-    if (c.cuda) {
-        VmafCudaState *cu_state;
-        VmafCudaConfiguration cuda_cfg = { 0 };
-        cuda_cfg.pic_params.w = vid_info.pic_w;
-        cuda_cfg.pic_params.h = vid_info.pic_h;
-        cuda_cfg.pic_params.bpc = vid_info.depth;
-        cuda_cfg.pic_params.pix_fmt = pix_fmt_map(vid_info.pixel_fmt);
-        err = vmaf_cuda_init(vmaf, &cu_state, cuda_cfg);
-        if (err) {
-            fprintf(stderr, "problem during vmaf_cuda_init\n");
-            return -1;
-        }
+    VmafCudaState *cu_state;
+    VmafCudaConfiguration cuda_cfg = { 0 };
+    err = vmaf_cuda_init(vmaf, &cu_state, cuda_cfg);
+    if (err) {
+        fprintf(stderr, "problem during vmaf_cuda_init\n");
+        return -1;
     }
 #endif
 


### PR DESCRIPTION
This PR makes it so `VmafConfiguration.gpumask` mask operates in a similar fashion to `VmafConfiguration.cpumask`. If `libvmaf` is compiled with CUDA support, then GPU feature extraction will be enabled by default. If you would like to fall back to CPU-only feature extraction, then you may set `VmafConfiguration.gpumask` to something non-zero. The command-line flag `--cuda` has been removed, and `--gpumask` has been added.

Additionally, this PR enables parallel feature extraction, it is now possible to compute vmaf on the GPU and other metrics (`psnr`, `cambi`, ...) on the CPU at the same time. The library can take either host or device pictures as input and will make copies as necessary. Implementation is still not 100% where it should be (more to come), but this small change to the API behavior should hopefully be final.

For a usage example demonstrating these changes, see: `libvmaf/tools/test/test_vmaf_cuda_gpumask.sh`.

