### PR TITLE
fix vif_avx512 bug; enable avx512 for vif

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -610,7 +610,6 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         s->vif_statistic_8 = vif_statistic_8_avx2;
         s->vif_statistic_16 = vif_statistic_16_avx2;
     }
-/*
 #if HAVE_AVX512
     if (flags & VMAF_X86_CPU_FLAG_AVX512) {
         s->subsample_rd_8 = vif_subsample_rd_8_avx2;
@@ -619,7 +618,6 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         s->vif_statistic_16 = vif_statistic_16_avx512;
     }
 #endif
-*/
 #elif ARCH_AARCH64
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_ARM_CPU_FLAG_NEON) {

--- a/libvmaf/src/feature/x86/vif_avx512.c
+++ b/libvmaf/src/feature/x86/vif_avx512.c
@@ -106,8 +106,7 @@ static inline void vif_statistic_avx512(Residuals512 *out, __m512i xx, __m512i x
         mden_val = _mm512_sub_epi64(mden_val, _mm512_set1_epi64(2048 * 17));
         __mmask8 msigma1_mask = _mm512_cmpgt_epi64_mask(_mm512_set1_epi64(sigma_nsq), msigma1);
         __mmask8 msigma2_mask = _mm512_cmpgt_epi64_mask(msigma2, _mm512_setzero_si512());
-        //msigma12 = _mm512_and_si512_(msigma2_mask, msigma12);
-        //maccum_x = _mm512_add_epi64(maccum_x, _mm512_andnot_si512(msigma1_mask, _mm512_add_epi64(mx, _mm512_set1_epi64(17))));
+        __mmask8 msigma12_mask = _mm512_cmpgt_epi64_mask(msigma12, _mm512_setzero_si512());
         __m512d msigma1_d = _mm512_cvtepu64_pd(msigma1);
         __m512d mg = _mm512_div_pd(_mm512_cvtepu64_pd(msigma12), _mm512_add_pd(msigma1_d, _mm512_set1_pd(eps)));
         __m512i msv_sq = _mm512_cvttpd_epi64(_mm512_sub_pd(_mm512_cvtepi64_pd(msigma2), _mm512_mul_pd(mg, _mm512_cvtepi64_pd(msigma12))));
@@ -128,7 +127,7 @@ static inline void vif_statistic_avx512(Residuals512 *out, __m512i xx, __m512i x
 
         __m512i mnum_val = _mm512_sub_epi64(mnumer1_tmp_log, mnumer1_log);
 
-        maccum_num_log = _mm512_mask_add_epi64(maccum_num_log, ~msigma1_mask, maccum_num_log, mnum_val);
+        maccum_num_log = _mm512_mask_add_epi64(maccum_num_log, (~msigma1_mask) & msigma12_mask & msigma2_mask, maccum_num_log, mnum_val);
         maccum_den_log = _mm512_mask_add_epi64(maccum_den_log, ~msigma1_mask, maccum_den_log, mden_val);
 
         // non log stage


### PR DESCRIPTION
Context: there was a numerical discrepancy in the AVX-512 implementation of VIF that led us to temporarily disable it. This PR fixes it and re-enables AVX-512 for VIF.