### PR TITLE
libvmaf/cuda: avoid unneeded device to host copy

### DIFF
--- a/libvmaf/src/fex_ctx_vector.c
+++ b/libvmaf/src/fex_ctx_vector.c
@@ -102,15 +102,3 @@ void feature_extractor_vector_destroy(RegisteredFeatureExtractors *rfe)
     free(rfe->fex_ctx);
     return;
 }
-
-unsigned feature_extractor_vector_flags(RegisteredFeatureExtractors *rfe)
-{
-    if (!rfe) return -EINVAL;
-
-    unsigned flags = 0;
-
-    for (unsigned i = 0; i < rfe->cnt; i++)
-        flags |= rfe->fex_ctx[i]->fex->flags;
-
-    return flags;
-}

--- a/libvmaf/src/fex_ctx_vector.h
+++ b/libvmaf/src/fex_ctx_vector.h
@@ -34,6 +34,4 @@ int feature_extractor_vector_append(RegisteredFeatureExtractors *rfe,
 
 void feature_extractor_vector_destroy(RegisteredFeatureExtractors *rfe);
 
-unsigned feature_extractor_vector_flags(RegisteredFeatureExtractors *rfe);
-
 #endif /* __VMAF_SRC_FEX_CTX_VECTOR_H__ */


### PR DESCRIPTION
Fix for #1167.

**Before**: `frame=  500 fps=215 q=-0.0 Lsize=N/A time=00:00:09.98 bitrate=N/A speed= 4.3x`
**After**: `frame=  500 fps=313 q=-0.0 Lsize=N/A time=00:00:09.98 bitrate=N/A speed=6.25x`