### PR TITLE
Add support to v2.3.1 tag to support y4m input files with different bit depths

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -351,7 +351,7 @@ void cli_parse(const int argc, char *const *const argv,
             break;
         case 'b':
             settings->bitdepth = parse_bitdepth(optarg, 'b', argv[0]);
-            settings->use_yuv = true;
+            // allow bitdepth to be set for y4m, so do not set use_yuv = true
             break;
         case 'o':
             settings->output_path = optarg;

--- a/libvmaf/tools/vidinput.c
+++ b/libvmaf/tools/vidinput.c
@@ -46,9 +46,9 @@ int raw_input_open(video_input *_vid,FILE *_fin,
   return -1;
 }
 
-int video_input_open(video_input *_vid,FILE *_fin) {
+int video_input_open(video_input *_vid,FILE *_fin,int _out_bd) {
   void *ctx;
-  if ((ctx = Y4M_INPUT_VTBL.open(_fin))!=NULL){
+  if ((ctx = Y4M_INPUT_VTBL.open(_fin,_out_bd))!=NULL){
     _vid->vtbl=&Y4M_INPUT_VTBL;
     _vid->ctx=ctx;
     _vid->fin=_fin;

--- a/libvmaf/tools/vidinput.h
+++ b/libvmaf/tools/vidinput.h
@@ -51,7 +51,7 @@ struct video_input_plane {
 };
 typedef struct video_input_plane video_input_ycbcr[3];
 
-typedef void* (*video_input_open_func)(FILE *_fin);
+typedef void* (*video_input_open_func)(FILE *_fin,int _out_bd);
 typedef void (*video_input_get_info_func)(void *_ctx,video_input_info *_ti);
 typedef int (*video_input_fetch_frame_func)(void *_ctx,FILE *_fin,
  video_input_ycbcr _ycbcr,char _tag[5]);
@@ -80,7 +80,7 @@ int raw_input_open(video_input *_vid, FILE *_fin,
                    unsigned width, unsigned height,
                    int pix_fmt, unsigned bitdepth);
 
-int video_input_open(video_input *_vid, FILE *_fin);
+int video_input_open(video_input *_vid, FILE *_fin, int _out_bd);
 void video_input_close(video_input *_vid);
 
 void video_input_get_info(video_input *_vid, video_input_info *_ti);
@@ -119,6 +119,7 @@ struct video_input_info{
   video_input_pixel_format pixel_fmt;
   char              interlace;
   char              chroma_type[16];
+  int               depth_input;
   int               depth;
 };
 

--- a/libvmaf/tools/yuv_input.c
+++ b/libvmaf/tools/yuv_input.c
@@ -97,6 +97,7 @@ static void yuv_input_get_info(yuv_input *_yuv, video_input_info *_info)
     _info->frame_w = _info->pic_w = _yuv->width;
     _info->frame_h = _info->pic_h = _yuv->height;
     _info->pixel_fmt = pix_fmt_map(_yuv->pix_fmt);
+    _info->depth_input = _yuv->bitdepth;
     _info->depth = _yuv->bitdepth;
 }
 


### PR DESCRIPTION
This pull request implements code to support AOM CWG-D088 "Coding 8-bit video using 10 bits" which was adopted for CTC v6.0. The code changes are made on top of tag v2.3.1, which is used for CTC v5.0.

I am requesting a new tag to be created for this pull request so that AOM can use it for CTC v6.0.