### PR TITLE
Fix memory leak: Free data when cleaning up feature extractor

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -818,6 +818,7 @@ static int close(VmafFeatureExtractor *fex)
 {
     VifState *s = fex->priv;
     if (s->public.buf.data) aligned_free(s->public.buf.data);
+    vmaf_dictionary_free(&s->feature_name_dict);
     return 0;
 }
 


### PR DESCRIPTION
Hi

While doing release testing for  Bridgetech probes we found a memory leak when deinitializing the vmaf feature extractor. This can be verified in valgrind by initializing a vmaf scorer, scoring an image and cleaning up. Valgrind will then report that some memory is leaked. 

This PR contains a fix that fixes the leakage for us.  It seems like a free function call was lost during an earlier merge, so this PR adds the free back, so the code looks similar to the other feature extractors.