### PR TITLE
Update meson command

### DIFF
--- a/libvmaf/README.md
+++ b/libvmaf/README.md
@@ -27,7 +27,7 @@ Ninja package name might be `ninja` or `ninja-build`, depending on your system. 
 Run:
 
 ```
-meson build --buildtype release
+meson setup build --buildtype release
 ```
 
 Special cases:


### PR DESCRIPTION
Removes the following warning

```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```