### PR TITLE
Clean up: remove support for python2

### DIFF
--- a/python/vmaf/core/cross_validation.py
+++ b/python/vmaf/core/cross_validation.py
@@ -8,11 +8,6 @@ from math import floor
 import sys
 
 
-# TODO: remove this once python2 support is dropped, in python3 all int are as long as you want
-if sys.version_info[0] == 3:
-    long = int
-
-
 class ModelCrossValidation(object):
 
     @staticmethod
@@ -66,7 +61,7 @@ class ModelCrossValidation(object):
         :return: output
         """
 
-        if isinstance(kfold, (int, long)):
+        if isinstance(kfold, int):
             kfold_type = 'int'
         elif isinstance(kfold, (list, tuple)):
             kfold_type = 'list'
@@ -158,7 +153,7 @@ class ModelCrossValidation(object):
         :return: output
         """
 
-        if isinstance(kfold, (int, long)):
+        if isinstance(kfold, int):
             kfold_type = 'int'
         elif isinstance(kfold, (list, tuple)):
             kfold_type = 'list'

--- a/python/vmaf/core/raw_extractor.py
+++ b/python/vmaf/core/raw_extractor.py
@@ -13,10 +13,6 @@ from vmaf.core.result import RawResult
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
-# TODO: remove this once python2 support is dropped
-if sys.version_info[0] == 3:
-    basestring = str
-
 
 class RawExtractor(Executor):
 
@@ -85,7 +81,7 @@ class DisYUVRawVideoExtractor(H5pyMixin, RawExtractor):
             return 'yuv'
         else:
             channels = self.optional_dict['channels']
-            assert isinstance(channels, basestring)
+            assert isinstance(channels, str)
             channels = set(channels.lower())
             assert channels.issubset(set('yuv'))
             return ''.join(channels)

--- a/python/vmaf/tools/misc.py
+++ b/python/vmaf/tools/misc.py
@@ -23,13 +23,6 @@ __license__ = "BSD+Patent"
 
 
 try:
-    unicode  # noqa, remove this once python2 support is dropped
-
-except NameError:
-    unicode = str
-
-
-try:
     multiprocessing.set_start_method('fork')
 except ValueError:  # noqa, If platform does not support, just ignore
     pass

--- a/python/vmaf/tools/scanf.py
+++ b/python/vmaf/tools/scanf.py
@@ -173,13 +173,7 @@ import string
 import sys
 import unittest
 
-try:
-    import StringIO
-
-    StringIO = StringIO.StringIO  # TODO: remove this once python2 support is dropped
-
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 
 __all__ = ['scanf', 'sscanf', 'fscanf']


### PR DESCRIPTION
We already [specify](https://github.com/Netflix/vmaf/blob/master/resource/doc/python.md) that python should be >= 3.6, and use python3.6 features such as f-strings throughout the code base. This should make no difference to any users.