### PR TITLE
requirements.txt: pin numpy to <2.0.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.18.2
+numpy>=1.18.2,<2.0.0
 scipy>=1.4.1
 matplotlib>=3.2.1
 pandas>=1.0.3


### PR DESCRIPTION
Some of our python code is broken by the numpy v2.0.0 changes. Namely, printing numpy float values is now different:
* in numpy 1.x:
```
>>> a = {"a": np.float64(3.2)}
>>> print(a)
{'a': 3.2}
```

* in numpy 2.x:
```
>>> a = {"a": np.float64(3.2)}
>>> print(a)
{'a': np.float64(3.2)}
```

This doesn't play well with the `ast.literal_eval`-based parsing that we use. Longer term, we should get rid of `ast.literal_eval` and use JSON. 