### PR TITLE
integer_vif: fix avx512 function usage

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -612,7 +612,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     }
 #if HAVE_AVX512
     if (flags & VMAF_X86_CPU_FLAG_AVX512) {
-        s->subsample_rd_8 = vif_subsample_rd_8_avx2;
+        s->subsample_rd_8 = vif_subsample_rd_8_avx512;
         s->subsample_rd_16 = vif_subsample_rd_16_avx512;
         s->vif_statistic_8 = vif_statistic_8_avx512;
         s->vif_statistic_16 = vif_statistic_16_avx512;

--- a/libvmaf/src/feature/x86/vif_avx512.h
+++ b/libvmaf/src/feature/x86/vif_avx512.h
@@ -21,7 +21,7 @@
 
 #include "feature/integer_vif.h"
 
-void vif_subsample_rd_8_avx2(VifBuffer buf, unsigned w, unsigned h);
+void vif_subsample_rd_8_avx512(VifBuffer buf, unsigned w, unsigned h);
 
 void vif_subsample_rd_16_avx512(VifBuffer buf, unsigned w, unsigned h, int scale,
                              int bpc);


### PR DESCRIPTION
We were using an avx2 function in the avx512 version, pretty sure this was due to a typo in the original pipelining PR. I have tested on some inputs and results are identical. I haven't seen a significant speedup.