### PR TITLE
fix wrong ENTRYPOINT in Dockerfile.cuda

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -42,4 +42,4 @@ ENTRYPOINT ["ffmpeg" ,"-hwaccel", "cuda", "-hwaccel_output_format" ,"cuda", \
     "-i" ,"/data/ref.mp4", \
     "-hwaccel", "cuda", "-hwaccel_output_format", "cuda", \
     "-i", "/data/dis.mp4"  ,\
-    "-filter_complex", "[0:v][1:v]libvmaf_cuda" ,"-f" ,"null", "-"]
+    "-filter_complex", "[0:v]scale_cuda=format=yuv420p[ref];[1:v]scale_cuda=format=yuv420p[dist];[dist][ref]libvmaf_cuda" ,"-f" ,"null", "-"]


### PR DESCRIPTION
Adjust the order and format of inputs to libvmaf_cuda  according to https://ffmpeg.org/ffmpeg-filters.html#toc-libvmaf_005fcuda


The libvmaf_cuda filter allows only `AV_FIX_FMT_CUDA` but `NV12`(sw_format) is not supported.
> https://github.com/FFmpeg/FFmpeg/blob/master/libavfilter/vf_libvmaf.c#L821C26-L821C41

So the current config raises `[libvmaf @ 0x7f95d00050c0] Unsupported input format: nv12` like below.

```
Stream mapping:
  Stream #0:0 (h264) -> libvmaf_cuda
  Stream #1:0 (h264) -> libvmaf_cuda
  libvmaf_cuda:default -> Stream #0:0 (wrapped_avframe)
Press [q] to stop, [?] for help
[libvmaf @ 0x7f95d00050c0] Unsupported input format: nv12
[Parsed_libvmaf_cuda_0 @ 0x7f95d0004fc0] Failed to configure output pad on Parsed_libvmaf_cuda_0
[fc#0 @ 0x55b0b17da800] Error reinitializing filters!
[fc#0 @ 0x55b0b17da800] Task finished with error code: -22 (Invalid argument)
[fc#0 @ 0x55b0b17da800] Terminating thread with return code -22 (Invalid argument)
[vost#0:0/wrapped_avframe @ 0x55b0b181a8c0] Could not open encoder before EOF
[vost#0:0/wrapped_avframe @ 0x55b0b181a8c0] Task finished with error code: -22 (Invalid argument)
[vost#0:0/wrapped_avframe @ 0x55b0b181a8c0] Terminating thread with return code -22 (Invalid argument)
[out#0/null @ 0x55b0b181be80] Nothing was written into output file, because at least one of its streams received no packets.
frame=    0 fps=0.0 q=0.0 Lsize=       0KiB time=N/A bitrate=N/A speed=N/A

Conversion failed!
```