### PR TITLE
[#1381] Change cuMemFreeAsync to cuMemFree in vmaf_cuda_picture_free()

### DIFF
--- a/libvmaf/src/cuda/picture_cuda.c
+++ b/libvmaf/src/cuda/picture_cuda.c
@@ -223,7 +223,7 @@ int vmaf_cuda_picture_free(VmafPicture *pic, void *cookie)
 
     for (int i = 0; i < 3; i++) {
 	    if (pic->data[i])
-		    CHECK_CUDA(cuMemFreeAsync(pic->data[i], priv->cuda.str));
+	        CHECK_CUDA(cuMemFree(pic->data[i]));
     }
 
     CHECK_CUDA(cuEventDestroy(priv->cuda.finished));


### PR DESCRIPTION
This PR is a fix to #1381 

### Description
* We have identified that when using the libvmaf_cuda(vmaf-3.0.0) filter with ffmpeg in a constrained virtual memory environment, an assertion failure occurs in vmaf_cuda_picture_free() when ffmpeg terminates.

* You can easily reproduce the issue by running the ffmpeg command with the libvmaf_cuda filter along with `ulimit -v 16777216`. (16777216 represents 16GB, which is a sufficient size for virtual memory.)

```
ulimit -v 16777216;ffmpeg -i a.mp4 -i b.mp4 -filter_complex "[0:v]hwupload_cuda[main];[1:v]hwupload_cuda[ref];[main][ref]libvmaf_cuda=log_fmt=json:log_path=vmaf_log.json" -f null -
```

```
code: 2; description: CUDA_ERROR_OUT_OF_MEMORY
ffmpeg: ../src/cuda/picture_cuda.c:226: vmaf_cuda_picture_free: Assertion `0' failed.
Aborted (core dumped)
```

According to the API documentation, cuMemFreeAsync() does not return CUDA_ERROR_OUT_OF_MEMORY. However, in this abnormal situation, it is returning CUDA_ERROR_OUT_OF_MEMORY.

We have confirmed that using the synchronous memory free API, cuMemFree(), resolves the issue. We propose modifying the code to use cuMemFree() for freeing memory until the underlying cause of the issue with the CUDA asynchronous API is resolved.
