### PR TITLE
remove deprecation warning in svm.cpp

### DIFF
--- a/libvmaf/src/svm.cpp
+++ b/libvmaf/src/svm.cpp
@@ -54,7 +54,7 @@ static void info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,BUFSIZ,fmt,ap);
 	va_end(ap);
 	(*svm_print_string)(buf);
 }


### PR DESCRIPTION
removes the following warning

```
../src/svm.cpp:57:2: warning: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Wdeprecated-declarations]
```