### PR TITLE
fix inf fps error

### DIFF
--- a/libvmaf/src/output.c
+++ b/libvmaf/src/output.c
@@ -124,7 +124,16 @@ int vmaf_write_output_json(VmafContext *vmaf, VmafFeatureCollector *fc,
 {
     fprintf(outfile, "{\n");
     fprintf(outfile, "  \"version\": \"%s\",\n", vmaf_version());
-    fprintf(outfile, "  \"fps\": %.2f,\n", fps);
+    switch(fpclassify(fps)) {
+    case FP_NORMAL:
+    case FP_ZERO:
+    case FP_SUBNORMAL:
+        fprintf(outfile, "  \"fps\": %.2f,\n", fps);
+        break;
+    case FP_INFINITE:
+    case FP_NAN:
+        fprintf(outfile, "  \"fps\": null,\n");
+    }
 
     unsigned n_frames = 0;
     fprintf(outfile, "  \"frames\": [");


### PR DESCRIPTION
Addressing #1114 by outputting `null` in the cases where the FPS is infinity (because of clock precision). This is consistent with how we treat similar cases such as [here](https://github.com/Netflix/vmaf/blob/b34b8f01ff97c42620905cfb56432a8f51b33b74/libvmaf/src/output.c#L175). This way we no longer output invalid JSON.