### PR TITLE
Just #define _GNU_SOURCE and _USE_MATH_MACROS unconditionally

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -19,14 +19,8 @@ cc = meson.get_compiler('c')
 libvmaf_inc = include_directories(['include'])
 
 # Arguments in test_args will be used even on feature tests
-test_args = []
-if host_machine.system() == 'linux' or host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
-    test_args += '-D_GNU_SOURCE'
-    add_project_arguments('-D_GNU_SOURCE', language: ['c', 'cpp'])
-elif host_machine.system() == 'darwin'
-    test_args += '-D_DARWIN_C_SOURCE'
-    add_project_arguments('-D_DARWIN_C_SOURCE', language: ['c', 'cpp'])
-endif
+test_args = ['-D_GNU_SOURCE', '-D_USE_MATH_DEFINES']
+add_project_arguments(test_args, language: ['c', 'cpp'])
 
 # Header checks
 stdatomic_dependency = []

--- a/libvmaf/src/feature/adm_tools.c
+++ b/libvmaf/src/feature/adm_tools.c
@@ -28,10 +28,6 @@
 #include "adm_options.h"
 #include "adm_tools.h"
 
-#ifndef M_PI
-#define M_PI 3.1415926535897932384626433832795028841971693993751
-#endif
-
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 

--- a/libvmaf/src/feature/adm_tools.h
+++ b/libvmaf/src/feature/adm_tools.h
@@ -19,10 +19,6 @@
 #include <math.h>
 #include "common/macros.h"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338327
-#endif
-
 #pragma once
 
 #ifndef ADM_TOOLS_H_

--- a/libvmaf/src/feature/integer_adm.h
+++ b/libvmaf/src/feature/integer_adm.h
@@ -60,10 +60,6 @@ typedef struct AdmBuffer {
 #define NUM_BUFS_ADM 30
 #endif
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846264338327
-#endif // M_PI
-
 /* Enhancement gain imposed on adm, must be >= 1.0, where 1.0 means the gain is completely disabled */
 #ifndef DEFAULT_ADM_ENHN_GAIN_LIMIT
 #define DEFAULT_ADM_ENHN_GAIN_LIMIT (100.0)

--- a/libvmaf/src/feature/integer_ssim.c
+++ b/libvmaf/src/feature/integer_ssim.c
@@ -35,10 +35,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define KERNEL_WEIGHT (1<<KERNEL_SHIFT)
 #define KERNEL_ROUND ((1<<KERNEL_SHIFT)>>1)
 
-#ifndef M_PI
-#define M_PI 3.141592653589793238462643
-#endif
-
 static int gaussian_filter_init(unsigned **_kernel,double _sigma,int _max_len){
   unsigned *kernel;
   double    scale;


### PR DESCRIPTION
Remove definitions of M_PI from source.
- `_USE_MATH_MACROS` is required by MSVC when compiling against UCRT.
- `_GNU_SOURCE` is required for other functions that are extensions to

The macros in math.h are not part of POSIX, but are visible by default so long as you don't declare you are trying to be strictly POSIX-conformant by defining `_POSIX_C_SOURCE` or `_XOPEN_SOURCE`.

Tested on:

- macOS 11.7.9 (it's old, sorry)
  Apple clang version 13.0.0
  x86_64-apple-darwin20.6.0

- FreeBSD 14.2-RELEASE
  FreeBSD clang version 18.1.6
  x86_64-unknown-freebsd14.2

- Amazon Linux release 2 (Karoo) 4.14.336-253.554.amzn2.x86_64
  cc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-17)
  x86_64-redhat-linux

- Windows 11 24H2:
  - MSYS2 c++ (GCC) 13.3.0
    x86_64-pc-msys
    msys-2.0.dll runtime

  - CLANG64 clang version 19.1.4
    x86_64-w64-windows-gnu
    ucrtbase.dll runtime

  - MINGW64 cc.exe (Rev2, Built by MSYS2 project)
    14.2.0 x86_64-w64-mingw32
    msvcrt.dll runtime

  - UCRT64 cc.exe (Rev2, Built by MSYS2 project)
    14.2.0 x86_64-w64-mingw32
    ucrtbase.dll runtime

  - Microsoft (R) C/C++ Optimizing Compiler Version 19.42.34433 for x64
    (Requires a few additional PRs that I will submit)