### PR TITLE
Docker + CUDA documentation

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -7,12 +7,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 
 RUN git clone https://github.com/Netflix/vmaf.git
 
-# ffmpeg patch from http://ffmpeg.org/pipermail/ffmpeg-devel/2023-August/313073.html
-RUN curl -LJ -o vf_libvmaf_cuda.diff https://ffmpeg.org/pipermail/ffmpeg-devel/attachments/20230807/29cf249a/attachment.obj
-
 RUN git clone https://github.com/FFmpeg/FFmpeg.git
-RUN cd FFmpeg && \
-    git apply --ignore-whitespace ../vf_libvmaf_cuda.diff
 
 RUN git clone https://github.com/FFmpeg/nv-codec-headers.git && cd nv-codec-headers && make && make install
 
@@ -32,7 +27,7 @@ RUN cd FFmpeg && ./configure \
     --enable-cuda \
     --enable-cuda-nvcc \
     --enable-libvmaf \
-    --enable-libvmaf-cuda \
+    --enable-ffnvcodec \
     --disable-stripping \
     --extra-cflags="-I/usr/local/cuda/include" \
     --extra-ldflags="-L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs/" 

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,48 @@
+ARG CUDA_VERSION=12.1.0
+# By copying the installation from a devel to a runtime container one could likely save a lot container size
+FROM nvidia/cuda:$CUDA_VERSION-devel-ubuntu22.04 
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libopenjp2-7-dev \
+    ninja-build cmake git python3 python3-pip nasm xxd pkg-config curl unzip
+
+RUN git clone https://github.com/Netflix/vmaf.git
+
+# ffmpeg patch from http://ffmpeg.org/pipermail/ffmpeg-devel/2023-August/313073.html
+RUN curl -LJ -o vf_libvmaf_cuda.diff https://ffmpeg.org/pipermail/ffmpeg-devel/attachments/20230807/29cf249a/attachment.obj
+
+RUN git clone https://github.com/FFmpeg/FFmpeg.git
+RUN cd FFmpeg && \
+    git apply --ignore-whitespace ../vf_libvmaf_cuda.diff
+
+RUN git clone https://github.com/FFmpeg/nv-codec-headers.git && cd nv-codec-headers && make && make install
+
+# install vmaf
+RUN python3 -m pip install meson cpython
+RUN cd vmaf && meson libvmaf/build libvmaf -Denable_cuda=true -Denable_avx512=true --buildtype release && \
+    ninja -vC libvmaf/build  && \
+    ninja -vC libvmaf/build  install
+
+# install ffmpeg
+RUN cd FFmpeg && ./configure \
+    --enable-libnpp \
+    --enable-nonfree \
+    --enable-nvdec \
+    --enable-nvenc \
+    --enable-cuvid \
+    --enable-cuda \
+    --enable-cuda-nvcc \
+    --enable-libvmaf \
+    --enable-libvmaf-cuda \
+    --disable-stripping \
+    --extra-cflags="-I/usr/local/cuda/include" \
+    --extra-ldflags="-L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs/" 
+
+RUN cd FFmpeg && make -j && make install
+
+RUN mkdir /data
+# VMAF+decode GPU (only works for NVDec supported formats https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new)
+ENTRYPOINT ["ffmpeg" ,"-hwaccel", "cuda", "-hwaccel_output_format" ,"cuda", \
+    "-i" ,"/data/ref.mp4", \
+    "-hwaccel", "cuda", "-hwaccel_output_format", "cuda", \
+    "-i", "/data/dis.mp4"  ,\
+    "-filter_complex", "[0:v][1:v]libvmaf_cuda" ,"-f" ,"null", "-"]

