### PR TITLE
Fix frame double-free

### DIFF
--- a/libvmaf/src/picture.c
+++ b/libvmaf/src/picture.c
@@ -124,8 +124,8 @@ int vmaf_picture_unref(VmafPicture *pic) {
     if (!pic) return -EINVAL;
     if (!pic->ref) return -EINVAL;
 
-    vmaf_ref_fetch_decrement(pic->ref);
-    if (vmaf_ref_load(pic->ref) == 0) {
+    const long old_cnt = vmaf_ref_fetch_decrement(pic->ref);
+    if (old_cnt == 1) {
         const VmafPicturePrivate *priv = pic->priv;
         priv->release_picture(pic, priv->cookie);
         free(pic->priv);

--- a/libvmaf/src/ref.c
+++ b/libvmaf/src/ref.c
@@ -36,9 +36,9 @@ void vmaf_ref_fetch_increment(VmafRef *ref)
     atomic_fetch_add(&ref->cnt, 1);
 }
 
-void vmaf_ref_fetch_decrement(VmafRef *ref)
+long vmaf_ref_fetch_decrement(VmafRef *ref)
 {
-    atomic_fetch_sub(&ref->cnt, 1);
+    return atomic_fetch_sub(&ref->cnt, 1);
 }
 
 long vmaf_ref_load(VmafRef *ref)

--- a/libvmaf/src/ref.h
+++ b/libvmaf/src/ref.h
@@ -27,7 +27,7 @@ typedef struct VmafRef {
 
 int vmaf_ref_init(VmafRef **ref);
 void vmaf_ref_fetch_increment(VmafRef *ref);
-void vmaf_ref_fetch_decrement(VmafRef *ref);
+long vmaf_ref_fetch_decrement(VmafRef *ref);
 long vmaf_ref_load(VmafRef *ref);
 int vmaf_ref_close(VmafRef *ref);
 


### PR DESCRIPTION
Decrement refcnt and load the refcnt should be in 1 instruction in order to prevent data race in a multithreading environment.