### PR TITLE
Fix build by pinning libsvm-official to <=3.32

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,4 +9,4 @@ sureal>=0.4.2
 dill>=0.3.1
 PyWavelets>=1.1.1
 python-slugify>=5.0.0
-libsvm-official>=3.30
+libsvm-official>=3.30,<=3.32


### PR DESCRIPTION
The build has started failing with this error: 
```
TypeError: <lambda>() got an unexpected keyword argument 'nopython'
```

This is coming from the libsvm module. Past builds have succeeded with 3.32. Trying to pin to see if the upgrade to 3.33 has caused the failures.