### PR TITLE
Partially fix score difference for CUDA (bpc >=10) 

### DIFF
--- a/libvmaf/src/feature/cuda/integer_adm/adm_dwt2.cu
+++ b/libvmaf/src/feature/cuda/integer_adm/adm_dwt2.cu
@@ -172,8 +172,6 @@ __device__ __forceinline__ void adm_dwt2_8_vert_hori_kernel(const T * d_picture,
             const int32_t *filter_lo = params.dwt2_db2_coeffs_lo;
             const int32_t *filter_hi = params.dwt2_db2_coeffs_hi;
 
-            int32_t accum = 0;
-
             // we need 2 addition rows for each item processed by a thread.
             const int size_u = 2 + 2 * v_rows_per_thread;
             int32_t u_s[size_u];

--- a/libvmaf/src/feature/cuda/integer_adm_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_adm_cuda.c
@@ -63,9 +63,9 @@ typedef struct AdmStateCuda {
                func_dwt_s123_combined_vert_kernel_32768_16_int32_t,
                func_dwt_s123_combined_hori_kernel_16384_15,
                func_dwt_s123_combined_hori_kernel_32768_16,
-               func_adm_dwt2_8_vert_hori_kernel_8_128_4_16_32768_128_8_uint8_t,
-               func_adm_dwt2_8_vert_hori_kernel_16_32768_4_16_32768_128_8_uint16_t,          // untested
-                                                                                             // adm_decouple kernel
+               func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint8_t,
+               func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint16_t,          // untested
+                                                                                    // adm_decouple kernel
                func_adm_decouple_kernel,
                func_adm_decouple_s123_kernel,
                // adm_csf kernel
@@ -110,9 +110,12 @@ void dwt2_8_device(AdmStateCuda *s, const uint8_t *d_picture, cuda_adm_dwt_band_
     const int horz_out_tile_rows = vert_out_tile_rows;
     const int horz_out_tile_cols = vert_out_tile_cols / 2 - 2;
 
-    void *args[] = {&d_picture, &*d_dst, &i4_dwt_dst, &w, &h, &src_stride, &dst_stride, &*p};
+    const int16_t v_shift = 8;
+    const int32_t v_add_shift = 1 << (v_shift - 1);
 
-    CHECK_CUDA(cuLaunchKernel(s->func_adm_dwt2_8_vert_hori_kernel_8_128_4_16_32768_128_8_uint8_t,
+    void *args[] = {&d_picture, &*d_dst, &i4_dwt_dst, &w, &h, &src_stride, &dst_stride, &v_shift, &v_add_shift, &*p};
+
+    CHECK_CUDA(cuLaunchKernel(s->func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint8_t,
                 DIV_ROUND_UP((w + 1) / 2, horz_out_tile_cols), DIV_ROUND_UP((h + 1) / 2, horz_out_tile_rows), 1,
                 vert_out_tile_cols, vert_out_tile_rows / rows_per_thread, 1,
                 0, c_stream, args, NULL));
@@ -130,9 +133,12 @@ void adm_dwt2_16_device(AdmStateCuda *s, const uint16_t *d_picture, cuda_adm_dwt
     const int horz_out_tile_rows = vert_out_tile_rows;
     const int horz_out_tile_cols = vert_out_tile_cols / 2 - 2;
 
-    void *args[] = {&d_picture, &*d_dst, &i4_dwt_dst, &w, &h, &src_stride, &dst_stride, &*p};
+    const int16_t v_shift = inp_size_bits;
+    const int32_t v_add_shift = 1 << (inp_size_bits - 1);
 
-    CHECK_CUDA(cuLaunchKernel(s->func_adm_dwt2_8_vert_hori_kernel_16_32768_4_16_32768_128_8_uint16_t,
+    void *args[] = {&d_picture, &*d_dst, &i4_dwt_dst, &w, &h, &src_stride, &dst_stride, &v_shift, &v_add_shift, &*p};
+
+    CHECK_CUDA(cuLaunchKernel(s->func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint16_t,
                 DIV_ROUND_UP((w + 1) / 2, horz_out_tile_cols), DIV_ROUND_UP((h + 1) / 2, horz_out_tile_rows), 1,
                 vert_out_tile_cols, vert_out_tile_rows / rows_per_thread, 1,
                 0, c_stream, args, NULL));
@@ -835,7 +841,7 @@ static void integer_compute_adm_cuda(VmafFeatureExtractor *fex, AdmStateCuda *s,
                 dwt2_8_device(s, (const uint8_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (int16_t*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, &p,  vmaf_cuda_picture_get_stream(dis_pic));
             }
             else {
-                adm_dwt2_16_device(s,(uint16_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_dis_dwt2, (int16_t*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, ref_pic->bpc, &p,  vmaf_cuda_picture_get_stream(ref_pic));
+                adm_dwt2_16_device(s,(uint16_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_ref_dwt2, (int16_t*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, ref_pic->bpc, &p,  vmaf_cuda_picture_get_stream(ref_pic));
 
                 adm_dwt2_16_device(s,(uint16_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (int16_t*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, dis_pic->bpc, &p,  vmaf_cuda_picture_get_stream(dis_pic));
 
@@ -1026,8 +1032,8 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     CHECK_CUDA(cuModuleGetFunction(&s->func_dwt_s123_combined_vert_kernel_32768_16_int32_t, adm_dwt_module, "dwt_s123_combined_vert_kernel_32768_16_int32_t"));
     CHECK_CUDA(cuModuleGetFunction(&s->func_dwt_s123_combined_hori_kernel_16384_15, adm_dwt_module, "dwt_s123_combined_hori_kernel_16384_15"));
     CHECK_CUDA(cuModuleGetFunction(&s->func_dwt_s123_combined_hori_kernel_32768_16, adm_dwt_module, "dwt_s123_combined_hori_kernel_32768_16"));
-    CHECK_CUDA(cuModuleGetFunction(&s->func_adm_dwt2_8_vert_hori_kernel_8_128_4_16_32768_128_8_uint8_t, adm_dwt_module, "adm_dwt2_8_vert_hori_kernel_8_128_4_16_32768_128_8_uint8_t"));
-    CHECK_CUDA(cuModuleGetFunction(&s->func_adm_dwt2_8_vert_hori_kernel_16_32768_4_16_32768_128_8_uint16_t, adm_dwt_module, "adm_dwt2_8_vert_hori_kernel_16_32768_4_16_32768_128_8_uint16_t"));
+    CHECK_CUDA(cuModuleGetFunction(&s->func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint8_t, adm_dwt_module, "adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint8_t"));
+    CHECK_CUDA(cuModuleGetFunction(&s->func_adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint16_t, adm_dwt_module, "adm_dwt2_8_vert_hori_kernel_4_16_32768_128_8_uint16_t"));
 
 
     // Get csf kernel function pointers check adm_csf.cu for __global__ templated kernels

--- a/libvmaf/src/feature/cuda/integer_vif/filter1d.cu
+++ b/libvmaf/src/feature/cuda/integer_vif/filter1d.cu
@@ -202,7 +202,6 @@ __device__ __forceinline__ void filter1d_8_horizontal_kernel(VifBufferCuda buf, 
 
         uint16_t *ref = (uint16_t *)buf.ref;
         uint16_t *dis = (uint16_t *)buf.dis;
-        const ptrdiff_t stride = buf.stride_16 / sizeof(uint16_t);
         for (int off = 0; off < val_per_thread; ++off) {
             const int x = x_start + off;
             if (y < h && x < w) {
@@ -385,7 +384,7 @@ filter1d_16_horizontal_kernel(VifBufferCuda buf, int w, int h,
                     if (fj >= (fwidth - fwidth_rd) / 2 &&
                             fj < (fwidth - (fwidth - fwidth_rd) / 2) && fwidth_rd > 0 &&
                             off % 2 == 0) {
-                        const uint16_t fcoeff_rd =
+                        const uint32_t fcoeff_rd =
                             vif_filt.filter[scale + 1][fj - ((fwidth - fwidth_rd) / 2)];
                         accum_ref_rd[off / 2] +=
                             fcoeff_rd *
@@ -426,7 +425,6 @@ filter1d_16_horizontal_kernel(VifBufferCuda buf, int w, int h,
             }
         }
 
-        const ptrdiff_t dst_stride = buf.stride_32 / sizeof(uint32_t);
         for (int off = 0; off < val_per_thread; ++off) {
             const int x = x_start + off;
             if (y < h && x < w) {

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -213,8 +213,7 @@ void filter1d_8(VifStateCuda *s, VifBufferCuda *buf, uint8_t* ref_in, uint8_t* d
 
         const int size_of_alignment_type = sizeof(uint32_t),
         BLOCKX = 128 / size_of_alignment_type,
-        BLOCKY = 128 / (VMAF_CUDA_CACHE_LINE_SIZE / size_of_alignment_type),
-        val_per_thread = 2;
+        BLOCKY = 128 / (VMAF_CUDA_CACHE_LINE_SIZE / size_of_alignment_type);
         void* args_vert[] = {
             &*buf, &ref_in, &dis_in, &w, &h, &vif_filter1d_table
         };
@@ -260,19 +259,16 @@ void filter1d_16(VifStateCuda *s, VifBufferCuda *buf, uint16_t* ref_in, uint16_t
         shift_VP_sq = 16;
         add_shift_round_VP_sq = 32768;
     }
-
-    const int fwidth[4] = {17, 9, 5, 3};
-
+    
     struct uint2 {
         unsigned x ,y;
     } uint2;
 
     const int size_of_alginment = sizeof(uint2),
           val_per_thread = size_of_alginment / sizeof(uint16_t),
-          val_per_thread_horizontal = 2,
           BLOCKX = 128,
-          BLOCK_VERT_X = VMAF_CUDA_CACHE_LINE_SIZE / val_per_thread, BLOCK_VERT_Y = 128 / (VMAF_CUDA_CACHE_LINE_SIZE / val_per_thread),
-          GRID_VERT_X = DIV_ROUND_UP(w, BLOCKX), GRID_VERT_Y = h,
+          BLOCK_VERT_X = VMAF_CUDA_CACHE_LINE_SIZE / val_per_thread, BLOCK_VERT_Y = 128 / (VMAF_CUDA_CACHE_LINE_SIZE / val_per_thread);
+    const int GRID_VERT_X = DIV_ROUND_UP(w, BLOCK_VERT_X * val_per_thread), GRID_VERT_Y = DIV_ROUND_UP(h, BLOCK_VERT_Y),
           GRID_HORI_X = DIV_ROUND_UP(w, BLOCKX), GRID_HORI_Y = h;
 
     void * args_vert[] = {


### PR DESCRIPTION
Superseding #1195

Text from 1195:

> Greatly lowers score difference on CUDA for high bit images.
> 
> VMAF score for 1000 frames of a 4096x2160 10bpc sequence in FFMPEG:
> with libvmaf_cuda (GPU):
> [Parsed_libvmaf_cuda_0 @ 0x559ffac22b00] VMAF score: 76.101209
> 
> with libvmaf (CPU):
> [Parsed_libvmaf_2 @ 0x55a7e344cf80] VMAF score: 76.101269
> 
> Score difference is now dependet on the sequence used.