### PR TITLE
fix: minor CUDA related memory leaks

### DIFF
--- a/libvmaf/src/cuda/picture_cuda.c
+++ b/libvmaf/src/cuda/picture_cuda.c
@@ -216,7 +216,7 @@ int vmaf_cuda_picture_free(VmafPicture *pic, void *cookie)
     if (!pic) return -EINVAL;
 
     int err = vmaf_ref_load(pic->ref);
-    if (!err) -EINVAL;
+    if (!err) return -EINVAL;
     
     VmafPicturePrivate *priv = pic->priv;
     VmafCudaCookie *cuda_cookie = cookie;
@@ -232,6 +232,7 @@ int vmaf_cuda_picture_free(VmafPicture *pic, void *cookie)
     CHECK_CUDA(cuEventDestroy(priv->cuda.ready));
     CHECK_CUDA(cuStreamDestroy(priv->cuda.str));
     CHECK_CUDA(cuCtxPopCurrent(NULL));
+    vmaf_ref_close(pic->ref);
     free(priv);
     memset(pic, 0, sizeof(*pic));
 

--- a/libvmaf/src/cuda/ring_buffer.c
+++ b/libvmaf/src/cuda/ring_buffer.c
@@ -85,6 +85,7 @@ int vmaf_ring_buffer_close(VmafRingBuffer *ring_buffer)
     }
 
     free(ring_buffer->pic);
+    free(ring_buffer);
     return err;
 }
 

--- a/libvmaf/src/feature/cuda/integer_adm_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_adm_cuda.c
@@ -1123,6 +1123,10 @@ free_ref:
         ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_ref);
         free(s->buf.tmp_ref);
     }
+    if (s->buf.tmp_dis) {
+        ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_dis);
+        free(s->buf.tmp_dis);
+    }
     if (s->buf.tmp_accum) {
         ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_accum);
         free(s->buf.tmp_accum);
@@ -1196,6 +1200,10 @@ static int close_fex_cuda(VmafFeatureExtractor *fex)
     if (s->buf.tmp_ref) {
         ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_ref);
         free(s->buf.tmp_ref);
+    }
+    if (s->buf.tmp_dis) {
+        ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_dis);
+        free(s->buf.tmp_dis);
     }
     if (s->buf.tmp_accum) {
         ret |= vmaf_cuda_buffer_free(fex->cu_state, s->buf.tmp_accum);

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -203,6 +203,9 @@ free_ref:
     if (s->buf.accum_host) {
         ret |= vmaf_cuda_buffer_host_free(fex->cu_state, s->buf.accum_host);
     }
+    if (s->buf.cpu_param_buf) {
+        free(s->buf.cpu_param_buf);
+    }
 
     return -ENOMEM;
 }
@@ -516,6 +519,9 @@ static int close_fex_cuda(VmafFeatureExtractor *fex)
     }
     if (s->buf.accum_host) {
         ret |= vmaf_cuda_buffer_host_free(fex->cu_state, s->buf.accum_host);
+    }
+    if (s->buf.cpu_param_buf) {
+        free(s->buf.cpu_param_buf);
     }
     ret |= vmaf_dictionary_free(&s->feature_name_dict);
     return ret;


### PR DESCRIPTION
valgrinding the VMAF CUDA enabled code shows some minor memory leaks due to missing `free`s for corresponding `malloc`s/`calloc`s during teardown. Also, I think I found a missing return statement.

Happy to provide a valgrind log if required. 