### PR TITLE
tools/vmaf: support y4m input files with different bit depths; add command-line flag to gate this behavior

### DIFF
--- a/libvmaf/tools/cli_parse.c
+++ b/libvmaf/tools/cli_parse.c
@@ -320,6 +320,12 @@ static void aom_ctc_v5_0(CLISettings *settings, const char *app)
     aom_ctc_v4_0(settings, app);
 }
 
+static void aom_ctc_v6_0(CLISettings *settings, const char *app)
+{
+    aom_ctc_v5_0(settings, app);
+    settings->common_bitdepth = true;
+}
+
 static void parse_aom_ctc(CLISettings *settings, const char *const optarg,
                           const char *const app)
 {
@@ -348,6 +354,11 @@ static void parse_aom_ctc(CLISettings *settings, const char *const optarg,
 
     if (!strcmp(optarg, "v5.0")) {
         aom_ctc_v5_0(settings, app);
+        return;
+    }
+
+    if (!strcmp(optarg, "v6.0")) {
+        aom_ctc_v6_0(settings, app);
         return;
     }
 

--- a/libvmaf/tools/cli_parse.h
+++ b/libvmaf/tools/cli_parse.h
@@ -48,6 +48,7 @@ typedef struct {
     unsigned thread_cnt;
     bool no_prediction;
     bool quiet;
+    bool common_bitdepth;
     unsigned cpumask;
     unsigned gpumask;
 } CLISettings;

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -27,7 +27,7 @@ static enum VmafPixelFormat pix_fmt_map(int pf)
     }
 }
 
-static int validate_videos(video_input *vid1, video_input *vid2)
+static int validate_videos(video_input *vid1, video_input *vid2, bool common_bitdepth)
 {
     int err_cnt = 0;
 
@@ -49,6 +49,12 @@ static int validate_videos(video_input *vid1, video_input *vid2)
 
     if (!pix_fmt_map(info1.pixel_fmt) || !pix_fmt_map(info2.pixel_fmt)) {
         fprintf(stderr, "unsupported pixel format: %d\n", info1.pixel_fmt);
+        err_cnt++;
+    }
+
+    if (!common_bitdepth && info1.depth != info2.depth) {
+        fprintf(stderr, "bitdepths do not match: %d, %d\n",
+                info1.depth, info2.depth);
         err_cnt++;
     }
 
@@ -208,7 +214,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    err = validate_videos(&vid_ref, &vid_dist);
+    err = validate_videos(&vid_ref, &vid_dist, c.common_bitdepth);
     if (err) {
         fprintf(stderr, "videos are incompatible, %d %s.\n",
                 err, err == 1 ? "problem" : "problems");


### PR DESCRIPTION
Continuation of #1260, with two extra commits to gate the behavior behind the new `--convert_bitdepth` CLI flag, and to add `--aom_ctc v6.0` enabling this flag.