### PR TITLE
Install python build dependencies in Makefile; simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # get and install building tools
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
     build-essential \
-    git \
     ninja-build \
     nasm \
     doxygen \
@@ -17,11 +16,7 @@ RUN apt-get update && \
     python3-pip \
     python3-setuptools \
     python3-wheel \
-    python3-tk \
-    python3-venv \
-    && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
+    python3-venv
 
 # retrieve source code
 COPY . /vmaf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # setup timezone
 ENV TZ=UTC

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,13 @@ RUN apt-get update && \
     python3-setuptools \
     python3-wheel \
     python3-tk \
+    python3-venv \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
 # retrieve source code
 COPY . /vmaf
-
-# install python requirements
-RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir meson cython numpy
 
 # setup environment
 ENV PATH=/vmaf:/vmaf/libvmaf/build/tools:$PATH

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
-all:
+VENV=.venv
+.PHONY: all install clean distclean deps
+
+all: deps
 	meson setup libvmaf/build libvmaf --buildtype release -Denable_float=true && \
-	ninja -vC libvmaf/build
-	cd python && python3 setup.py build_ext --build-lib .
+	ninja -vC libvmaf/build && \
+	cd python && \
+	../$(VENV)/bin/python setup.py build_ext --build-lib .
+
+install: deps
+	meson setup libvmaf/build libvmaf --buildtype release && \
+	ninja -vC libvmaf/build install
 
 clean:
 	rm -rf libvmaf/build
 	rm -f python/vmaf/core/adm_dwt2_cy.c*
 
-install:
-	meson setup libvmaf/build libvmaf --buildtype release && \
-	ninja -vC libvmaf/build install
+distclean: clean
+	rm -rf $(VENV)
+
+deps:
+	test -d $(VENV) || python3 -mvenv $(VENV)
+	$(VENV)/bin/pip install meson ninja cython numpy

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ VENV=.venv
 .PHONY: all install clean distclean deps
 
 all: deps
-	meson setup libvmaf/build libvmaf --buildtype release -Denable_float=true && \
-	ninja -vC libvmaf/build && \
+	$(VENV)/bin/meson setup libvmaf/build libvmaf --buildtype release -Denable_float=true && \
+	$(VENV)/bin/ninja -vC libvmaf/build && \
 	cd python && \
 	../$(VENV)/bin/python setup.py build_ext --build-lib .
 
 install: deps
-	meson setup libvmaf/build libvmaf --buildtype release && \
-	ninja -vC libvmaf/build install
+	$(VENV)/bin/meson setup libvmaf/build libvmaf --buildtype release && \
+	$(VENV)/bin/ninja -vC libvmaf/build install
 
 clean:
 	rm -rf libvmaf/build


### PR DESCRIPTION
This seems like a more streamlined user experience to make sure they have the pip dependencies installed when they run `make` or `make install`.