### PR TITLE
.github: replace set-output with non-deprecated alternative

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -85,8 +85,8 @@ jobs:
         id: get_info
         run: |
           ldd "./install/bin/vmaf" || true
-          echo "::set-output name=path::./install/bin/vmaf"
-          echo "::set-output name=upload_url::$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")"
+          echo "path=./install/bin/vmaf" >> $GITHUB_OUTPUT
+          echo "upload_url=$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")" >> $GITHUB_OUTPUT
 
       - name: Upload vmaf
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,8 +61,8 @@ jobs:
         id: get_info
         run: |
           ldd "$MINGW_PREFIX/bin/vmaf.exe" || true
-          echo "::set-output name=path::$(cygpath -m "$(command -v vmaf)")"
-          echo "::set-output name=upload_url::$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")"
+          echo "path=$(cygpath -m "$(command -v vmaf)")" >> $GITHUB_OUTPUT
+          echo "upload_url=$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")" >> $GITHUB_OUTPUT
 
       - name: Upload vmaf
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/