### PR TITLE
Fix UB in void* pointer arithmetic

### DIFF
--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -630,22 +630,22 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     if (!data) return -ENOMEM;
     memset(data, 0, data_sz);
 
-    s->public.buf.data = data; data += pad_size;
-    s->public.buf.ref = data; data += frame_size + pad_size + pad_size;
-    s->public.buf.dis = data; data += frame_size + pad_size;
-    s->public.buf.mu1 = data; data += h * s->public.buf.stride_16;
-    s->public.buf.mu2 = data; data += h * s->public.buf.stride_16;
-    s->public.buf.mu1_32 = data; data += s->public.buf.stride_32;
-    s->public.buf.mu2_32 = data; data += s->public.buf.stride_32;
-    s->public.buf.ref_sq = data; data += s->public.buf.stride_32;
-    s->public.buf.dis_sq = data; data += s->public.buf.stride_32;
-    s->public.buf.ref_dis = data; data += s->public.buf.stride_32;
-    s->public.buf.tmp.mu1 = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.mu2 = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.dis = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref_dis = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref_convol = data; data += s->public.buf.stride_tmp;
+    s->public.buf.data = data; data = (char *)data + pad_size;
+    s->public.buf.ref = data; data = (char *)data + (frame_size + pad_size + pad_size);
+    s->public.buf.dis = data; data = (char *)data + (frame_size + pad_size);
+    s->public.buf.mu1 = data; data = (char *)data + (h * s->public.buf.stride_16);
+    s->public.buf.mu2 = data; data = (char *)data + (h * s->public.buf.stride_16);
+    s->public.buf.mu1_32 = data; data = (char *)data + s->public.buf.stride_32;
+    s->public.buf.mu2_32 = data; data = (char *)data + s->public.buf.stride_32;
+    s->public.buf.ref_sq = data; data = (char *)data + s->public.buf.stride_32;
+    s->public.buf.dis_sq = data; data = (char *)data + s->public.buf.stride_32;
+    s->public.buf.ref_dis = data; data = (char *)data + s->public.buf.stride_32;
+    s->public.buf.tmp.mu1 = data; data = (char *)data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.mu2 = data; data = (char *)data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref = data; data = (char *)data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.dis = data; data = (char *)data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_dis = data; data = (char *)data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_convol = data; data = (char *)data + s->public.buf.stride_tmp;
     s->public.buf.tmp.dis_convol = data;
 
     s->feature_name_dict =
@@ -656,7 +656,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     return 0;
 
 fail:
-    if (data) aligned_free(data);
+    if (s->public.buf.data) aligned_free(s->public.buf.data);
     vmaf_dictionary_free(&s->feature_name_dict);
     return -ENOMEM;
 }


### PR DESCRIPTION
Fix undefined behavior in `void*` pointer arithmetic and a potential memory leak in the failure path of `vif_init()`.

### Changes
- Replaced all `data += N` operations (which are UB on `void*` per C standard) with the portable and well-defined idiom `data = (char *)data + N`.
- In the `fail:` label, we now free the **original** allocation pointer (`s->public.buf.data`) instead of the advanced `data` pointer, preventing a memory leak when `vmaf_feature_name_dict_from_provided_features()` fails.

### Why
- The original code relied on a GNU extension (treating `void*` as `char*` for arithmetic), which is not guaranteed by the C standard and can break under strict conformance or aggressive optimizers.
- The leak was present even before this change; the UB fix simply made it more visible.

The memory layout and runtime behavior remain **identical** — only the correctness and portability are improved.

No functional change, only standard corrections.