### PR TITLE
Pull request #275: VCQ-101 refactor to enable process captor

### DIFF
--- a/python/vmaf/__init__.py
+++ b/python/vmaf/__init__.py
@@ -33,12 +33,19 @@ VMAF_PYTHON_ROOT = os.path.dirname(os.path.abspath(__file__))
 VMAF_ROOT = os.path.abspath(os.path.join(VMAF_PYTHON_ROOT, '..', '..', ))
 
 
+class ProcessRunner(object):
+
+    def run(self, cmd, kwargs):
+        try:
+            logger.info(cmd)
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, **kwargs)
+        except subprocess.CalledProcessError as e:
+            raise AssertionError(f'Process returned {e.returncode}, cmd: {cmd}, kwargs: {kwargs}, msg: {str(e.output)}')
+
+
 def run_process(cmd, **kwargs):
-    try:
-        logger.info(cmd)
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, **kwargs)
-    except subprocess.CalledProcessError as e:
-        raise AssertionError(f'Process returned {e.returncode}, cmd: {cmd}, msg: {str(e.output)}')
+    process_runner = ProcessRunner()
+    process_runner.run(cmd, kwargs)
     return 0
 
 


### PR DESCRIPTION
Merge in MCE/vmaf-private-lts from VCQ-101-refactor-to-enable-process-captor to master

Squashed commit of the following:

commit 4016747cf65291377b0175eca490084b8663fc80
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 22:02:33 2023 -0700

    VCQ-101 fix test.

commit 007fd77a01dfce92a914da69ddb8434e34193a89
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 21:40:42 2023 -0700

    VCQ-101 remove unused setUp and tearDown.

commit 500468efd439cf91c3c2a40d2f2b333c1dd7538c
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 21:39:15 2023 -0700

    VCQ-101 remove regular test_run_psnr_fextractor_5frms.

commit 2492f9ddff0786cef3ecd72cdcaf4114247f277b
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 21:35:37 2023 -0700

    VCQ-101 add tests of specific commands in the first command test.

commit 691adb07065f0926ff518581ebaf1f85742a954c
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 18:45:24 2023 -0700

    VCQ-101 update ProcessRunner to allow testing args.

commit 90f3b86b19a4d95279a230a196a3b9dffa5e8096
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 18:17:08 2023 -0700

    VCQ-101, coverage: Add first command test.

commit 0ee9b6f185cd586334299f06760f69f423823412
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 16:57:50 2023 -0700

    VCQ-101 add kwargs to Assertion message of ProcessRunner.

commit 66670c6752269fd5ded21983e05c5f59bfe89f97
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 16:57:13 2023 -0700

    [VCQ-101, refactor] extract ProcessRunner in run_process.

commit 9d8a8d0785aea26c7ce794e7349dc51df6eaddf1
Author: Zhi Li <zli@netflix.com>
Date:   Sun Jul 23 16:26:42 2023 -0700

    [VCQ-101, coverage] add a test that invokes run_rpocess 3 times.

VCQ-101 move FeatureExtractorCommandTest to private.