### PR TITLE
Add 'enable_tools' option

### DIFF
--- a/libvmaf/meson_options.txt
+++ b/libvmaf/meson_options.txt
@@ -8,6 +8,11 @@ option('enable_docs',
     value: true,
     description: 'Build libvmaf documentation')
 
+option('enable_tools',
+    type: 'boolean',
+    value: true,
+    description: 'Build libvmaf tools')
+
 option('enable_asm',
     type: 'boolean',
     value: true,

--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -1,3 +1,7 @@
+if not get_option('enable_tools')
+    subdir_done()
+endif
+
 compat_cflags = []
 if cc.has_function('strsep')
   compat_cflags += '-DHAVE_STRSEP'


### PR DESCRIPTION
Currently, when you only want the libvmaf library there is no way to disable tool building. This causes problems specially in MSVC environment where those tools do not even compile.

This PR adds an option 'enable_tools' with to allow for tools disabling. As it has a default true value it does not affect current builds.