### PR TITLE
Look for pthreads-win32 when building with MSVC

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -366,7 +366,13 @@ if is_cuda_enabled
     common_cuda_objects += cuda_static_lib.extract_all_objects()
 endif
 
-thread_lib = dependency('threads')
+if host_machine.system() == 'windows' and cc.get_id() == 'msvc'
+  # We require pthreads-win32, not native threading via kernel32.dll, which is what dependency('threads') gives us.
+  # The dirs must be added to %LIB% and %INCLUDE%
+  thread_lib = cc.find_library('pthread_static_lib', has_headers: ['pthread.h'], required : true)
+else
+  thread_lib = dependency('threads')
+endif
 math_lib = cc.find_library('m', required : false)
 
 vmaf_include = include_directories(


### PR DESCRIPTION
Note that MSYS64 identifies itself to Meson as 'cygwin', and has a pthreads-compliant threads implementation.

The sources for pthreads-win32 were once included in this project as a requirement for MSVC, but never made it into the Meson config and were removed at some point (I don't know which happened first).