### PR TITLE
y4m_input: Expand to support yuv444p12/yuv422p12/yuv420p12

### DIFF
--- a/libvmaf/tools/y4m_input.c
+++ b/libvmaf/tools/y4m_input.c
@@ -611,6 +611,15 @@ static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
     _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
     _y4m->convert=y4m_convert_null;
   }
+  else if(strcmp(_y4m->chroma_type,"420p12")==0){
+    _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=2;
+    _y4m->dst_buf_read_sz=(_y4m->pic_w*_y4m->pic_h
+                           +2*((_y4m->pic_w+1)/2)*((_y4m->pic_h+1)/2))*2;
+    _y4m->depth=12;
+    /*Natively supported: no conversion required.*/
+    _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
+    _y4m->convert=y4m_convert_null;
+  }
   else if (strcmp(_y4m->chroma_type,"422p10")==0) {
     _y4m->src_c_dec_h=_y4m->dst_c_dec_h=2;
     _y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
@@ -620,10 +629,27 @@ static int y4m_input_open_impl(y4m_input *_y4m,FILE *_fin){
     _y4m->aux_buf_sz = _y4m->aux_buf_read_sz = 0;
     _y4m->convert = y4m_convert_null;
   }
+  else if (strcmp(_y4m->chroma_type,"422p12")==0) {
+    _y4m->src_c_dec_h=_y4m->dst_c_dec_h=2;
+    _y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
+    _y4m->depth = 12;
+    _y4m->dst_buf_read_sz = 2*(_y4m->pic_w*_y4m->pic_h
+		    +2*((_y4m->pic_w+1)/2)*_y4m->pic_h);
+    _y4m->aux_buf_sz = _y4m->aux_buf_read_sz = 0;
+    _y4m->convert = y4m_convert_null;
+  }
   else if(strcmp(_y4m->chroma_type,"444p10")==0){
     _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
     _y4m->dst_buf_read_sz=_y4m->pic_w*_y4m->pic_h*3*2;
     _y4m->depth=10;
+    /*Natively supported: no conversion required.*/
+    _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
+    _y4m->convert=y4m_convert_null;
+  }
+  else if(strcmp(_y4m->chroma_type,"444p12")==0){
+    _y4m->src_c_dec_h=_y4m->dst_c_dec_h=_y4m->src_c_dec_v=_y4m->dst_c_dec_v=1;
+    _y4m->dst_buf_read_sz=_y4m->pic_w*_y4m->pic_h*3*2;
+    _y4m->depth=12;
     /*Natively supported: no conversion required.*/
     _y4m->aux_buf_sz=_y4m->aux_buf_read_sz=0;
     _y4m->convert=y4m_convert_null;


### PR DESCRIPTION
Tested locally with samples,

Implementation based on https://aomedia.googlesource.com/aom/+/refs/heads/main/common/y4minput.c

=== Processing 420 ===
x265 [info]: HEVC encoder version 3.5+102-34532bda1
x265 [info]: build info [Linux][GCC 12.2.0][64 bit] 12bit
x265 [info]: using cpu capabilities: MMX2 SSE2Fast LZCNT SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
x265 [info]: Main 12 profile, Level-4 (Main tier)
x265 [info]: Thread pool created using 20 threads
x265 [info]: Slices                              : 1
x265 [info]: frame threads / pool features       : 4 / wpp(17 rows)
x265 [info]: Coding QT: max CU size, min CU size : 64 / 8
x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra
x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3
x265 [info]: Keyframe min / max / scenecut / bias  : 25 / 250 / 40 / 5.00 
x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2
x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0
x265 [info]: References / ref-limit  cu / depth  : 3 / off / on
x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1
x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60
x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip mode=1 signhide tmvp
x265 [info]: tools: b-intra strong-intra-smoothing lslices=6 deblock sao
x265 [info]: frame I:      1, Avg QP:31.53  kb/s: 25232.37
x265 [info]: frame P:      1, Avg QP:32.95  kb/s: 17973.87
x265 [info]: frame B:      3, Avg QP:34.61  kb/s: 13053.35
x265 [info]: Weighted P-Frames: Y:0.0% UV:0.0%

encoded 5 frames in 0.82s (6.11 fps), 16473.26 kb/s, Avg QP:33.66
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.492657
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.492657


=== Processing 422 ===
x265 [info]: HEVC encoder version 3.5+102-34532bda1
x265 [info]: build info [Linux][GCC 12.2.0][64 bit] 12bit
x265 [info]: using cpu capabilities: MMX2 SSE2Fast LZCNT SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
x265 [info]: Main 4:2:2 12 profile, Level-4 (Main tier)
x265 [info]: Thread pool created using 20 threads
x265 [info]: Slices                              : 1
x265 [info]: frame threads / pool features       : 4 / wpp(17 rows)
x265 [info]: Coding QT: max CU size, min CU size : 64 / 8
x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra
x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3
x265 [info]: Keyframe min / max / scenecut / bias  : 25 / 250 / 40 / 5.00 
x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2
x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0
x265 [info]: References / ref-limit  cu / depth  : 3 / off / on
x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1
x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60
x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip mode=1 signhide tmvp
x265 [info]: tools: b-intra strong-intra-smoothing lslices=6 deblock sao
x265 [info]: frame I:      1, Avg QP:31.53  kb/s: 25697.74
x265 [info]: frame P:      1, Avg QP:32.94  kb/s: 18144.34
x265 [info]: frame B:      3, Avg QP:34.62  kb/s: 13127.59
x265 [info]: Weighted P-Frames: Y:0.0% UV:0.0%

encoded 5 frames in 0.72s (6.97 fps), 16644.97 kb/s, Avg QP:33.67
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.429016
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.429016

=== Processing 444 ===
x265 [info]: HEVC encoder version 3.5+102-34532bda1
x265 [info]: build info [Linux][GCC 12.2.0][64 bit] 12bit
x265 [info]: using cpu capabilities: MMX2 SSE2Fast LZCNT SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
x265 [warning]: halving the quality when psy-rd is enabled for 444 input. Setting cbQpOffset = 6 and crQpOffset = 6
x265 [info]: Main 4:4:4 12 profile, Level-4 (Main tier)
x265 [info]: Thread pool created using 20 threads
x265 [info]: Slices                              : 1
x265 [info]: frame threads / pool features       : 4 / wpp(17 rows)
x265 [info]: Coding QT: max CU size, min CU size : 64 / 8
x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra
x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3
x265 [info]: Keyframe min / max / scenecut / bias  : 25 / 250 / 40 / 5.00 
x265 [info]: Cb/Cr QP Offset                     : 6 / 6
x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2
x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0
x265 [info]: References / ref-limit  cu / depth  : 3 / off / on
x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1
x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60
x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip mode=1 signhide tmvp
x265 [info]: tools: b-intra strong-intra-smoothing lslices=6 deblock sao
x265 [info]: frame I:      1, Avg QP:31.57  kb/s: 25036.00
x265 [info]: frame P:      1, Avg QP:32.95  kb/s: 17901.70
x265 [info]: frame B:      3, Avg QP:34.64  kb/s: 13061.34
x265 [info]: Weighted P-Frames: Y:0.0% UV:0.0%

encoded 5 frames in 0.92s (5.45 fps), 16424.34 kb/s, Avg QP:33.69
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.459173
VMAF version 6b75f377
5 frames ⡂⠀ 0.00 FPS
vmaf_v0.6.1: 83.459173
