### PR TITLE
fix crash when vmaf_picture_unref

### DIFF
--- a/libvmaf/src/picture.c
+++ b/libvmaf/src/picture.c
@@ -124,13 +124,14 @@ int vmaf_picture_unref(VmafPicture *pic) {
     if (!pic) return -EINVAL;
     if (!pic->ref) return -EINVAL;
 
-    vmaf_ref_fetch_decrement(pic->ref);
-    if (vmaf_ref_load(pic->ref) == 0) {
-        const VmafPicturePrivate *priv = pic->priv;
+    if (vmaf_ref_fetch_decrement(pic->ref) == 1)
+    {
+        const VmafPicturePrivate* priv = pic->priv;
         priv->release_picture(pic, priv->cookie);
         free(pic->priv);
         vmaf_ref_close(pic->ref);
     }
+
     memset(pic, 0, sizeof(*pic));
     return 0;
 }

--- a/libvmaf/src/ref.c
+++ b/libvmaf/src/ref.c
@@ -31,14 +31,14 @@ int vmaf_ref_init(VmafRef **ref)
     return 0;
 }
 
-void vmaf_ref_fetch_increment(VmafRef *ref)
+long  vmaf_ref_fetch_increment(VmafRef* ref)
 {
-    atomic_fetch_add(&ref->cnt, 1);
+    return atomic_fetch_add(&ref->cnt, 1);
 }
 
-void vmaf_ref_fetch_decrement(VmafRef *ref)
+long  vmaf_ref_fetch_decrement(VmafRef* ref)
 {
-    atomic_fetch_sub(&ref->cnt, 1);
+    return atomic_fetch_sub(&ref->cnt, 1);
 }
 
 long vmaf_ref_load(VmafRef *ref)

--- a/libvmaf/src/ref.h
+++ b/libvmaf/src/ref.h
@@ -26,8 +26,8 @@ typedef struct VmafRef {
 } VmafRef;
 
 int vmaf_ref_init(VmafRef **ref);
-void vmaf_ref_fetch_increment(VmafRef *ref);
-void vmaf_ref_fetch_decrement(VmafRef *ref);
+long vmaf_ref_fetch_increment(VmafRef* ref);
+long vmaf_ref_fetch_decrement(VmafRef* ref);
 long vmaf_ref_load(VmafRef *ref);
 int vmaf_ref_close(VmafRef *ref);
 


### PR DESCRIPTION
pull request #1026 is closed after force-pushed the newest code. 
this is the rebased version.
some crash happened when use vmaf. seems a double free problem caused by multi-thread. This will ensure VmafPicture only free once.
