### PR TITLE
Add aom_ctc v4.0 and v5.0 CLI options

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -310,6 +310,16 @@ static void aom_ctc_v3_0(CLISettings *settings, const char *app)
         parse_feature_config("cambi", app);
 }
 
+static void aom_ctc_v4_0(CLISettings *settings, const char *app)
+{
+    aom_ctc_v3_0(settings, app);
+}
+
+static void aom_ctc_v5_0(CLISettings *settings, const char *app)
+{
+    aom_ctc_v4_0(settings, app);
+}
+
 static void parse_aom_ctc(CLISettings *settings, const char *const optarg,
                           const char *const app)
 {
@@ -328,6 +338,16 @@ static void parse_aom_ctc(CLISettings *settings, const char *const optarg,
 
     if (!strcmp(optarg, "v3.0")) {
         aom_ctc_v3_0(settings, app);
+        return;
+    }
+
+    if (!strcmp(optarg, "v4.0")) {
+        aom_ctc_v4_0(settings, app);
+        return;
+    }
+
+    if (!strcmp(optarg, "v5.0")) {
+        aom_ctc_v5_0(settings, app);
         return;
     }
 


### PR DESCRIPTION
In preparation for supporting aom_ctc v6.0, adding support for v4 and v5, which are identical to v3.