### PR TITLE
Test Github Actions MacOS M1 Runner

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -61,7 +61,7 @@ jobs:
           ccache --version
 
       - name: Install dependencies (mac)
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-13-xlarge'
         run: |
           brew install -q ninja nasm ccache
 

--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -25,7 +25,7 @@ jobs:
             CC: ccache clang
             CXX: ccache clang++
             experimental: true
-          - os: macos-latest-xlarge
+          - os: macos-13-xlarge
             CC: ccache clang
             CXX: ccache clang++
             experimental: true

--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -25,6 +25,10 @@ jobs:
             CC: ccache clang
             CXX: ccache clang++
             experimental: true
+          - os: macos-latest-xlarge
+            CC: ccache clang
+            CXX: ccache clang++
+            experimental: true
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
@@ -57,7 +61,7 @@ jobs:
           ccache --version
 
       - name: Install dependencies (mac)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-latest-xlarge'
         run: |
           brew install -q ninja nasm ccache
 


### PR DESCRIPTION
https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/

If we can get arm64 builds on Github Actions CI, we should be able to get rid of Travis completely.