### PR TITLE
Update Dockerfile.cuda

### DIFF
--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -13,11 +13,30 @@ RUN git clone https://github.com/FFmpeg/FFmpeg.git && cd FFmpeg && git checkout 
 
 RUN git clone https://github.com/FFmpeg/nv-codec-headers.git && cd nv-codec-headers && make && make install
 
+#Add CUDA Stubs to ldconfig:
+
+RUN bash -c "echo '/usr/local/cuda/lib64/stubs/' > /etc/ld.so.conf.d/cuda-stubs.conf"
+RUN ldconfig
+
 # install vmaf
 RUN python3 -m pip install meson
-RUN cd vmaf && meson libvmaf/build libvmaf -Denable_cuda=true -Denable_avx512=true --buildtype release && \
+RUN cd vmaf && meson setup \
+    libvmaf/build libvmaf \
+    --prefix=/usr/local \
+    --libdir=/usr/local/lib \
+    --default-library=shared \
+    -Denable_tests=false \
+    -Denable_cuda=true \
+    -Denable_avx512=true \
+    --buildtype release && \
     ninja -vC libvmaf/build  && \
-    ninja -vC libvmaf/build  install
+    ninja -vC libvmaf/build  install && \
+    mkdir -p /usr/local/share/model/ && \
+    cp -r /vmaf/model/* /usr/local/share/model/
+
+#Call ldconfig again:
+
+RUN ldconfig
 
 # install ffmpeg
 RUN cd FFmpeg && ./configure \
@@ -32,7 +51,7 @@ RUN cd FFmpeg && ./configure \
     --enable-ffnvcodec \
     --disable-stripping \
     --extra-cflags="-I/usr/local/cuda/include" \
-    --extra-ldflags="-L/usr/local/cuda/lib64 -L/usr/local/cuda/lib64/stubs/" 
+    --extra-ldflags="-L/usr/local/cuda/lib64" 
 
 RUN cd FFmpeg && make -j && make install
 


### PR DESCRIPTION
This patch is a fix to #1379, wherein:

1. The CUDA library stubs are added to `ldconfig`'s cache.
2. The build type for `libvmaf` is set to `shared`.
3. The included models are also copied to `/usr/local/share/model` for re-usability with custom FFmpeg pipelines as needed.
4. `ldconfig` is called up immediately after `libvmaf` build so that `FFmpeg` can detect it.