### PR TITLE
github/workflows/libvmaf.yml: upload to a specific name for each matrix.oss and matrix.cc

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Upload vmaf
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}-vmaf
+          name: ${{ matrix.os }}-${{ matrix.CC }}-vmaf
           path: ${{ steps.get_info.outputs.path }}
       - name: Upload vmaf
         if: steps.get_info.outputs.upload_url != 'null'


### PR DESCRIPTION
Should fix #1278 and unblock #1292