### PR TITLE
MSVC: Miscellaneous uncontroversial fixes

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -29,6 +29,19 @@ elif host_machine.system() == 'darwin'
 endif
 
 # Header checks
+if cc.has_header('unistd.h', args: test_args)
+    add_project_arguments('-DHAVE_UNISTD_H', language: ['c', 'cpp'])
+endif
+if cc.has_header('malloc.h', args: test_args)
+    add_project_arguments('-DHAVE_MALLOC_H', language: ['c', 'cpp'])
+endif
+if cc.has_header('alloca.h', args: test_args)
+    add_project_arguments('-DHAVE_ALLOCA_H', language: ['c', 'cpp'])
+endif
+if cc.has_header('direct.h', args: test_args)
+    add_project_arguments('-DHAVE_DIRECT_H', language: ['c', 'cpp'])
+endif
+
 stdatomic_dependency = []
 if not cc.check_header('stdatomic.h')
     if cc.get_id() == 'msvc'

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -31,6 +31,19 @@
 #include <arm_neon.h>
 #endif
 
+#ifdef _MSC_VER
+#include <intrin.h>
+
+static inline int __builtin_clz(unsigned x) {
+    return (int)__lzcnt(x);
+}
+
+static inline int __builtin_clzll(unsigned long long x) {
+    return (int)__lzcnt64(x);
+}
+
+#endif
+
 typedef struct AdmState {
     size_t integer_stride;
     AdmBuffer buf;

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -626,7 +626,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     const size_t data_sz =
         2 * (pad_size + frame_size + pad_size) + 2 * (h * s->public.buf.stride_16) +
         5 * (s->public.buf.stride_32) + 7 * s->public.buf.stride_tmp;
-    void *data = aligned_malloc(data_sz, MAX_ALIGN);
+    char *data = aligned_malloc(data_sz, MAX_ALIGN);
     if (!data) return -ENOMEM;
     memset(data, 0, data_sz);
 

--- a/libvmaf/src/feature/mkdirp.c
+++ b/libvmaf/src/feature/mkdirp.c
@@ -6,7 +6,12 @@
 // MIT licensed
 //
 
+#ifdef HAVE_DIRECT_H
+#include <direct.h>
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libvmaf/src/feature/mkdirp.h
+++ b/libvmaf/src/feature/mkdirp.h
@@ -12,6 +12,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+typedef unsigned short mode_t;
+#endif
+
 /*
  * Recursively `mkdir(path, mode)`
  */

--- a/libvmaf/src/log.c
+++ b/libvmaf/src/log.c
@@ -19,7 +19,11 @@
 #include "libvmaf/libvmaf.h"
 
 #include <stdarg.h>
+#ifdef _WIN32
+#include <corecrt_io.h> // isatty()
+#if HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 static enum VmafLogLevel vmaf_log_level = VMAF_LOG_LEVEL_INFO;
 static int istty = 0;

--- a/libvmaf/test/test_framesync.c
+++ b/libvmaf/test/test_framesync.c
@@ -18,9 +18,8 @@
 
 #include <stdint.h>
 #include <string.h>
-#ifdef _WIN32
-#include <windows.h>
-#else
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -1,7 +1,18 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <corecrt_io.h> // isatty()
+#endif
+#ifdef HAVE_MALLOC_H
+#include <malloc.h> // alloca()
+#endif
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 
 #include "cli_parse.h"
 #include "spinner.h"


### PR DESCRIPTION
- Copy __builtin_clz wrapper into another source file.
- mode_t is not defined on _WIN32
- Avoid arithmetic on void *
- Try to thin out of use of <windows.h>