### PR TITLE
Fix meson warning for deprecated source_root()

### DIFF
--- a/libvmaf/doc/meson.build
+++ b/libvmaf/doc/meson.build
@@ -6,12 +6,12 @@ doxygen = find_program('doxygen', required: false)
 
 if doxygen.found()
     conf_data = configuration_data()
-    doxygen_input = [join_paths(meson.source_root(), 'include/libvmaf'),
-                     join_paths(meson.source_root(), 'src/feature'),
+    doxygen_input = [join_paths(meson.project_source_root(), 'include/libvmaf'),
+                     join_paths(meson.project_source_root(), 'src/feature'),
                     ]
 
     conf_data.set('DOXYGEN_INPUT', ' '.join(doxygen_input))
-    conf_data.set('DOXYGEN_STRIP', join_paths(meson.source_root(), 'include'))
+    conf_data.set('DOXYGEN_STRIP', join_paths(meson.project_source_root(), 'include'))
     conf_data.set('DOXYGEN_OUTPUT', meson.current_build_dir())
     doxyfile = configure_file(input: 'Doxyfile.in',
                               output: 'Doxyfile',


### PR DESCRIPTION
https://mesonbuild.com/Release-notes-for-0-56-0.html#mesonbuild_root-and-mesonsource_root-are-deprecated