### PR TITLE
added vmaf_cuda_fex_synchronize, fixed cuda fex flush functions

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf_cuda.h
+++ b/libvmaf/include/libvmaf/libvmaf_cuda.h
@@ -102,6 +102,17 @@ int vmaf_cuda_preallocate_pictures(VmafContext *vmaf,
  */
 int vmaf_cuda_fetch_preallocated_picture(VmafContext *vmaf, VmafPicture* pic);
 
+/**
+ * Synchronizes all CUDA feature extractors within the VmafContext 
+ * with the CPU using their flush function. All feature scores will 
+ * be written when this function returns.
+ *
+ * @param vmaf VMAF context allocated with `vmaf_init()` and
+ *             initialized with `vmaf_cuda_preallocate_pictures()`.
+ * @return 0 on success, or < 0 (a negative errno code) on error.
+ */
+int vmaf_cuda_fex_synchronize(VmafContext *vmaf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libvmaf/src/feature/cuda/integer_adm_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_adm_cuda.c
@@ -31,7 +31,6 @@
 #include "cuda/integer_adm_cuda.h"
 #include "picture_cuda.h"
 #include <unistd.h>
-
 #include <assert.h>
 
 #define RES_BUFFER_SIZE 4 * 3 * 2
@@ -1223,7 +1222,8 @@ static int flush_fex_cuda(VmafFeatureExtractor *fex,
 {
     AdmStateCuda *s = fex->priv;
     CHECK_CUDA(cuStreamSynchronize(s->str));
-    return 1;
+    CHECK_CUDA(cuStreamSynchronize(s->host_stream));
+    return 0;
 }
 
 static const char *provided_features[] = {

--- a/libvmaf/src/feature/cuda/integer_motion_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_motion_cuda.c
@@ -210,13 +210,14 @@ static int flush_fex_cuda(VmafFeatureExtractor *fex,
     CHECK_CUDA(cuStreamSynchronize(s->str));
     CHECK_CUDA(cuStreamSynchronize(s->host_stream));
 
-    if (s->index > 0) {
-        ret = vmaf_feature_collector_append(feature_collector,
-                "VMAF_integer_feature_motion2_score",
-                s->score, s->index);
-    }
+    // Not required, write_scores takes care of this
+    // if (s->index > 0) {
+    //     ret = vmaf_feature_collector_append(feature_collector,
+    //             "VMAF_integer_feature_motion2_score",
+    //             s->score, s->index);
+    // }
 
-    return (ret < 0) ? ret : !ret;
+    return 0;
 }
 
 static inline double normalize_and_scale_sad(uint64_t sad,

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -496,7 +496,7 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex,
     write_score_parameters_vif *data = s->buf.cpu_param_buf;
     data->feature_collector = feature_collector;
     data->index = index;
-    CHECK_CUDA(cuLaunchHostFunc(s->str, write_scores, data));
+    CHECK_CUDA(cuLaunchHostFunc(s->host_stream, write_scores, data));
     return 0;
 }
 
@@ -527,7 +527,8 @@ static int flush_fex_cuda(VmafFeatureExtractor *fex,
     VifStateCuda *s = fex->priv;
 
     CHECK_CUDA(cuStreamSynchronize(s->str));
-    return 1;
+    CHECK_CUDA(cuStreamSynchronize(s->host_stream));
+    return 0;
 }
 
 static const char *provided_features[] = {

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -362,6 +362,20 @@ int vmaf_use_features_from_model_collection(VmafContext *vmaf,
     return err;
 }
 
+
+int vmaf_cuda_fex_synchronize(VmafContext *vmaf) {
+    if(!vmaf) return -EINVAL;
+    int err = 0;
+    RegisteredFeatureExtractors rfe = vmaf->registered_feature_extractors;
+        for (unsigned i = 0; i < rfe.cnt; i++) {
+            if ((rfe.fex_ctx[i]->fex->flags & VMAF_FEATURE_EXTRACTOR_CUDA))
+                err |= vmaf_feature_extractor_context_flush(rfe.fex_ctx[i],
+                                                            vmaf->feature_collector);
+        }
+
+    return err;
+}
+
 struct ThreadData {
     VmafFeatureExtractorContext *fex_ctx;
     VmafPicture ref, dist;


### PR DESCRIPTION
This PR fixes the CUDA feature extractor flush functions and adds the possibility to synchronize the CUDA Feature extractors with the CPU so you can retrieve the VMAF, otherwise the function vmaf_score_at_index would either hang or not return a proper result. 

Usage:
```
vmaf_read_pictures(vmaf_ctx, ref, dis, idx);
vmaf_cuda_fex_synchronize(vmaf_ctx);
vmaf_score_at_index(vmaf_ctx, vmaf_model, vmaf_score, idx);
```

