### PR TITLE
[RFC] Introduce framesync API

### DIFF
--- a/libvmaf/src/framesync.c
+++ b/libvmaf/src/framesync.c
@@ -1,0 +1,25 @@
+#include "framesync.h"
+
+typedef struct VmafFrameSyncContext {
+    VmafFrameSyncConfiguration cfg;
+} VmafFrameSyncContext;
+
+int vmaf_framesync_init(VmafFrameSyncContext **fs_ctx, VmafFrameSyncConfiguration cfg)
+{
+    return 0;
+}
+
+int vmaf_framesync_fetch_data(VmafFrameSyncContext *fs_ctx, void **data)
+{
+    return 0;
+}
+
+int vmaf_framesync_submit_data(VmafFrameSyncContext *fs_ctx, void *data, unsigned index)
+{
+    return 0;
+}
+
+int vmaf_framesync_close(VmafFrameSyncContext *fs_ctx)
+{
+    return 0;
+}

--- a/libvmaf/src/framesync.h
+++ b/libvmaf/src/framesync.h
@@ -1,0 +1,16 @@
+typedef struct VmafFrameSyncConfiguration {
+    size_t data_sz;
+    int (*framesync_callback)(void *data, unsigned data_cnt, unsigned index);
+    int *index_offsets;
+    unsigned index_offsets_cnt;
+} VmafFrameSyncConfiguration;
+
+typedef struct VmafFrameSyncContext VmafFrameSyncContext;
+
+int vmaf_framesync_init(VmafFrameSyncContext **fs_ctx, VmafFrameSyncConfiguration cfg);
+
+int vmaf_framesync_fetch_data(VmafFrameSyncContext *fs_ctx, void **data);
+
+int vmaf_framesync_submit_data(VmafFrameSyncContext *fs_ctx, void *data, unsigned index);
+
+int vmaf_framesync_close(VmafFrameSyncContext *fs_ctx);

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -122,6 +122,11 @@ test_psnr = executable('test_psnr',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
 )
 
+test_framesync = executable('test_framesync',
+    ['test.c', 'test_framesync.c'],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+)
+
 if get_option('enable_cuda')
 test_ring_buffer = executable('test_ring_buffer',
     ['test.c', 'test_ring_buffer.c', '../src/cuda/ring_buffer.c', '../src/cuda/picture_cuda.c'],
@@ -158,3 +163,4 @@ test('test_cambi', test_cambi)
 test('test_luminance_tools', test_luminance_tools)
 test('test_cli_parse', test_cli_parse)
 test('test_psnr', test_psnr)
+test('test_framesync', test_framesync)

--- a/libvmaf/test/test_framesync.c
+++ b/libvmaf/test/test_framesync.c
@@ -1,0 +1,90 @@
+#include "test.h"
+#include "../src/framesync.c"
+
+#include <stdint.h>
+
+static int most_recent_callback_index = -1;
+
+struct my_cookie {
+    uint8_t my_data[256];
+};
+
+int my_framesync_callback(void *data, unsigned data_cnt, unsigned index)
+{
+    struct my_cookie* my_data = (struct my_cookie*)data;
+
+    (void)my_data;
+    (void)data_cnt;
+
+    most_recent_callback_index = index;
+    return 0;
+}
+
+static char *test_framesync()
+{
+    int err = 0;
+
+    VmafFrameSyncContext *fs_ctx;
+
+    int index_offsets[] = { -1, 0, +1 };
+    unsigned index_offsets_cnt = sizeof(index_offsets) / sizeof(*index_offsets);
+
+    VmafFrameSyncConfiguration cfg = {
+        .data_sz = sizeof(struct my_cookie),
+        .framesync_callback = my_framesync_callback,
+        .index_offsets = index_offsets,
+        .index_offsets_cnt = index_offsets_cnt,
+    };
+
+    err = vmaf_framesync_init(&fs_ctx, cfg);
+    mu_assert("problem during vmaf_framesync_init", !err);
+
+    mu_assert("no callbacks should have been executed yet, "
+              "vmaf_framesync_init",
+              most_recent_callback_index == -1);
+
+    struct my_cookie *my_data = NULL;
+    err = vmaf_framesync_fetch_data(fs_ctx, (void**)&my_data);
+    mu_assert("problem during vmaf_framesync_fetch_data", !err);
+    mu_assert("fetched data pointer is still null", my_data);
+
+    err = vmaf_framesync_submit_data(fs_ctx, my_data, 0);
+    mu_assert("problem during vmaf_framesync_submit_data", !err);
+
+    mu_assert("no callbacks should have been executed yet, "
+              "callback dependencies unmet",
+              most_recent_callback_index == -1);
+
+    err = vmaf_framesync_fetch_data(fs_ctx, (void**)&my_data);
+    mu_assert("problem during vmaf_framesync_fetch_data", !err);
+    mu_assert("fetched data pointer is still null", my_data);
+
+    err = vmaf_framesync_submit_data(fs_ctx, my_data, 1);
+    mu_assert("problem during vmaf_framesync_submit_data", !err);
+
+    mu_assert("no callbacks should have been executed yet, "
+              "callback dependencies unmet",
+              most_recent_callback_index == -1);
+
+    err = vmaf_framesync_fetch_data(fs_ctx, (void**)&my_data);
+    mu_assert("problem during vmaf_framesync_fetch_data", !err);
+    mu_assert("fetched data pointer is still null", my_data);
+
+    err = vmaf_framesync_submit_data(fs_ctx, my_data, 2);
+    mu_assert("problem during vmaf_framesync_submit_data", !err);
+
+    mu_assert("callback should have been executed for index == 1, "
+              "callback dependencies are met: (0, 1, 2)",
+              most_recent_callback_index == 1);
+
+    err = vmaf_framesync_close(fs_ctx);
+    mu_assert("problem during vmaf_framesync_close", !err);
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_framesync);
+    return NULL;
+}


### PR DESCRIPTION
A proposed API (design only, no implementation yet) to support dependency-based callbacks. If used with temporal feature extractor, it should allow proper multithreading. Currently these feature extractors (`motion`) are required to be executed in serial. In addition to improved multithread performance, this should also allow us to insert pictures in an out-of-order fashion, currently that is a silent bug. Questions/comments welcome.