### PR TITLE
Expose builtin model versions

### DIFF
--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -91,7 +91,7 @@ void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
 /// @param prev previous model. NULL to get the first model
 /// @param name OUT var - name of next model. If last model, this function does not modify name
 /// @return next model or NULL after the last model
-const void* vmaf_version_next(const void* prev, const char** name);
+const void* vmaf_model_version_next(const void* prev, const char** name);
 
 #ifdef __cplusplus
 }

--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -87,6 +87,12 @@ int vmaf_model_collection_feature_overload(VmafModel *model,
 
 void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
 
+/// @brief Iterate through all built in vmaf model versions
+/// @param prev previous model. NULL to get the first model
+/// @param name OUT var - name of next model. If last model, this function does not modify name
+/// @return next model or NULL after the last model
+const void* vmaf_version_next(const void* prev, char** name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -91,7 +91,7 @@ void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
 /// @param prev previous model. NULL to get the first model
 /// @param name OUT var - name of next model. If last model, this function does not modify name
 /// @return next model or NULL after the last model
-const void* vmaf_model_version_next(const void* prev, const char** name);
+const void* vmaf_model_version_next(const void* prev, const char** version);
 
 #ifdef __cplusplus
 }

--- a/libvmaf/include/libvmaf/model.h
+++ b/libvmaf/include/libvmaf/model.h
@@ -91,7 +91,7 @@ void vmaf_model_collection_destroy(VmafModelCollection *model_collection);
 /// @param prev previous model. NULL to get the first model
 /// @param name OUT var - name of next model. If last model, this function does not modify name
 /// @return next model or NULL after the last model
-const void* vmaf_version_next(const void* prev, char** name);
+const void* vmaf_version_next(const void* prev, const char** name);
 
 #ifdef __cplusplus
 }

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -322,3 +322,17 @@ exit:
     return err;
 }
 
+const void* vmaf_version_next(const void* prev, char** name){
+    VmafBuiltInModel* prev_model = prev;
+    VmafBuiltInModel* out_model = NULL;
+    if (!prev_model){
+        out_model = &built_in_models[0];
+    }
+    if(prev_model - built_in_models < BUILT_IN_MODEL_CNT){
+        out_model = prev_model + 1;
+    }
+    if (name && out_model){
+        *name = out_model->version;
+    }
+    return out_model;
+}

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -322,7 +322,7 @@ exit:
     return err;
 }
 
-const void* vmaf_version_next(const void* prev, const char** name){
+const void* vmaf_model_version_next(const void* prev, const char** name){
     VmafBuiltInModel* prev_model = prev;
     VmafBuiltInModel* out_model = NULL;
     if (!prev_model){

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -322,7 +322,7 @@ exit:
     return err;
 }
 
-const void* vmaf_version_next(const void* prev, char** name){
+const void* vmaf_version_next(const void* prev, const char** name){
     VmafBuiltInModel* prev_model = prev;
     VmafBuiltInModel* out_model = NULL;
     if (!prev_model){

--- a/libvmaf/src/model.c
+++ b/libvmaf/src/model.c
@@ -322,7 +322,7 @@ exit:
     return err;
 }
 
-const void* vmaf_model_version_next(const void* prev, const char** name){
+const void* vmaf_model_version_next(const void* prev, const char** version){
     VmafBuiltInModel* prev_model = prev;
     VmafBuiltInModel* out_model = NULL;
     if (!prev_model){
@@ -331,8 +331,8 @@ const void* vmaf_model_version_next(const void* prev, const char** name){
     if(prev_model - built_in_models < BUILT_IN_MODEL_CNT){
         out_model = prev_model + 1;
     }
-    if (name && out_model){
-        *name = out_model->version;
+    if (version && out_model){
+        *version = out_model->version;
     }
     return out_model;
 }

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -371,6 +371,17 @@ static char *test_model_set_flags()
     return NULL;
 }
 
+
+static char* test_version_next(){
+    void* next = NULL;
+    char* version = NULL;
+    while(next = vmaf_version_next(next, &version)){
+        VmafBuiltInModel* m = next;
+        mu_assert("Model versions must match",m->version == version);
+    }
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_json_model);
@@ -382,5 +393,6 @@ char *run_tests()
     mu_run_test(test_model_check_default_behavior_set_flags);
     mu_run_test(test_model_set_flags);
     mu_run_test(test_model_feature);
+    mu_run_test(test_version_next);
     return NULL;
 }

--- a/libvmaf/test/test_model.c
+++ b/libvmaf/test/test_model.c
@@ -375,7 +375,7 @@ static char *test_model_set_flags()
 static char* test_version_next(){
     void* next = NULL;
     char* version = NULL;
-    while(next = vmaf_version_next(next, &version)){
+    while(next = vmaf_model_version_next(next, &version)){
         VmafBuiltInModel* m = next;
         mu_assert("Model versions must match",m->version == version);
     }


### PR DESCRIPTION
Related to issue #1128 

`vmaf_model_load` allows you to load a builtin vmaf model when provided a `version` string to identify the desired model, but there is not currently any way to get a listing of the built in model versions.

This PR adds a function `vmaf_model_version_next` which iterates each item in `built_in_models`, allowing the caller to enumerate a list of available model versions.