--- a/libvmaf/README.md
+++ b/libvmaf/README.md
@@ -30,7 +30,11 @@ Run:
 meson build --buildtype release
 ```
 
-(add `-Denable_float=true` flag in the rare case if you want to use the floating-point feature extractors.)
+Special cases:
+- add `-Denable_float=true` flag in the rare case if you want to use the floating-point feature extractors.
+- add `-Denable_avx512=true` to support wider SIMD instructions to achieve the fastest processing on supported CPUs
+- add `-Denable_cuda=true` to build with CUDA support, which requires `nvcc` for compilation (tested with CUDA >= 11)
+- add `-Denable_nvtx=true` to build with [NVTX](https://github.com/NVIDIA/NVTX) marker support, which enables easy profiling using Nsight Systems
 
 Build with:
 

--- a/resource/doc/docker.md
+++ b/resource/doc/docker.md
@@ -63,3 +63,7 @@ To run a custom ffmpeg command line inside the container use:
 ```shell script
 docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=compute,video --entrypoint=bash -it --rm vmaf_cuda 
 ```
+
+For 420 video format we will have to convert from NV12 to 420 as well: 
+`-filter_complex [0:v]scale_cuda=format=yuv420p[ref];[1:v]scale_cuda=format=yuv420p[dist];[ref][dist]libvmaf_cuda`
+ 

--- a/resource/doc/docker.md
+++ b/resource/doc/docker.md
@@ -30,3 +30,36 @@ Note that you need to first download the test videos from [vmaf_resource](https:
 wget https://github.com/Netflix/vmaf_resource/raw/master/python/test/resource/yuv/src01_hrc00_576x324.yuv
 wget https://github.com/Netflix/vmaf_resource/raw/master/python/test/resource/yuv/src01_hrc01_576x324.yuv
 ```
+
+To run `vmafossexec` with a specified model file:
+
+```shell script
+docker run --rm -v $(pwd):/files vmaf \
+    --entrypoint ""
+    vmafossexec yuv420p 576 324 \
+    /files/src01_hrc00_576x324.yuv \
+    /files/src01_hrc01_576x324.yuv \
+    /files/model/vmaf_float_v0.6.1.pkl \
+    --log /dev/stdout
+```
+
+## Docker with CUDA support 
+
+To run docker containers with GPU support you have to install the [nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+After that a CUDA enabled container can be built using the below command line:
+```shell script
+docker build -f Dockerfile.cuda -t vmaf_cuda .
+```
+
+Besides VMAF the container also build ffmpeg support to enable GPU enabled decode to be able to run VMAF at speed of light.
+
+```shell script
+REF_VIDEO=$PWD/data/text_ref.mp4 
+DIS_VIDEO=$PWD/data/text_dis.mp4 
+
+docker run --gpus all  -e NVIDIA_DRIVER_CAPABILITIES=compute,video -v $REF_VIDEO:/data/ref.mp4 -v $DIS_VIDEO:/data/dis.mp4 vmaf_cuda
+```
+To run a custom ffmpeg command line inside the container use: 
+```shell script
+docker run --gpus all -e NVIDIA_DRIVER_CAPABILITIES=compute,video --entrypoint=bash -it --rm vmaf_cuda 
+```

--- a/resource/doc/docker.md
+++ b/resource/doc/docker.md
@@ -31,18 +31,6 @@ wget https://github.com/Netflix/vmaf_resource/raw/master/python/test/resource/yu
 wget https://github.com/Netflix/vmaf_resource/raw/master/python/test/resource/yuv/src01_hrc01_576x324.yuv
 ```
 
-To run `vmafossexec` with a specified model file:
-
-```shell script
-docker run --rm -v $(pwd):/files vmaf \
-    --entrypoint ""
-    vmafossexec yuv420p 576 324 \
-    /files/src01_hrc00_576x324.yuv \
-    /files/src01_hrc01_576x324.yuv \
-    /files/model/vmaf_float_v0.6.1.pkl \
-    --log /dev/stdout
-```
-
 ## Docker with CUDA support 
 
 To run docker containers with GPU support you have to install the [nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).


### PR DESCRIPTION
Actually the base image is a bit overkill. CUDA Toolkit is only required for compilation but not for execution. It should be sufficient to compile in a CUDA docker but copy everything over to the respective Ubuntu base image. Any help with reducing the image into a build image and a final image would be much appreciated ! If image size is not a concern this is working as is.