### PR TITLE
Simplify framesync API

### DIFF
--- a/libvmaf/src/framesync.c
+++ b/libvmaf/src/framesync.c
@@ -110,8 +110,7 @@ int vmaf_framesync_acquire_new_buf(VmafFrameSyncContext *fs_ctx, void **data,
     return 0;
 }
 
-int vmaf_framesync_submit_filled_data(VmafFrameSyncContext *fs_ctx, void *data,
-                                      unsigned index)
+int vmaf_framesync_submit_filled_data(VmafFrameSyncContext *fs_ctx, unsigned index)
 {
     VmafFrameSyncBuf *buf_que = fs_ctx->buf_que;
 
@@ -121,8 +120,6 @@ int vmaf_framesync_submit_filled_data(VmafFrameSyncContext *fs_ctx, void *data,
     for (unsigned i = 0; i < fs_ctx->buf_cnt; i++) {
         if ((buf_que->index == index) && (buf_que->buf_status == BUF_ACQUIRED)) {
             buf_que->buf_status = BUF_FILLED;
-            if (data != buf_que->frame_data)
-                return -1;
             break;
         }
 
@@ -167,8 +164,7 @@ int vmaf_framesync_retrieve_filled_data(VmafFrameSyncContext *fs_ctx,
     return 0;
 }
 
-int vmaf_framesync_release_buf(VmafFrameSyncContext *fs_ctx, void *data,
-                               unsigned index)
+int vmaf_framesync_release_buf(VmafFrameSyncContext *fs_ctx, unsigned index)
 {
     VmafFrameSyncBuf *buf_que = fs_ctx->buf_que;
 
@@ -176,9 +172,6 @@ int vmaf_framesync_release_buf(VmafFrameSyncContext *fs_ctx, void *data,
     // loop until a matching buffer is found
     for (unsigned i = 0; i < fs_ctx->buf_cnt; i++) {
         if ((buf_que->index == index) && (buf_que->buf_status == BUF_RETRIEVED)) {
-            if (data != buf_que->frame_data)
-                return -1;
-
             free(buf_que->frame_data);
             buf_que->frame_data = NULL;
             buf_que->buf_status = BUF_FREE;

--- a/libvmaf/src/framesync.h
+++ b/libvmaf/src/framesync.h
@@ -32,14 +32,12 @@ int vmaf_framesync_init(VmafFrameSyncContext **fs_ctx);
 int vmaf_framesync_acquire_new_buf(VmafFrameSyncContext *fs_ctx, void **data,
                                    unsigned data_sz, unsigned index);
 
-int vmaf_framesync_submit_filled_data(VmafFrameSyncContext *fs_ctx, void *data,
-                                      unsigned index);
+int vmaf_framesync_submit_filled_data(VmafFrameSyncContext *fs_ctx, unsigned index);
 
 int vmaf_framesync_retrieve_filled_data(VmafFrameSyncContext *fs_ctx, void **data,
                                         unsigned index);
 
-int vmaf_framesync_release_buf(VmafFrameSyncContext *fs_ctx, void *data,
-                               unsigned index);
+int vmaf_framesync_release_buf(VmafFrameSyncContext *fs_ctx, unsigned index);
 
 int vmaf_framesync_destroy(VmafFrameSyncContext *fs_ctx);
 

--- a/libvmaf/test/test_framesync.c
+++ b/libvmaf/test/test_framesync.c
@@ -55,8 +55,7 @@ static void my_worker(void *data)
         shared_buf[ctr] = thread_data->ref[ctr] + thread_data->dist[ctr] + 2;
 
     //submit filled buffer back to frame sync
-    vmaf_framesync_submit_filled_data(thread_data->fs_ctx, shared_buf,
-                                      thread_data->index);
+    vmaf_framesync_submit_filled_data(thread_data->fs_ctx, thread_data->index);
 
     //sleep to simulate work load
     const int sleep_seconds = 1;
@@ -81,8 +80,7 @@ static void my_worker(void *data)
     }
 
     //release dependent buffer from frame sync
-    vmaf_framesync_release_buf(thread_data->fs_ctx, dependent_buf,
-                               thread_data->index - 1);
+    vmaf_framesync_release_buf(thread_data->fs_ctx, thread_data->index - 1);
 
 cleanup:
     free(thread_data->ref);


### PR DESCRIPTION
The `data` parameter to `vmaf_framesync_submit_filled_data` and `vmaf_framesync_release_buf` was only used to check that it was the same pointer that was present in the framesync internal data structure. I believe this can be simplified.

As an example usage, the `integer_funque` implementation [here](https://github.com/MallikarjunKamble/vmaf/blob/FLOAT_FUNQUE_PLUS_MULTITHREADING/libvmaf/src/feature/third_party/funque/integer_funque.c) creates two dummy variables, `shared_buf_temp` and `dependent_buf_temp`, just to pass into these functions. With this simplification, we could avoid those.