### PR TITLE
Fix gcc14 build errors with CUDA enabled

### DIFF
--- a/libvmaf/src/feature/cuda/integer_adm_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_adm_cuda.c
@@ -838,14 +838,14 @@ static void integer_compute_adm_cuda(VmafFeatureExtractor *fex, AdmStateCuda *s,
             // consumes reference picture
             // produces buf->ref_dwt2, buf->dis_dwt2
             if (ref_pic->bpc == 8) {
-                dwt2_8_device(s, (const uint8_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_ref_dwt2, (int16_t*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, &p, vmaf_cuda_picture_get_stream(ref_pic));
+                dwt2_8_device(s, (const uint8_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_ref_dwt2, (short2*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, &p, vmaf_cuda_picture_get_stream(ref_pic));
 
-                dwt2_8_device(s, (const uint8_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (int16_t*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, &p,  vmaf_cuda_picture_get_stream(dis_pic));
+                dwt2_8_device(s, (const uint8_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (short2*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, &p,  vmaf_cuda_picture_get_stream(dis_pic));
             }
             else {
-                adm_dwt2_16_device(s,(uint16_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_ref_dwt2, (int16_t*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, ref_pic->bpc, &p,  vmaf_cuda_picture_get_stream(ref_pic));
+                adm_dwt2_16_device(s,(uint16_t*)ref_pic->data[0], &buf->ref_dwt2, buf->i4_ref_dwt2, (short2*)buf->tmp_ref->data, buf, w, h, curr_ref_stride, buf_stride, ref_pic->bpc, &p,  vmaf_cuda_picture_get_stream(ref_pic));
 
-                adm_dwt2_16_device(s,(uint16_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (int16_t*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, dis_pic->bpc, &p,  vmaf_cuda_picture_get_stream(dis_pic));
+                adm_dwt2_16_device(s,(uint16_t*)dis_pic->data[0], &buf->dis_dwt2, buf->i4_dis_dwt2, (short2*)buf->tmp_dis->data, buf, w, h, curr_dis_stride, buf_stride, dis_pic->bpc, &p,  vmaf_cuda_picture_get_stream(dis_pic));
 
             }
             CHECK_CUDA(cuEventRecord(s->ref_event,  vmaf_cuda_picture_get_stream(ref_pic)));

--- a/libvmaf/src/feature/cuda/integer_motion_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_motion_cuda.c
@@ -173,7 +173,7 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     if (ret) goto free_ref;
     ret |= vmaf_cuda_buffer_alloc(fex->cu_state, &s->sad, sizeof(uint64_t));
     if (ret) goto free_ref;
-    ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, &s->sad_host, sizeof(uint64_t));
+    ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->sad_host, sizeof(uint64_t));
     if (ret) goto free_ref;
 
     s->feature_name_dict =
@@ -315,7 +315,7 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
     params->h = ref_pic->h[0];
     params->w = ref_pic->w[0];
     params->index = index;
-    CHECK_CUDA(cuLaunchHostFunc(s->host_stream, write_scores, s->write_score_parameters));
+    CHECK_CUDA(cuLaunchHostFunc(s->host_stream, (CUhostFn)write_scores, s->write_score_parameters));
     return 0;
 }
 

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -159,27 +159,27 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
 
     s->buf.ref = data; data += frame_size;
     s->buf.dis = data; data += frame_size;
-    s->buf.mu1 = data; data += h * s->buf.stride_16;
-    s->buf.mu2 = data; data += h * s->buf.stride_16;
-    s->buf.mu1_32 = data; data += h * s->buf.stride_32;
-    s->buf.mu2_32 = data; data += h * s->buf.stride_32;
-    s->buf.ref_sq = data; data += h * s->buf.stride_32;
-    s->buf.dis_sq = data; data += h * s->buf.stride_32;
-    s->buf.ref_dis = data; data += h * s->buf.stride_32;
-    s->buf.tmp.mu1 = data; data += s->buf.stride_tmp * h;
-    s->buf.tmp.mu2 = data; data += s->buf.stride_tmp * h;
-    s->buf.tmp.ref = data; data += s->buf.stride_tmp * h;
-    s->buf.tmp.dis = data; data += s->buf.stride_tmp * h;
-    s->buf.tmp.ref_dis = data; data += s->buf.stride_tmp * h;
-    s->buf.tmp.ref_convol = data; data += s->buf.stride_tmp  * h;
-    s->buf.tmp.dis_convol = data; data += s->buf.stride_tmp  * h;
-    s->buf.tmp.padding = data; data += s->buf.stride_tmp  * h;
+    s->buf.mu1 = (uint16_t*)data; data += h * s->buf.stride_16;
+    s->buf.mu2 = (uint16_t*)data; data += h * s->buf.stride_16;
+    s->buf.mu1_32 = (uint32_t*)data; data += h * s->buf.stride_32;
+    s->buf.mu2_32 = (uint32_t*)data; data += h * s->buf.stride_32;
+    s->buf.ref_sq = (uint32_t*)data; data += h * s->buf.stride_32;
+    s->buf.dis_sq = (uint32_t*)data; data += h * s->buf.stride_32;
+    s->buf.ref_dis = (uint32_t*)data; data += h * s->buf.stride_32;
+    s->buf.tmp.mu1 = (uint32_t*)data; data += s->buf.stride_tmp * h;
+    s->buf.tmp.mu2 = (uint32_t*)data; data += s->buf.stride_tmp * h;
+    s->buf.tmp.ref = (uint32_t*)data; data += s->buf.stride_tmp * h;
+    s->buf.tmp.dis = (uint32_t*)data; data += s->buf.stride_tmp * h;
+    s->buf.tmp.ref_dis = (uint32_t*)data; data += s->buf.stride_tmp * h;
+    s->buf.tmp.ref_convol = (uint32_t*)data; data += s->buf.stride_tmp  * h;
+    s->buf.tmp.dis_convol = (uint32_t*)data; data += s->buf.stride_tmp  * h;
+    s->buf.tmp.padding = (uint32_t*)data; data += s->buf.stride_tmp  * h;
 
     CUdeviceptr data_accum;
     ret = vmaf_cuda_buffer_get_dptr(s->buf.accum_data, &data_accum);
     if (ret) goto free_ref;
 
-    s->buf.accum = data_accum;
+    s->buf.accum = (uint64_t*)data_accum;
 
     s->buf.cpu_param_buf = malloc(sizeof(write_score_parameters_vif));
     write_score_parameters_vif *data_p = s->buf.cpu_param_buf;
@@ -496,7 +496,7 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex,
     write_score_parameters_vif *data = s->buf.cpu_param_buf;
     data->feature_collector = feature_collector;
     data->index = index;
-    CHECK_CUDA(cuLaunchHostFunc(s->str, write_scores, data));
+    CHECK_CUDA(cuLaunchHostFunc(s->str, (CUhostFn)write_scores, data));
     return 0;
 }
 


### PR DESCRIPTION
I observed a bunch of errors when compiling vmaf with CUDA enabled. Looks like those errors were exposed when using gcc-14. Running meson with gcc-13 works fine with no issues. This PR fixes errors that prevent me from compiling: explicit casting, missing headers, unused parameter.

Repro:
```
$ meson libvmaf/build libvmaf -Denable_cuda=true -Denable_avx512=true
$ ninja -vC libvmaf/build
```

System:
```
$ cat /etc/redhat-release
Fedora release 41 (Forty One)
```
```
$ gcc --version
gcc (GCC) 14.2.1 20250110 (Red Hat 14.2.1-7)
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```