### PR TITLE
MSVC: Avoid the use of variable-length arrays

### DIFF
--- a/libvmaf/meson.build
+++ b/libvmaf/meson.build
@@ -29,6 +29,13 @@ elif host_machine.system() == 'darwin'
 endif
 
 # Header checks
+if cc.has_header('malloc.h', args: test_args)
+    add_project_arguments('-DHAVE_MALLOC_H', language: ['c', 'cpp'])
+endif
+if cc.has_header('alloca.h', args: test_args)
+    add_project_arguments('-DHAVE_ALLOCA_H', language: ['c', 'cpp'])
+endif
+
 stdatomic_dependency = []
 if not cc.check_header('stdatomic.h')
     if cc.get_id() == 'msvc'

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -22,6 +22,12 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
 #include <string.h>
 #include <time.h>
 
@@ -893,7 +899,7 @@ int vmaf_score_pooled_model_collection(VmafContext *vmaf,
     const char *suffix_stddev = "_stddev";
     const size_t name_sz =
         strlen(model_collection->name) + strlen(suffix_lo) + 1;
-    char name[name_sz];
+    char *name = alloca(name_sz);
     memset(name, 0, name_sz);
 
     snprintf(name, name_sz, "%s%s", model_collection->name, suffix_bagging);

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -21,6 +21,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
 
 #include "dict.h"
 #include "feature/alias.h"
@@ -358,7 +364,7 @@ static int vmaf_bootstrap_predict_score_at_index(
                                         VmafModelCollectionScore *score)
 {
     int err = 0;
-    double scores[model_collection->cnt];
+    double *scores = alloca(model_collection->cnt * sizeof(*scores));
 
     for (unsigned i = 0; i < model_collection->cnt; i++) {
         // mean, stddev, etc. are calculated on untransformed/unclipped scores
@@ -424,7 +430,7 @@ static int vmaf_bootstrap_predict_score_at_index(
     const char *suffix_stddev = "_stddev";
     const size_t name_sz =
         strlen(model_collection->name) + strlen(suffix_lo) + 1;
-    char name[name_sz];
+    char *name = alloca(name_sz);
     memset(name, 0, name_sz);
 
     snprintf(name, name_sz, "%s%s", model_collection->name, suffix_bagging);

--- a/libvmaf/src/read_json_model.c
+++ b/libvmaf/src/read_json_model.c
@@ -23,6 +23,12 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
 #include <string.h>
 
 #define MAX_FEATURE_COUNT 64 //FIXME
@@ -493,9 +499,9 @@ static int model_collection_parse(json_stream *s, VmafModel **model,
     if (!c.name) return -ENOMEM;
 
     const size_t cfg_name_sz = strlen(name) + 5 + 1;
-    char cfg_name[cfg_name_sz];
+    char *cfg_name = alloca(cfg_name_sz);
 
-    const size_t generated_key_sz = 4 + 1;
+    enum { generated_key_sz = 4 + 1 };
     char generated_key[generated_key_sz];
 
     unsigned i = 0;

--- a/libvmaf/test/test_cambi.c
+++ b/libvmaf/test/test_cambi.c
@@ -258,7 +258,7 @@ static char *test_decimate_generic()
 static char *test_filter_mode()
 {
     VmafPicture filtered_image, image;
-    unsigned w = 5, h = 5;
+    enum { w = 5, h = 5 };
     uint16_t buffer[3 * w];
 
     int err = 0;

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -56,7 +56,7 @@ static char *test_feature_extractor_context_pool()
 {
     int err = 0;
 
-    const unsigned n_threads = 8;
+    enum { n_threads = 8 };
     VmafFeatureExtractorContextPool *pool;
     err = vmaf_fex_ctx_pool_create(&pool, n_threads);
     mu_assert("problem during vmaf_fex_ctx_pool_create", !err);

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -1,6 +1,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h> // alloca()
+#endif
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
 #include <unistd.h>
 
 #include "cli_parse.h"
@@ -268,7 +274,7 @@ int main(int argc, char *argv[])
     model_collection = malloc(model_sz);
     memset(model_collection, 0, model_collection_sz);
 
-    const char *model_collection_label[c.model_cnt];
+    const char **model_collection_label = alloca(c.model_cnt * sizeof(*model_collection_label));
     unsigned model_collection_cnt = 0;
 
     for (unsigned i = 0; i < c.model_cnt; i++) {


### PR DESCRIPTION
Microsoft claims their C implementation will never include variable-length arrays because there isn't a secure way to implement them[1]. I don't know how this is different from variable-length arrays in C++ unless the standard includes a bounds check and well-defined behavior similar to std::bad_alloc.

1. https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/