### PR TITLE
materialize map object before calling np.vstack

### DIFF
--- a/python/vmaf/core/niqe_train_test_model.py
+++ b/python/vmaf/core/niqe_train_test_model.py
@@ -64,9 +64,9 @@ class NiqeTrainTestModel(TrainTestModel, RegressorMixin):
 
         xs_2d = []
         for i_sample in range(num_samples):
-            xs_2d_ = np.vstack(map(
+            xs_2d_ = np.vstack(list(map(
                 lambda feature_name: xys[feature_name][i_sample], feature_names)
-            ).T
+            )).T
             xs_2d.append(xs_2d_)
         xs_2d = np.vstack(xs_2d)
 


### PR DESCRIPTION
Newer numpy versions no longer allow passing in iterable objects to array stack. 
```
arrays to stack must be passed as a "sequence" type such as list or tuple
```

This has been a future warning for a while and I guess at some point it was actually removed. The easy fix is to wrap the map object in a list() call.