### PR TITLE
Fix: Missing alias on cuda options

### DIFF
--- a/libvmaf/src/feature/cuda/integer_adm_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_adm_cuda.c
@@ -596,6 +596,7 @@ static const VmafOption options_cuda[] = {
     },
     {
         .name = "adm_enhn_gain_limit",
+        .alias = "egl",
         .help = "enhancement gain imposed on adm, must be >= 1.0, "
             "where 1.0 means the gain is completely disabled",
         .offset = offsetof(AdmStateCuda, adm_enhn_gain_limit),
@@ -603,6 +604,7 @@ static const VmafOption options_cuda[] = {
         .default_val.d = DEFAULT_ADM_ENHN_GAIN_LIMIT,
         .min = 1.0,
         .max = DEFAULT_ADM_ENHN_GAIN_LIMIT,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     {
         .name = "adm_norm_view_dist",

--- a/libvmaf/src/feature/cuda/integer_motion_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_motion_cuda.c
@@ -67,6 +67,7 @@ static const VmafOption options[] = {
         .offset = offsetof(MotionStateCuda, motion_force_zero),
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     { 0 }
 };

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -78,6 +78,7 @@ static const VmafOption options[] = {
     },
     {
         .name = "vif_enhn_gain_limit",
+        .alias = "egl",
         .help = "enhancement gain imposed on vif, must be >= 1.0, "
             "where 1.0 means the gain is completely disabled",
         .offset = offsetof(VifStateCuda, vif_enhn_gain_limit),
@@ -85,6 +86,7 @@ static const VmafOption options[] = {
         .default_val.d = DEFAULT_VIF_ENHN_GAIN_LIMIT,
         .min = 1.0,
         .max = DEFAULT_VIF_ENHN_GAIN_LIMIT,
+        .flags = VMAF_OPT_FLAG_FEATURE_PARAM,
     },
     { 0 }
 };


### PR DESCRIPTION
I found that when running with the "neg" model the feature names are not correctly propagated due to having different options on CUDA and normal feature extractors. 
```bash
$ vmaf -r data/distorted_1080p_yuv420p.yuv -d data/reference_1080p_yuv420p.yuv -w 1080 -h 1920 -p 420 -b 8 -m path=./model/vmaf_v0.6.1neg.json --gpumask 0 
VMAF version b9150a23
128 frames ⠋⠉ 273.88 FPS
libvmaf ERROR vmaf_predict_score_at_index(): no feature 'integer_adm2_egl_1' at index 0
problem generating pooled VMAF score
```
This PR fixes that but i am not sure if it would be more optimal to move the options for adm into `integer_adm.h` and "template" them with `AdmState` and `AdmStateCuda` due to different offsets. Currently it looks like a dangerous code duplication of the option definition.
@kylophone What do you think of that?