### PR TITLE
libvmaf: don't set _XOPEN_SOURCE

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -20,15 +20,12 @@ libvmaf_inc = include_directories(['include'])
 
 # Arguments in test_args will be used even on feature tests
 test_args = []
-if host_machine.system() == 'linux'
+if host_machine.system() == 'linux' or host_machine.system() == 'windows'
     test_args += '-D_GNU_SOURCE'
     add_project_arguments('-D_GNU_SOURCE', language: 'c')
 elif host_machine.system() == 'darwin'
     test_args += '-D_DARWIN_C_SOURCE'
     add_project_arguments('-D_DARWIN_C_SOURCE', language: 'c')
-else
-    test_args += '-D_XOPEN_SOURCE=600'
-    add_project_arguments('-D_XOPEN_SOURCE=600', language: 'c')
 endif
 
 # Header checks


### PR DESCRIPTION
This used to set _POSIX_C_SOURCE.  [I tried to remove it](https://github.com/Netflix/vmaf/pull/1162), because it caused some functions to be unavailable on BSD, but this broke Windows, so I settled for setting _XOPEN_SOURCE=600, which exposed the necessary functions on BSDs.

This no longer works.  libvmaf now uses the non-standard strsep() function, and FreeBSD only exposes non-standard functions if no standards macros are defined — they're purely subtractive.  So if setting _POSIX_C_SOURCE or _XOPEN_SOURCE isn't the right thing to do, what is?  The build error for Windows is due to a missing M_PI macro.  mingw provides this macro if any of the standards macros defined, or _BSD_SOURCE, _GNU_SOURCE, or _USE_MATH_DEFINES.  Since we already set _GNU_SOURCE for Linux, using that for mingw as well is probably the best thing to do.  That way, we don't have to set a macro thta causes FreeBSD to restrict which functions are available.