### PR TITLE
libvmaf: use _XOPEN_SOURCE, not _POSIX_C_SOURCE 

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -27,8 +27,8 @@ elif host_machine.system() == 'darwin'
     test_args += '-D_DARWIN_C_SOURCE'
     add_project_arguments('-D_DARWIN_C_SOURCE', language: 'c')
 else
-    test_args += '-D_POSIX_C_SOURCE=200112L'
-    add_project_arguments('-D_POSIX_C_SOURCE=200112L', language: 'c')
+    test_args += '-D_XOPEN_SOURCE=600'
+    add_project_arguments('-D_XOPEN_SOURCE=600', language: 'c')
 endif
 
 # Header checks


### PR DESCRIPTION
On BSD operating systems (I tested FreeBSD and NetBSD), with _POSIX_C_SOURCE=200112L, M_PI (needed by src/feature/ciede.c) is not exposed.

_XOPEN_SOURCE=600 exposes a superset of _POSIX_C_SOURCE=200112L, including M_PI.

<details><summary>Description of attempt #1</summary>

On BSD operating systems (I tested FreeBSD and NetBSD), this has the effect of hiding M_PI, which is needed by src/feature/ciede.c.

A patch doing exactly this is [used in FreeBSD Ports](https://cgit.freebsd.org/ports/tree/multimedia/vmaf/files/patch-meson.build?id=6c807939df684267f5eaac09b70821de4f124b52).

</details>