### PR TITLE
python/__init__.py: update python version to 3.0.0

### DIFF
--- a/python/vmaf/__init__.py
+++ b/python/vmaf/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 logging.basicConfig()
 logger = logging.getLogger(os.path.splitext(os.path.basename(__file__))[0])


### PR DESCRIPTION
Regarding #1309, this brings both versions up to parity again but doesn't address the long term mismatch. Leaving that issue open until that is solved.