### PR TITLE
Expose vmaf_picture_ref in picture.h

### DIFF
--- a/libvmaf/include/libvmaf/picture.h
+++ b/libvmaf/include/libvmaf/picture.h
@@ -47,6 +47,8 @@ typedef struct {
 int vmaf_picture_alloc(VmafPicture *pic, enum VmafPixelFormat pix_fmt,
                        unsigned bpc, unsigned w, unsigned h);
 
+int vmaf_picture_ref(VmafPicture *dst, VmafPicture *src);
+
 int vmaf_picture_unref(VmafPicture *pic);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR exposes `vmaf_picture_ref` in picture.h in the include directory. Exposing this function would allow library users to increase the reference count of a VmafPicture. 

I'm writing a rust wrapper crate around libvmaf and not having this function causes problems for me if I implicitly call `vmaf_picture_unref` in the Drop trait, which is supposed to clean up memory after it goes out of scope. If I pass a VmafPicture to `vmaf_read_picture()` My code segfaults because `vmaf_picture_unref` is called twice (once in vmaf_read_picture, and again in the Drop trait) while `vmaf_picture_ref` is only called once within `vmaf_read_picture`. My plan is to automatically increase the reference count of `VmafPicture` in the constructor of my Newtype around this pointer to resolve this