### PR TITLE
increase max feature count to 64

### DIFF
--- a/libvmaf/src/read_json_model.c
+++ b/libvmaf/src/read_json_model.c
@@ -25,7 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_FEATURE_COUNT 32 //FIXME
+#define MAX_FEATURE_COUNT 64 //FIXME
 #define MAX_KNOT_COUNT 10 //FIXME
 
 static int parse_feature_opts_dicts(json_stream *s, VmafModel *model)


### PR DESCRIPTION
During the implementation of FUNQUE+ feature extractors we ran into the 32 max limit for JSON features and hand to bump this up to 64. In practice this may not be needed as not all exposed features are likely to be used, but we needed this to exhaustively exercise the feature extractor.

Co-authored-by: Mallikarjun Kamble <mallikarjun.kamble@ittiam.com>