### PR TITLE
Treat MSYS2/MSYS64/Cygwin like Windows when configuring.

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -20,7 +20,7 @@ libvmaf_inc = include_directories(['include'])
 
 # Arguments in test_args will be used even on feature tests
 test_args = []
-if host_machine.system() == 'linux' or host_machine.system() == 'windows'
+if host_machine.system() == 'linux' or host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
     test_args += '-D_GNU_SOURCE'
     add_project_arguments('-D_GNU_SOURCE', language: 'c')
 elif host_machine.system() == 'darwin'

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -89,7 +89,7 @@ if is_asm_enabled
         cdata_asm.set10('PIC', true)
         config_asm_target = configure_file(output: 'config.asm', output_format: 'nasm', configuration: cdata_asm)
 
-        if host_machine.system() == 'windows'
+        if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
             nasm_format = 'win'
         elif host_machine.system() == 'darwin'
             nasm_format = 'macho'


### PR DESCRIPTION
By the way, NASM has been added as a first-class language to Meson, but it would require converting from the custom rule here.