### PR TITLE
libvmaf: fix case of windows.h

### DIFF
--- a/libvmaf/test/test_framesync.c
+++ b/libvmaf/test/test_framesync.c
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
mingw provides a windows.h header, not Windows.h.  This causes a build failure when cross compiling from a Unix system with a case sensitive filesystem.