### PR TITLE
ssim: add scale parameter to control decimation factor

### DIFF
--- a/libvmaf/src/feature/float_ssim.c
+++ b/libvmaf/src/feature/float_ssim.c
@@ -35,6 +35,7 @@ typedef struct SsimState {
     bool enable_db;
     bool clip_db;
     double max_db;
+    int scale;
 } SsimState;
 
 static const VmafOption options[] = {
@@ -58,6 +59,15 @@ static const VmafOption options[] = {
         .offset = offsetof(SsimState, clip_db),
         .type = VMAF_OPT_TYPE_BOOL,
         .default_val.b = false,
+    },
+    {
+        .name = "scale",
+        .help = "decimation scale factor (0=auto, 1=no downscaling, 2-10=explicit)",
+        .offset = offsetof(SsimState, scale),
+        .type = VMAF_OPT_TYPE_INT,
+        .default_val.i = 0,
+        .min = 0,
+        .max = 10,
     },
     { 0 }
 };
@@ -115,7 +125,7 @@ static int extract(VmafFeatureExtractor *fex,
     double score, l_score, c_score, s_score;
     err = compute_ssim(s->ref, s->dist, ref_pic->w[0], ref_pic->h[0],
                        s->float_stride, s->float_stride,
-                       &score, &l_score, &c_score, &s_score);
+                       &score, &l_score, &c_score, &s_score, s->scale);
     if (err) return err;
 
     if (s->enable_db)

--- a/libvmaf/src/feature/ssim.c
+++ b/libvmaf/src/feature/ssim.c
@@ -47,7 +47,8 @@ float _ssim_reduce(int w, int h, void *ctx)
 
 int compute_ssim(const float *ref, const float *cmp, int w, int h,
         int ref_stride, int cmp_stride, double *score,
-        double *l_score, double *c_score, double *s_score)
+        double *l_score, double *c_score, double *s_score,
+        int scale_override)
 {
 
     int ret = 1;
@@ -77,7 +78,11 @@ int compute_ssim(const float *ref, const float *cmp, int w, int h,
     int gaussian = 1; /* 0 for 8x8 square window, 1 for 11x11 circular-symmetric Gaussian window (default) */
 
     /* initialize algorithm parameters */
-    scale = _max( 1, _round( (float)_min(w,h) / 256.0f ) );
+    if (scale_override > 0) {
+        scale = scale_override;
+    } else {
+        scale = _max( 1, _round( (float)_min(w,h) / 256.0f ) );
+    }
     if (args) {
         if(args->f) {
             scale = args->f;

--- a/libvmaf/src/feature/ssim.h
+++ b/libvmaf/src/feature/ssim.h
@@ -18,4 +18,5 @@
 
 int compute_ssim(const float *ref, const float *cmp, int w, int h,
                  int ref_stride, int cmp_stride, double *score,
-                 double *l_score, double *c_score, double *s_score);
+                 double *l_score, double *c_score, double *s_score,
+                 int scale_override);


### PR DESCRIPTION
The SSIM feature extractor internally downscales input images to a resolution in the 256-384 pixel range before computing the SSIM score. For high-resolution content this discards fine spatial detail, causing SSIM to underestimate quality differences between codecs.

Add a user-controllable "scale" integer parameter (0-10) to the float_ssim feature extractor:
  - scale=0 (default): auto-compute from resolution (existing behavior)
  - scale=1: no downscaling, compute SSIM at original resolution
  - scale=2..10: explicit integer decimation factor

Usage: --feature float_ssim=scale=1
```
# Default behavior (auto-computed scale, same as original libvmaf):
./vmaf_mod --reference trees_orig.y4m --distorted trees_jpegli_q65.y4m --feature float_ssim --no_prediction

# No downscaling (full resolution SSIM):
./vmaf_mod --reference trees_orig.y4m --distorted trees_jpegli_q65.y4m --feature float_ssim=scale=1 --no_prediction
```

This change is backward-compatible: the default value of 0 preserves the existing auto-scaling behavior.

See CWG-G053i for detailed analysis of the issue and BD-rate results demonstrating the impact of downscaling on SSIM accuracy at high resolutions.

Results comparison (trees_orig.y4m vs trees_jpegli_q65.y4m):
```
Scale               SSIM Score   Behavior
Original binary     0.999803     baseline (auto 13x downsample)
scale=0 (auto)      0.999803     matches original exactly
default (no param)  0.999803     matches original exactly
scale=1             0.957188     full resolution — reveals quality difference
scale=2             0.984007     2x downsample
scale=3             0.993038     3x downsample
scale=4             0.995914     4x downsample
scale=5             0.998101     5x downsample
scale=6             0.998743     ...
scale=7             0.999190     ...
scale=8             0.999467     ...
scale=9             0.999546     ...
scale=10            0.999630     approaches auto-computed value
scale=11            rejected     exit 255, out of range
scale=-1            rejected     exit 255, out of range
```

This addresses https://github.com/Netflix/vmaf/issues/1449