### PR TITLE
Fix warnings raised by pytest

### DIFF
--- a/python/test/asset_test.py
+++ b/python/test/asset_test.py
@@ -521,7 +521,6 @@ class AssetTest(unittest.TestCase):
         asset = Asset(dataset="test", content_id=0, asset_id=0,
                       ref_path="", dis_path="",
                       asset_dict={'fps': 24, 'start_sec': 2, 'end_sec': 3})
-        self.assertEqual(asset.resampling_type, 'bicubic')
         self.assertEqual(asset.ref_resampling_type, 'bicubic')
         self.assertEqual(asset.dis_resampling_type, 'bicubic')
 
@@ -529,7 +528,6 @@ class AssetTest(unittest.TestCase):
                       ref_path="", dis_path="",
                       asset_dict={'fps': 24, 'start_sec': 2, 'end_sec': 3,
                                   'resampling_type': 'lanczos'})
-        self.assertEqual(asset.resampling_type, 'lanczos')
         self.assertEqual(asset.ref_resampling_type, 'lanczos')
         self.assertEqual(asset.dis_resampling_type, 'lanczos')
 
@@ -537,7 +535,6 @@ class AssetTest(unittest.TestCase):
                       ref_path="", dis_path="",
                       asset_dict={'fps': 24, 'start_sec': 2, 'end_sec': 3,
                                   'resampling_type': 'bicubic'})
-        self.assertEqual(asset.resampling_type, 'bicubic')
         self.assertEqual(asset.ref_resampling_type, 'bicubic')
         self.assertEqual(asset.dis_resampling_type, 'bicubic')
 
@@ -548,8 +545,6 @@ class AssetTest(unittest.TestCase):
                                   'dis_resampling_type': 'lanczos'})
         self.assertEqual(asset.ref_resampling_type, 'bilinear')
         self.assertEqual(asset.dis_resampling_type, 'lanczos')
-        with self.assertRaises(AssertionError):
-            _ = asset.resampling_type
 
         asset = Asset(dataset="test", content_id=0, asset_id=0,
                       ref_path="", dis_path="",
@@ -559,8 +554,6 @@ class AssetTest(unittest.TestCase):
                                   'resampling_type': 'bilinear'})
         self.assertEqual(asset.ref_resampling_type, 'bilinear')
         self.assertEqual(asset.dis_resampling_type, 'lanczos')
-        with self.assertRaises(AssertionError):
-            _ = asset.resampling_type
 
     def test_use_path_as_workpath(self):
         asset = Asset(dataset="test", content_id=0, asset_id=0,

--- a/python/test/routine_test.py
+++ b/python/test/routine_test.py
@@ -136,11 +136,13 @@ class TestReadDataset(unittest.TestCase):
         self.assertTrue('groundtruth' in assets[0].asset_dict.keys())
         self.assertTrue('os' not in assets[0].asset_dict.keys())
         self.assertEqual(assets[0].quality_width_height, (1920, 1080))
-        self.assertEqual(assets[0].resampling_type, 'bicubic')
+        self.assertEqual(assets[0].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[0].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[0].ref_yuv_type, 'yuv420p')
         self.assertEqual(assets[0].dis_yuv_type, 'yuv420p')
         self.assertEqual(assets[1].quality_width_height, (1920, 1080))
-        self.assertEqual(assets[1].resampling_type, 'bicubic')
+        self.assertEqual(assets[1].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[1].dis_resampling_type, 'bicubic')
 
     def test_read_dataset_mixed(self):
         dataset_path = VmafConfig.test_resource_path('test_dataset_mixed.py')
@@ -149,25 +151,29 @@ class TestReadDataset(unittest.TestCase):
 
         self.assertEqual(len(assets), 4)
 
-        self.assertEqual(assets[0].resampling_type, 'bicubic')
+        self.assertEqual(assets[0].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[0].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[0].ref_yuv_type, 'yuv420p')
         self.assertEqual(assets[0].dis_yuv_type, 'yuv420p')
         self.assertEqual(assets[0].ref_width_height, (1920, 1080))
         self.assertEqual(assets[0].dis_width_height, (1920, 1080))
 
-        self.assertEqual(assets[1].resampling_type, 'bicubic')
+        self.assertEqual(assets[1].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[1].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[1].ref_yuv_type, 'yuv420p')
         self.assertEqual(assets[1].dis_yuv_type, 'notyuv')
         self.assertEqual(assets[1].ref_width_height, (1920, 1080))
         self.assertEqual(assets[1].dis_width_height, None)
 
-        self.assertEqual(assets[2].resampling_type, 'bicubic')
+        self.assertEqual(assets[2].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[2].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[2].ref_yuv_type, 'yuv420p')
         self.assertEqual(assets[2].dis_yuv_type, 'yuv420p')
         self.assertEqual(assets[2].ref_width_height, (720, 480))
         self.assertEqual(assets[2].dis_width_height, (720, 480))
 
-        self.assertEqual(assets[3].resampling_type, 'bicubic')
+        self.assertEqual(assets[3].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[3].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[3].ref_yuv_type, 'yuv420p')
         self.assertEqual(assets[3].dis_yuv_type, 'notyuv')
         self.assertEqual(assets[3].ref_width_height, (720, 480))
@@ -182,7 +188,8 @@ class TestReadDataset(unittest.TestCase):
 
         self.assertEqual(len(assets), 3)
 
-        self.assertEqual(assets[0].resampling_type, 'bicubic')
+        self.assertEqual(assets[0].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[0].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[0].ref_yuv_type, 'notyuv')
         self.assertEqual(assets[0].dis_yuv_type, 'notyuv')
         self.assertEqual(assets[0].ref_width_height, None)
@@ -217,7 +224,8 @@ class TestReadDataset(unittest.TestCase):
 
         self.assertEqual(len(assets), 3)
 
-        self.assertEqual(assets[0].resampling_type, 'bicubic')
+        self.assertEqual(assets[0].ref_resampling_type, 'bicubic')
+        self.assertEqual(assets[0].dis_resampling_type, 'bicubic')
         self.assertEqual(assets[0].ref_yuv_type, 'notyuv')
         self.assertEqual(assets[0].dis_yuv_type, 'notyuv')
         self.assertEqual(assets[0].ref_width_height, None)

--- a/python/vmaf/tools/sigproc.py
+++ b/python/vmaf/tools/sigproc.py
@@ -125,7 +125,9 @@ def calpvalue(aucs, sigma):
     # pvalue = 2 * (1 - normcdf(z, 0, 1));
     l = np.array([[1, -1]])
     z = np.abs(np.diff(aucs)) / np.sqrt(np.dot(np.dot(l, sigma), l.T))
-    pvalue = 2 * (1 - scipy.stats.norm.cdf(z, loc=0, scale=1))
+    # numpy returns a 2-dimensional array with shape (1, 1), extract the element
+    z_val = z[0, 0]
+    pvalue = 2 * (1 - scipy.stats.norm.cdf(z_val, loc=0, scale=1))
     return pvalue
 
 


### PR DESCRIPTION
Currently we mute the warnings in tox.ini, this is a first step towards cleaning them up.