### PR TITLE
update pip install instructions for macOS to use homebrew llvm

### DIFF
--- a/resource/doc/python.md
+++ b/resource/doc/python.md
@@ -41,7 +41,7 @@ brew install python3
 Install the remaining dependencies:
 
 ```bash
-brew install nasm doxygen
+brew install nasm doxygen llvm
 ```
 
 Note that `brew` requires no `sudo`.
@@ -75,6 +75,13 @@ Install the rest of the required Python packages:
 ```shell script
 pip3 install -r python/requirements.txt
 ```
+
+On macOS it's important to use the LLVM from homebrew as the macOS clang does not include support for OpenMP, which is needed for libsvm-official
+
+``` shell script
+LLVM_CONFIG=$HOMEBREW_PREFIX/opt/llvm/bin/llvm-config pip install -r ./python/requirements.txt
+```
+
 
 ## Testing
 


### PR DESCRIPTION
As reported in #1313 trying to install Python libraries on modern macOS will fail because Apple has explicitly disabled OpenMP support in clang. Instead mention installing and using the llvm from homebrew for the pip install.
