### PR TITLE
build: declare dependency to use it as subproject

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -574,3 +574,9 @@ pkg_mod.generate(libraries: libvmaf,
     description: 'VMAF, Video Multimethod Assessment Fusion',
     subdirs: [ '.', 'libvmaf']
 )
+
+libvmaf_dep = declare_dependency(
+    link_with: libvmaf,
+    include_directories: [libvmaf_inc]
+)
+meson.override_dependency('libvmaf', libvmaf_dep)


### PR DESCRIPTION
As part of the work we are doing to add a new [vmaf element in GStreamer](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9757), we are also adding vmaf as a subproject of GStreamer. In https://github.com/Netflix/vmaf/pull/1442  we fixed a linker issue with symbol names when building as a subproject.

In this PR  we declare the `libvmaf_dep` dependency following https://mesonbuild.com/Subprojects.html#naming-convention-for-dependency-variables so that  it can be used from other projects like:

```
libvmaf_dep = dependency('libvmaf', fallback : ['libvmaf', 'libvmaf_dep'])
```

One remaining issue is the lack of a `meson.build` in the repository root directory, for which I will open a new PR.
