### PR TITLE
model.c: fix -Wlto-type-mismatch

### DIFF
--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -21,24 +21,24 @@ typedef struct VmafBuiltInModel {
 
 #if VMAF_BUILT_IN_MODELS
 #if VMAF_FLOAT_FEATURES
-extern const char src_vmaf_float_v0_6_1neg_json;
+extern const char src_vmaf_float_v0_6_1neg_json[];
 extern const int src_vmaf_float_v0_6_1neg_json_len;
-extern const char src_vmaf_float_v0_6_1_json;
+extern const char src_vmaf_float_v0_6_1_json[];
 extern const int src_vmaf_float_v0_6_1_json_len;
-extern const char src_vmaf_float_b_v0_6_3_json;
+extern const char src_vmaf_float_b_v0_6_3_json[];
 extern const int src_vmaf_float_b_v0_6_3_json_len;
-extern const char src_vmaf_float_4k_v0_6_1_json;
+extern const char src_vmaf_float_4k_v0_6_1_json[];
 extern const int src_vmaf_float_4k_v0_6_1_json_len;
 #endif
-extern const char src_vmaf_v0_6_1_json;
+extern const char src_vmaf_v0_6_1_json[];
 extern const int src_vmaf_v0_6_1_json_len;
-extern const char src_vmaf_b_v0_6_3_json;
+extern const char src_vmaf_b_v0_6_3_json[];
 extern const int src_vmaf_b_v0_6_3_json_len;
-extern const char src_vmaf_v0_6_1neg_json;
+extern const char src_vmaf_v0_6_1neg_json[];
 extern const int src_vmaf_v0_6_1neg_json_len;
-extern const char src_vmaf_4k_v0_6_1_json;
+extern const char src_vmaf_4k_v0_6_1_json[];
 extern const int src_vmaf_4k_v0_6_1_json_len;
-extern const char src_vmaf_4k_v0_6_1neg_json;
+extern const char src_vmaf_4k_v0_6_1neg_json[];
 extern const int src_vmaf_4k_v0_6_1neg_json_len;
 #endif
 
@@ -47,48 +47,48 @@ static const VmafBuiltInModel built_in_models[] = {
 #if VMAF_FLOAT_FEATURES
     {
         .version = "vmaf_float_v0.6.1",
-        .data = &src_vmaf_float_v0_6_1_json,
+        .data = src_vmaf_float_v0_6_1_json,
         .data_len = &src_vmaf_float_v0_6_1_json_len,
     },
     {
         .version = "vmaf_float_b_v0.6.3",
-        .data = &src_vmaf_float_b_v0_6_3_json,
+        .data = src_vmaf_float_b_v0_6_3_json,
         .data_len = &src_vmaf_float_b_v0_6_3_json_len,
     },
     {
         .version = "vmaf_float_v0.6.1neg",
-        .data = &src_vmaf_float_v0_6_1neg_json,
+        .data = src_vmaf_float_v0_6_1neg_json,
         .data_len = &src_vmaf_float_v0_6_1neg_json_len,
     },
     {
         .version = "vmaf_float_4k_v0.6.1",
-        .data = &src_vmaf_float_4k_v0_6_1_json,
+        .data = src_vmaf_float_4k_v0_6_1_json,
         .data_len = &src_vmaf_float_4k_v0_6_1_json_len,
     },
 #endif
     {
         .version = "vmaf_v0.6.1",
-        .data = &src_vmaf_v0_6_1_json,
+        .data = src_vmaf_v0_6_1_json,
         .data_len = &src_vmaf_v0_6_1_json_len,
     },
     {
         .version = "vmaf_b_v0.6.3",
-        .data = &src_vmaf_b_v0_6_3_json,
+        .data = src_vmaf_b_v0_6_3_json,
         .data_len = &src_vmaf_b_v0_6_3_json_len,
     },
     {
         .version = "vmaf_v0.6.1neg",
-        .data = &src_vmaf_v0_6_1neg_json,
+        .data = src_vmaf_v0_6_1neg_json,
         .data_len = &src_vmaf_v0_6_1neg_json_len,
     },
     {
         .version = "vmaf_4k_v0.6.1",
-        .data = &src_vmaf_4k_v0_6_1_json,
+        .data = src_vmaf_4k_v0_6_1_json,
         .data_len = &src_vmaf_4k_v0_6_1_json_len,
     },
     {
         .version = "vmaf_4k_v0.6.1neg",
-        .data = &src_vmaf_4k_v0_6_1neg_json,
+        .data = src_vmaf_4k_v0_6_1neg_json,
         .data_len = &src_vmaf_4k_v0_6_1neg_json_len,
     },
 #endif


### PR DESCRIPTION
Partly addresses #1228. The mismatch is between these `extern` variables and the output of `xxd` which hex-dumps the model JSON files into unsigned char arrays in C files.