### PR TITLE
unpin PyWavelets since 1.1.1 will not build with recent Python versions

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,6 +8,6 @@ h5py>=2.6.0
 sureal>=0.4.2
 dill>=0.3.1
 cython
-PyWavelets==1.1.1
+PyWavelets>=1.1.1
 python-slugify>=5.0.0
 libsvm-official>=3.30


### PR DESCRIPTION
Trying to install the Python requirements with a modern (3.11+) version of Python fails due to some internal API changes. See #1313 for more details

```
pywt/_extensions/_pywt.c:253:12: fatal error: 'longintrepr.h' file not found
```

it looks like even 3.10 does not build 

```
 pywt/_extensions/_pywt.c:32259:5: error: expression is not assignable
          ++Py_REFCNT(o);
```

After doing some digging I'm not seeing a clear reason why PyWavelets was pinned to 1.1.1 in the first place. Unpinning it allows the requirements to install the wavelet related tests are passing. 

Some tests do fail with modern numpy versions due to some API changes, but those are unrelated and I'll address those in a separate PR.