### PR TITLE
add test_cli_parse.c

### DIFF
--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -109,6 +109,13 @@ test_luminance_tools = executable('test_luminance_tools',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
 )
 
+test_cli_parse = executable('test_cli_parse',
+    ['test.c', 'test_cli_parse.c', '../tools/cli_parse.c'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/'), include_directories('../tools/')],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+    c_args : [compat_cflags],
+)
+
 if get_option('enable_cuda')
 test_ring_buffer = executable('test_ring_buffer',
     ['test.c', 'test_ring_buffer.c', '../src/cuda/ring_buffer.c', '../src/cuda/picture_cuda.c'],
@@ -143,3 +150,4 @@ test('test_feature', test_feature)
 test('test_ciede', test_ciede)
 test('test_cambi', test_cambi)
 test('test_luminance_tools', test_luminance_tools)
+test('test_cli_parse', test_cli_parse)

--- a/libvmaf/test/test_cli_parse.c
+++ b/libvmaf/test/test_cli_parse.c
@@ -1,0 +1,140 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <getopt.h>
+
+#include "test.h"
+
+#include "cli_parse.h"
+
+static char *test_aom_ctc_v1_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v1.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v1.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v1.0 provided but number of features is not 5", settings.feature_cnt == 5);
+    mu_assert("cli_parse: --aom_ctc v1.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_aom_ctc_v2_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v2.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v2.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v2.0 provided but number of features is not 5", settings.feature_cnt == 5);
+    mu_assert("cli_parse: --aom_ctc v2.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_aom_ctc_v3_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v3.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v3.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v3.0 provided but number of features is not 6", settings.feature_cnt == 6);
+    mu_assert("cli_parse: --aom_ctc v3.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_aom_ctc_v4_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v4.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v4.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v4.0 provided but number of features is not 6", settings.feature_cnt == 6);
+    mu_assert("cli_parse: --aom_ctc v4.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_aom_ctc_v5_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v5.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v5.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v5.0 provided but number of features is not 6", settings.feature_cnt == 6);
+    mu_assert("cli_parse: --aom_ctc v5.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_aom_ctc_v6_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--aom_ctc", "v6.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --aom_ctc v6.0 provided but common_bitdepth not enabled", settings.common_bitdepth);
+    mu_assert("cli_parse: --aom_ctc v6.0 provided but number of features is not 6", settings.feature_cnt == 6);
+    mu_assert("cli_parse: --aom_ctc v6.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+static char *test_nflx_ctc_v1_0()
+{
+    char *argv[7] = {"vmaf", "-r", "ref.y4m", "-d", "dis.y4m", "--nflx_ctc", "v1.0"};
+    int argc = 7;
+    CLISettings settings;
+    optind = 1;
+    cli_parse(argc, argv, &settings);
+    mu_assert("cli_parse: --nflx_ctc v1.0 provided but common_bitdepth enabled", !settings.common_bitdepth);
+    mu_assert("cli_parse: --nflx_ctc v1.0 provided but number of features is not 3", settings.feature_cnt == 3);
+    mu_assert("cli_parse: --nflx_ctc v1.0 provided but number of models is not 2", settings.model_cnt == 2);
+    cli_free(&settings);
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_aom_ctc_v1_0);
+    mu_run_test(test_aom_ctc_v2_0);
+    mu_run_test(test_aom_ctc_v3_0);
+    mu_run_test(test_aom_ctc_v4_0);
+    mu_run_test(test_aom_ctc_v5_0);
+    mu_run_test(test_aom_ctc_v6_0);
+    mu_run_test(test_nflx_ctc_v1_0);
+    return NULL;
+}


### PR DESCRIPTION
To start with, I only tested some basic behavior of the `--aom_ctc` and `--nflx_ctc` flags but this can easily be extended to cover other code paths.