### PR TITLE
model.c: change strncpy to strcpy, fix warning -Wstringop-truncation

### DIFF
--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -131,9 +131,9 @@ char *vmaf_model_generate_name(VmafModelConfig *cfg)
     memset(name, 0, name_sz);
 
     if (!cfg->name)
-        strncpy(name, default_name, name_sz);
+        strcpy(name, default_name);
     else
-        strncpy(name, cfg->name, name_sz);
+        strcpy(name, cfg->name);
 
     return name;
 }


### PR DESCRIPTION
I don't think this changes anything, since the size parameter `name_sz` was already computed from the lengths of the respective sources using `strlen`. This fixes the following warning:

```
warning: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Wstringop-truncation]
```

Addresses #1228.