### PR TITLE
fix enable_tools=false breaking test builds

### DIFF
--- a/libvmaf/tools/meson.build
+++ b/libvmaf/tools/meson.build
@@ -1,10 +1,10 @@
-if not get_option('enable_tools')
-    subdir_done()
-endif
-
 compat_cflags = []
 if cc.has_function('strsep')
   compat_cflags += '-DHAVE_STRSEP'
+endif
+
+if not get_option('enable_tools')
+    subdir_done()
 endif
 
 vmaf = executable(


### PR DESCRIPTION
Move compat_cflags definition before the subdir_done() guard so the variable is always available for test/meson.build regardless of the enable_tools setting.