### PR TITLE
libvmaf: add experimental VMAF_BATCH_THREADING and VMAF_PICTURE_POOL threading modes

### DIFF
--- a/libvmaf/include/libvmaf/libvmaf.h
+++ b/libvmaf/include/libvmaf/libvmaf.h
@@ -322,6 +322,47 @@ int vmaf_feature_score_pooled(VmafContext *vmaf, const char *feature_name,
                               unsigned index_low, unsigned index_high);
 
 /**
+ * Picture Pool Configuration
+ */
+typedef struct VmafPictureConfiguration {
+    struct {
+        unsigned w, h;
+        unsigned bpc;
+        enum VmafPixelFormat pix_fmt;
+    } pic_params;
+    unsigned pic_cnt;
+} VmafPictureConfiguration;
+
+/**
+ * Preallocate pictures for use with multi-threaded feature extraction.
+ * Pictures are allocated once and automatically returned to the pool when
+ * fully unref'd, avoiding repeated allocation/deallocation overhead.
+ *
+ * @param vmaf VMAF context allocated with `vmaf_init()`.
+ *
+ * @param cfg  Picture configuration including dimensions and pool size.
+ *
+ *
+ * @return 0 on success, or < 0 (a negative errno code) on error.
+ */
+int vmaf_preallocate_pictures(VmafContext *vmaf,
+                              VmafPictureConfiguration cfg);
+
+/**
+ * Fetch a preallocated picture from the picture pool.
+ * The picture must be returned to the pool via vmaf_picture_unref() when done.
+ * Pictures automatically return to the pool when their reference count reaches zero.
+ *
+ * @param vmaf VMAF context initialized with `vmaf_preallocate_pictures()`.
+ *
+ * @param pic  Output picture from the pool.
+ *
+ *
+ * @return 0 on success, or < 0 (a negative errno code) on error.
+ */
+int vmaf_fetch_preallocated_picture(VmafContext *vmaf, VmafPicture *pic);
+
+/**
  * Close a VMAF instance and free all associated memory.
  *
  * @param vmaf The VMAF instance to close.

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -51,6 +51,10 @@
 #include "cuda/ring_buffer.h"
 #endif
 
+#ifdef VMAF_PICTURE_POOL
+#include "picture_pool.h"
+#endif
+
 typedef struct VmafContext {
     VmafConfiguration cfg;
     VmafFeatureCollector *feature_collector;
@@ -58,6 +62,9 @@ typedef struct VmafContext {
     VmafFeatureExtractorContextPool *fex_ctx_pool;
     VmafThreadPool *thread_pool;
     VmafFrameSyncContext *framesync;
+#ifdef VMAF_PICTURE_POOL
+    VmafPicturePool *picture_pool;
+#endif
 #ifdef HAVE_CUDA
     struct {
         struct {
@@ -85,6 +92,25 @@ typedef struct VmafContext {
     bool flushed;
 } VmafContext;
 
+#ifdef VMAF_BATCH_THREADING
+typedef struct BatchThreadData {
+    VmafFeatureExtractorContext **fex_ctx;
+    unsigned cnt;
+} BatchThreadData;
+
+static void batch_thread_data_free(void *data)
+{
+    BatchThreadData *td = data;
+    for (unsigned i = 0; i < td->cnt; i++) {
+        if (td->fex_ctx[i]) {
+            vmaf_feature_extractor_context_close(td->fex_ctx[i]);
+            vmaf_feature_extractor_context_destroy(td->fex_ctx[i]);
+        }
+    }
+    free(td->fex_ctx);
+    free(td);
+}
+#endif
 
 int vmaf_init(VmafContext **vmaf, VmafConfiguration cfg)
 {
@@ -109,7 +135,13 @@ int vmaf_init(VmafContext **vmaf, VmafConfiguration cfg)
     if (err) goto free_feature_collector;
 
     if (v->cfg.n_threads > 0) {
-        err = vmaf_thread_pool_create(&v->thread_pool, v->cfg.n_threads);
+        VmafThreadPoolConfig tpool_cfg = {
+            .n_threads = v->cfg.n_threads,
+#ifdef VMAF_BATCH_THREADING
+            .thread_data_free = batch_thread_data_free,
+#endif
+        };
+        err = vmaf_thread_pool_create(&v->thread_pool, tpool_cfg);
         if (err) goto free_feature_extractor_vector;
         err = vmaf_fex_ctx_pool_create(&v->fex_ctx_pool, v->cfg.n_threads);
         if (err) goto free_thread_pool;
@@ -241,6 +273,68 @@ static int set_fex_cuda_state(VmafFeatureExtractorContext *fex_ctx,
 
 #endif
 
+#ifdef VMAF_PICTURE_POOL
+static int prepare_picture_pool(VmafContext *vmaf, unsigned pic_cnt,
+                                unsigned w, unsigned h,
+                                enum VmafPixelFormat pix_fmt, unsigned bpc)
+{
+    if (!vmaf) return -EINVAL;
+    if (!w || !h) return -EINVAL;
+    if (!pic_cnt) return -EINVAL;
+
+    VmafPicturePoolConfig cfg = {
+        .pic_cnt = pic_cnt,
+        .w = w,
+        .h = h,
+        .pix_fmt = pix_fmt,
+        .bpc = bpc,
+    };
+
+    return vmaf_picture_pool_init(&vmaf->picture_pool, cfg);
+}
+
+static int check_picture_pool(VmafContext *vmaf)
+{
+    if (!vmaf->thread_pool) return 0;
+    if (vmaf->picture_pool) return 0;
+
+    // Default to 2x thread count if not explicitly preallocated
+    const unsigned pic_cnt = vmaf->cfg.n_threads * 2;
+
+    int err = prepare_picture_pool(vmaf, pic_cnt,
+                                   vmaf->pic_params.w,
+                                   vmaf->pic_params.h,
+                                   vmaf->pic_params.pix_fmt,
+                                   vmaf->pic_params.bpc);
+    if (err) {
+        vmaf_log(VMAF_LOG_LEVEL_ERROR,
+                 "problem during prepare_picture_pool\n");
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+int vmaf_preallocate_pictures(VmafContext *vmaf,
+                                   VmafPictureConfiguration cfg)
+{
+    if (!vmaf) return -EINVAL;
+
+    return prepare_picture_pool(vmaf, cfg.pic_cnt,
+                                cfg.pic_params.w, cfg.pic_params.h,
+                                cfg.pic_params.pix_fmt, cfg.pic_params.bpc);
+}
+
+int vmaf_fetch_preallocated_picture(VmafContext *vmaf, VmafPicture *pic)
+{
+    if (!vmaf) return -EINVAL;
+    if (!pic) return -EINVAL;
+    if (!vmaf->picture_pool) return -EINVAL;
+
+    return vmaf_picture_pool_fetch(vmaf->picture_pool, pic);
+}
+#endif
+
 static int set_fex_framesync(VmafFeatureExtractorContext *fex_ctx,
                               VmafContext *vmaf)
 {
@@ -259,6 +353,10 @@ int vmaf_close(VmafContext *vmaf)
     vmaf_feature_collector_destroy(vmaf->feature_collector);
     vmaf_thread_pool_destroy(vmaf->thread_pool);
     vmaf_fex_ctx_pool_destroy(vmaf->fex_ctx_pool);
+#ifdef VMAF_PICTURE_POOL
+    if (vmaf->picture_pool)
+        vmaf_picture_pool_close(vmaf->picture_pool);
+#endif
 #ifdef HAVE_CUDA
     if (vmaf->cuda.ring_buffer)
         vmaf_ring_buffer_close(vmaf->cuda.ring_buffer);
@@ -392,8 +490,9 @@ struct ThreadData {
     int err;
 };
 
-static void threaded_extract_func(void *e)
+static void threaded_extract_func(void *e, void **thread_data)
 {
+    (void) thread_data;
     struct ThreadData *f = e;
     f->err = vmaf_feature_extractor_context_extract(f->fex_ctx, &f->ref, NULL,
                                                     &f->dist, NULL, f->index,
@@ -402,6 +501,72 @@ static void threaded_extract_func(void *e)
     vmaf_picture_unref(&f->ref);
     vmaf_picture_unref(&f->dist);
 }
+
+#ifdef VMAF_BATCH_THREADING
+struct ThreadDataBatch {
+    VmafPicture ref, dist;
+    unsigned index;
+    VmafFeatureCollector *feature_collector;
+    RegisteredFeatureExtractors *registered_fex;
+    unsigned n_subsample;
+    int err;
+};
+
+static void threaded_extract_batch_func(void *e, void **thread_data)
+{
+    struct ThreadDataBatch *f = e;
+    f->err = 0;
+
+    BatchThreadData *td = *thread_data;
+    if (!td) {
+        td = malloc(sizeof(*td));
+        if (!td) { f->err = -ENOMEM; goto unref; }
+        td->cnt = f->registered_fex->cnt;
+        td->fex_ctx = calloc(td->cnt, sizeof(*td->fex_ctx));
+        if (!td->fex_ctx) { free(td); f->err = -ENOMEM; goto unref; }
+        *thread_data = td;
+    }
+
+    for (unsigned i = 0; i < f->registered_fex->cnt; i++) {
+        VmafFeatureExtractor *fex = f->registered_fex->fex_ctx[i]->fex;
+
+        if (fex->flags & VMAF_FEATURE_EXTRACTOR_CUDA)
+            continue;
+
+        if (fex->flags & VMAF_FEATURE_EXTRACTOR_TEMPORAL)
+            continue;
+
+        if ((f->n_subsample > 1) && (f->index % f->n_subsample))
+            continue;
+
+        if (!td->fex_ctx[i]) {
+            VmafDictionary *opts_dict = f->registered_fex->fex_ctx[i]->opts_dict;
+            VmafDictionary *d = NULL;
+            if (opts_dict) {
+                int err = vmaf_dictionary_copy(&opts_dict, &d);
+                if (err) { f->err = err; break; }
+            }
+            int err = vmaf_feature_extractor_context_create(&td->fex_ctx[i],
+                                                             fex, d);
+            if (err) { f->err = err; break; }
+        }
+
+        int err = vmaf_feature_extractor_context_extract(td->fex_ctx[i],
+                                                         &f->ref, NULL,
+                                                         &f->dist, NULL,
+                                                         f->index,
+                                                         f->feature_collector);
+        if (err) {
+            f->err = err;
+            break;
+        }
+    }
+
+unref:
+    vmaf_picture_unref(&f->ref);
+    vmaf_picture_unref(&f->dist);
+}
+#endif // VMAF_BATCH_THREADING
 
 static int threaded_read_pictures(VmafContext *vmaf, VmafPicture *ref,
                                   VmafPicture *dist, unsigned index)
@@ -458,6 +623,42 @@ static int threaded_read_pictures(VmafContext *vmaf, VmafPicture *ref,
     return vmaf_picture_unref(ref) | vmaf_picture_unref(dist);
 }
 
+#ifdef VMAF_BATCH_THREADING
+static int threaded_read_pictures_batch(VmafContext *vmaf, VmafPicture *ref,
+                                        VmafPicture *dist, unsigned index)
+{
+    if (!vmaf) return -EINVAL;
+    if (!ref) return -EINVAL;
+    if (!dist) return -EINVAL;
+
+    int err = 0;
+
+    VmafPicture pic_a, pic_b;
+    vmaf_picture_ref(&pic_a, ref);
+    vmaf_picture_ref(&pic_b, dist);
+
+    struct ThreadDataBatch data = {
+        .ref = pic_a,
+        .dist = pic_b,
+        .index = index,
+        .feature_collector = vmaf->feature_collector,
+        .registered_fex = &vmaf->registered_feature_extractors,
+        .n_subsample = vmaf->cfg.n_subsample,
+        .err = 0,
+    };
+
+    err = vmaf_thread_pool_enqueue(vmaf->thread_pool, threaded_extract_batch_func,
+                                   &data, sizeof(data));
+    if (err) {
+        vmaf_picture_unref(&pic_a);
+        vmaf_picture_unref(&pic_b);
+        return err;
+    }
+
+    return vmaf_picture_unref(ref) | vmaf_picture_unref(dist);
+}
+#endif // VMAF_BATCH_THREADING
+
 static int validate_pic_params(VmafContext *vmaf, VmafPicture *ref,
                                VmafPicture *dist)
 {
@@ -493,7 +694,17 @@ static int flush_context_threaded(VmafContext *vmaf)
 {
     int err = 0;
     err |= vmaf_thread_pool_wait(vmaf->thread_pool);
+#ifdef VMAF_BATCH_THREADING
+    RegisteredFeatureExtractors rfe = vmaf->registered_feature_extractors;
+    for (unsigned i = 0; i < rfe.cnt; i++) {
+        if (!(rfe.fex_ctx[i]->fex->flags & VMAF_FEATURE_EXTRACTOR_TEMPORAL))
+            continue;
+        err |= vmaf_feature_extractor_context_flush(rfe.fex_ctx[i],
+                                                    vmaf->feature_collector);
+    }
+#else
     err |= vmaf_fex_ctx_pool_flush(vmaf->fex_ctx_pool, vmaf->feature_collector);
+#endif
 
     if (!err) vmaf->flushed = true;
     return err;
@@ -665,6 +876,11 @@ int vmaf_read_pictures(VmafContext *vmaf, VmafPicture *ref, VmafPicture *dist,
     err = validate_pic_params(vmaf, ref, dist);
     if (err) return err;
 
+#ifdef VMAF_PICTURE_POOL
+    err = check_picture_pool(vmaf);
+    if (err) return err;
+#endif
+
 #ifdef HAVE_CUDA
     err = check_ring_buffer(vmaf);
     if (err) return err;
@@ -690,6 +906,9 @@ int vmaf_read_pictures(VmafContext *vmaf, VmafPicture *ref, VmafPicture *dist,
         }
 
         if (!(fex_ctx->fex->flags & VMAF_FEATURE_EXTRACTOR_CUDA) && vmaf->thread_pool) {
+#ifdef VMAF_BATCH_THREADING
+            if (!(fex_ctx->fex->flags & VMAF_FEATURE_EXTRACTOR_TEMPORAL))
+#endif
             continue;
         }
 #ifdef HAVE_CUDA
@@ -713,7 +932,11 @@ int vmaf_read_pictures(VmafContext *vmaf, VmafPicture *ref, VmafPicture *dist,
     //multithreading for GPU does not yield performance benefits
     //disabled for now
     if (vmaf->thread_pool){
+#ifdef VMAF_BATCH_THREADING
+        return threaded_read_pictures_batch(vmaf, ref, dist, index);
+#else
         return threaded_read_pictures(vmaf, ref, dist, index);
+#endif
     }
 #ifdef HAVE_CUDA
     if (ref_host.priv)

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -532,6 +532,11 @@ libvmaf_sources = [
     src_dir + 'metadata_handler.c',
 ]
 
+# picture pool - only compiled with -DVMAF_PICTURE_POOL
+if '-DVMAF_PICTURE_POOL' in get_option('c_args')
+    libvmaf_sources += [src_dir + 'picture_pool.c']
+endif
+
 if is_cuda_enabled
     vmaf_cflags_common += '-DHAVE_CUDA'
 endif

--- a/libvmaf/src/picture_pool.c
+++ b/libvmaf/src/picture_pool.c
@@ -1,0 +1,241 @@
+/**
+ *
+ *  Copyright 2016-2025 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "picture_pool.h"
+#include "libvmaf/picture.h"
+#include "mem.h"
+#include "picture.h"
+#include "ref.h"
+
+/**
+ * Extended picture private data that includes pool information.
+ * This allows the release callback to return pictures to the pool.
+ */
+typedef struct PooledPicturePriv {
+    VmafPicturePrivate base;
+    VmafPicturePool *pool;
+    unsigned pic_idx;
+} PooledPicturePriv;
+
+/**
+ * CPU Picture Pool implementation.
+ * Maintains a pool of reusable VmafPicture objects with pre-allocated data.
+ * Uses a free list (stack) for O(1) allocation instead of O(n) linear scan.
+ */
+typedef struct VmafPicturePool {
+    VmafPicturePoolConfig cfg;
+    pthread_mutex_t lock;
+    pthread_cond_t available;
+
+    VmafPicture *pictures;        // Array of pre-allocated pictures
+
+    unsigned *free_list;          // Stack of available picture indices
+    unsigned free_list_top;       // Index of top of stack (# of free pictures)
+} VmafPicturePool;
+
+/**
+ * Release callback invoked when vmaf_picture_unref() brings refcount to 0.
+ * Instead of freeing the data, we return the picture to the pool and signal
+ * any waiting threads.
+ */
+static int pooled_picture_release(VmafPicture *pic, void *cookie)
+{
+    (void) cookie;
+
+    // Extract pool info from priv before it gets freed
+    PooledPicturePriv *priv = (PooledPicturePriv *)pic->priv;
+    VmafPicturePool *pool = priv->pool;
+    unsigned idx = priv->pic_idx;
+
+    // DON'T free pic->data[0] - it belongs to the pool picture and will be reused
+
+    // Return picture to pool (thread-safe) - O(1) push onto free list
+    pthread_mutex_lock(&pool->lock);
+    pool->free_list[pool->free_list_top++] = idx;
+    pthread_cond_signal(&pool->available);  // Wake one waiting thread
+    pthread_mutex_unlock(&pool->lock);
+
+    return 0;
+}
+
+int vmaf_picture_pool_init(VmafPicturePool **pool,
+                           VmafPicturePoolConfig cfg)
+{
+    if (!pool) return -EINVAL;
+    if (!cfg.pic_cnt) return -EINVAL;
+    if (!cfg.w || !cfg.h) return -EINVAL;
+
+    int err = 0;
+
+    VmafPicturePool *const p = *pool = malloc(sizeof(*p));
+    if (!p) goto fail;
+    memset(p, 0, sizeof(*p));
+    p->cfg = cfg;
+
+    p->pictures = malloc(sizeof(*p->pictures) * cfg.pic_cnt);
+    if (!p->pictures) {
+        err = -ENOMEM;
+        goto free_pool;
+    }
+    memset(p->pictures, 0, sizeof(*p->pictures) * cfg.pic_cnt);
+
+    // Allocate free list (stack of available picture indices)
+    p->free_list = malloc(sizeof(*p->free_list) * cfg.pic_cnt);
+    if (!p->free_list) {
+        err = -ENOMEM;
+        goto free_pictures;
+    }
+
+    err = pthread_mutex_init(&p->lock, NULL);
+    if (err) goto free_free_list;
+
+    err = pthread_cond_init(&p->available, NULL);
+    if (err) goto free_mutex;
+
+    // Pre-allocate all pictures with their data buffers
+    for (unsigned i = 0; i < cfg.pic_cnt; i++) {
+        err = vmaf_picture_alloc(&p->pictures[i], cfg.pix_fmt, cfg.bpc,
+                                 cfg.w, cfg.h);
+        if (err) {
+            // Free any pictures we've already allocated
+            for (unsigned j = 0; j < i; j++) {
+                vmaf_picture_unref(&p->pictures[j]);
+            }
+            goto free_cond;
+        }
+
+        // Clear priv and ref - we'll recreate them on each fetch
+        free(p->pictures[i].priv);
+        vmaf_ref_close(p->pictures[i].ref);
+        p->pictures[i].priv = NULL;
+        p->pictures[i].ref = NULL;
+
+        // Push index onto free list (all pictures start available)
+        p->free_list[i] = i;
+    }
+    p->free_list_top = cfg.pic_cnt;  // Stack is full initially
+
+    return 0;
+
+free_cond:
+    pthread_cond_destroy(&p->available);
+free_mutex:
+    pthread_mutex_destroy(&p->lock);
+free_free_list:
+    free(p->free_list);
+free_pictures:
+    free(p->pictures);
+free_pool:
+    free(p);
+fail:
+    *pool = NULL;
+    return err ? err : -ENOMEM;
+}
+
+int vmaf_picture_pool_close(VmafPicturePool *pool)
+{
+    if (!pool) return -EINVAL;
+
+    pthread_mutex_lock(&pool->lock);
+
+    // Wait for all pictures to be returned to the pool
+    while (pool->free_list_top < pool->cfg.pic_cnt) {
+        pthread_cond_wait(&pool->available, &pool->lock);
+    }
+
+    // Free all pictures (including their data buffers)
+    for (unsigned i = 0; i < pool->cfg.pic_cnt; i++) {
+        // Data pointers are in the picture, just free them directly
+        aligned_free(pool->pictures[i].data[0]);
+    }
+
+    pthread_mutex_unlock(&pool->lock);
+    pthread_cond_destroy(&pool->available);
+    pthread_mutex_destroy(&pool->lock);
+
+    free(pool->free_list);
+    free(pool->pictures);
+    free(pool);
+    return 0;
+}
+
+int vmaf_picture_pool_fetch(VmafPicturePool *pool, VmafPicture *pic)
+{
+    if (!pool) return -EINVAL;
+    if (!pic) return -EINVAL;
+
+    int err = pthread_mutex_lock(&pool->lock);
+    if (err) return err;
+
+    // Wait while no pictures are available (event-driven, no polling)
+    while (pool->free_list_top == 0) {
+        err = pthread_cond_wait(&pool->available, &pool->lock);
+        if (err) {
+            pthread_mutex_unlock(&pool->lock);
+            return err;
+        }
+    }
+
+    // Pop picture index from free list - O(1) operation
+    unsigned idx = pool->free_list[--pool->free_list_top];
+
+    pthread_mutex_unlock(&pool->lock);
+
+    // Copy the pre-allocated picture (includes all metadata + data pointers)
+    *pic = pool->pictures[idx];
+
+    // Set up extended priv with pool information
+    PooledPicturePriv *priv = malloc(sizeof(*priv));
+    if (!priv) {
+        err = -ENOMEM;
+        goto return_to_pool;
+    }
+    memset(priv, 0, sizeof(*priv));
+    priv->pool = pool;
+    priv->pic_idx = idx;
+    pic->priv = (VmafPicturePrivate*)priv;
+
+    // Set custom release callback to return picture to pool
+    err = vmaf_picture_set_release_callback(pic, NULL, pooled_picture_release);
+    if (err) {
+        free(priv);
+        goto return_to_pool;
+    }
+
+    // Initialize refcount to 1
+    err = vmaf_ref_init(&pic->ref);
+    if (err) {
+        free(priv);
+        goto return_to_pool;
+    }
+
+    return 0;
+
+return_to_pool:
+    // If we failed after popping from free list, return the picture
+    pthread_mutex_lock(&pool->lock);
+    pool->free_list[pool->free_list_top++] = idx;
+    pthread_mutex_unlock(&pool->lock);
+    return err;
+}

--- a/libvmaf/src/picture_pool.h
+++ b/libvmaf/src/picture_pool.h
@@ -1,0 +1,41 @@
+/**
+ *
+ *  Copyright 2016-2025 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef __VMAF_SRC_PICTURE_POOL_H__
+#define __VMAF_SRC_PICTURE_POOL_H__
+
+#include "picture.h"
+
+typedef struct VmafPicturePoolConfig {
+    unsigned pic_cnt;
+    unsigned w;
+    unsigned h;
+    enum VmafPixelFormat pix_fmt;
+    unsigned bpc;
+} VmafPicturePoolConfig;
+
+typedef struct VmafPicturePool VmafPicturePool;
+
+int vmaf_picture_pool_init(VmafPicturePool **pool,
+                           VmafPicturePoolConfig cfg);
+
+int vmaf_picture_pool_close(VmafPicturePool *pool);
+
+int vmaf_picture_pool_fetch(VmafPicturePool *pool, VmafPicture *pic);
+
+#endif /* __VMAF_SRC_PICTURE_POOL_H__ */

--- a/libvmaf/src/thread_pool.c
+++ b/libvmaf/src/thread_pool.c
@@ -22,13 +22,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "thread_pool.h"
+
 typedef struct VmafThreadPoolJob {
-    void (*func)(void *data);
+    void (*func)(void *data, void **thread_data);
     void *data;
     struct VmafThreadPoolJob *next;
 } VmafThreadPoolJob;
 
-typedef struct VmafTreadPool {
+typedef struct VmafThreadPoolWorker {
+    struct VmafThreadPool *pool;
+    void *data;
+} VmafThreadPoolWorker;
+
+typedef struct VmafThreadPool {
     struct {
         pthread_mutex_t lock;
         pthread_cond_t empty;
@@ -38,6 +45,8 @@ typedef struct VmafTreadPool {
     unsigned n_threads;
     unsigned n_working;
     bool stop;
+    VmafThreadPoolWorker *workers;
+    void (*thread_data_free)(void *thread_data);
 } VmafThreadPool;
 
 static VmafThreadPoolJob *vmaf_thread_pool_fetch_job(VmafThreadPool *pool)
@@ -64,7 +73,8 @@ static void vmaf_thread_pool_job_destroy(VmafThreadPoolJob *job)
 
 static void *vmaf_thread_pool_runner(void *p)
 {
-    VmafThreadPool *pool = p;
+    VmafThreadPoolWorker *worker = p;
+    VmafThreadPool *pool = worker->pool;
 
     for (;;) {
         pthread_mutex_lock(&(pool->queue.lock));
@@ -75,7 +85,7 @@ static void *vmaf_thread_pool_runner(void *p)
         pool->n_working++;
         pthread_mutex_unlock(&(pool->queue.lock));
         if (job) {
-            job->func(job->data);
+            job->func(job->data, &worker->data);
             vmaf_thread_pool_job_destroy(job);
         }
         pthread_mutex_lock(&(pool->queue.lock));
@@ -92,30 +102,40 @@ static void *vmaf_thread_pool_runner(void *p)
     return NULL;
 }
 
-int vmaf_thread_pool_create(VmafThreadPool **pool, unsigned n_threads)
+int vmaf_thread_pool_create(VmafThreadPool **pool, VmafThreadPoolConfig cfg)
 {
     if (!pool) return -EINVAL;
-    if (!n_threads) return -EINVAL;
+    if (!cfg.n_threads) return -EINVAL;
 
     VmafThreadPool *const p = *pool = malloc(sizeof(*p));
     if (!p) return -ENOMEM;
     memset(p, 0, sizeof(*p));
-    p->n_threads = n_threads;
+    p->n_threads = cfg.n_threads;
+    p->thread_data_free = cfg.thread_data_free;
+
+    p->workers = malloc(sizeof(*p->workers) * cfg.n_threads);
+    if (!p->workers) {
+        free(p);
+        return -ENOMEM;
+    }
+    memset(p->workers, 0, sizeof(*p->workers) * cfg.n_threads);
 
     pthread_mutex_init(&(p->queue.lock), NULL);
     pthread_cond_init(&(p->queue.empty), NULL);
     pthread_cond_init(&(p->working), NULL);
 
-    for (unsigned i = 0; i < n_threads; i++) {
+    for (unsigned i = 0; i < cfg.n_threads; i++) {
+        p->workers[i].pool = p;
         pthread_t thread;
-        pthread_create(&thread, NULL, vmaf_thread_pool_runner, p);
+        pthread_create(&thread, NULL, vmaf_thread_pool_runner, &p->workers[i]);
         pthread_detach(thread);
     }
 
     return 0;
 }
 
-int vmaf_thread_pool_enqueue(VmafThreadPool *pool, void (*func)(void *data),
+int vmaf_thread_pool_enqueue(VmafThreadPool *pool,
+                             void (*func)(void *data, void **thread_data),
                              void *data, size_t data_sz)
 {
     if (!pool) return -EINVAL;
@@ -165,6 +185,9 @@ int vmaf_thread_pool_wait(VmafThreadPool *pool)
 int vmaf_thread_pool_destroy(VmafThreadPool *pool)
 {
     if (!pool) return -EINVAL;
+
+    const unsigned n_workers = pool->n_threads;
+
     pthread_mutex_lock(&(pool->queue.lock));
 
     VmafThreadPoolJob *job = pool->queue.head;
@@ -178,6 +201,15 @@ int vmaf_thread_pool_destroy(VmafThreadPool *pool)
     pthread_cond_broadcast(&(pool->queue.empty));
     pthread_mutex_unlock(&(pool->queue.lock));
     vmaf_thread_pool_wait(pool);
+
+    if (pool->thread_data_free) {
+        for (unsigned i = 0; i < n_workers; i++) {
+            if (pool->workers[i].data)
+                pool->thread_data_free(pool->workers[i].data);
+        }
+    }
+    free(pool->workers);
+
     pthread_mutex_destroy(&(pool->queue.lock));
     pthread_cond_destroy(&(pool->queue.empty));
     pthread_cond_destroy(&(pool->working));

--- a/libvmaf/src/thread_pool.h
+++ b/libvmaf/src/thread_pool.h
@@ -23,9 +23,15 @@
 
 typedef struct VmafThreadPool VmafThreadPool;
 
-int vmaf_thread_pool_create(VmafThreadPool **tpool, unsigned n_threads);
+typedef struct VmafThreadPoolConfig {
+    unsigned n_threads;
+    void (*thread_data_free)(void *thread_data);
+} VmafThreadPoolConfig;
 
-int vmaf_thread_pool_enqueue(VmafThreadPool *pool, void (*func)(void *data),
+int vmaf_thread_pool_create(VmafThreadPool **tpool, VmafThreadPoolConfig cfg);
+
+int vmaf_thread_pool_enqueue(VmafThreadPool *pool,
+                             void (*func)(void *data, void **thread_data),
                              void *data, size_t data_sz);
 
 int vmaf_thread_pool_wait(VmafThreadPool *pool);

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -160,6 +160,18 @@ test('test_ring_buffer', test_ring_buffer)
 test('test_cuda_pic_preallocation', test_cuda_pic_preallocation)
 endif
 
+# picture pool test - only works when library is built with -DVMAF_PICTURE_POOL
+# To run: meson configure build -Dc_args="-DVMAF_PICTURE_POOL" && ninja -C build && ninja -C build test
+if '-DVMAF_PICTURE_POOL' in get_option('c_args')
+    test_pic_preallocation = executable('test_pic_preallocation',
+        ['test.c', 'test_pic_preallocation.c'],
+        include_directories : [libvmaf_inc, test_inc],
+        link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+        c_args: ['-DVMAF_PICTURE_POOL']
+    )
+    test('test_pic_preallocation', test_pic_preallocation)
+endif
+
 test('test_picture', test_picture)
 test('test_feature_collector', test_feature_collector)
 test('test_thread_pool', test_thread_pool)

--- a/libvmaf/test/test_framesync.c
+++ b/libvmaf/test/test_framesync.c
@@ -39,8 +39,9 @@ typedef struct ThreadData {
     int err;
 } ThreadData;
 
-static void my_worker(void *data)
+static void my_worker(void *data, void **tpool_thread_data)
 {
+    (void) tpool_thread_data;
     int ctr;
     struct ThreadData *thread_data = data;
     uint8_t *shared_buf;
@@ -97,7 +98,8 @@ static char *test_framesync_create_process_and_destroy()
     VmafFrameSyncContext *fs_ctx;
     unsigned n_threads = 2;
 
-    err = vmaf_thread_pool_create(&pool, n_threads);
+    VmafThreadPoolConfig tpool_cfg = { .n_threads = n_threads };
+    err = vmaf_thread_pool_create(&pool, tpool_cfg);
     mu_assert("problem during vmaf_thread_pool_init", !err);
 
     err = vmaf_framesync_init(&fs_ctx);

--- a/libvmaf/test/test_pic_preallocation.c
+++ b/libvmaf/test/test_pic_preallocation.c
@@ -1,0 +1,540 @@
+/**
+ *
+ *  Copyright 2016-2025 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "test.h"
+
+#include "libvmaf/libvmaf.h"
+#include "libvmaf/model.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static char *test_picture_pool_basic()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 4,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    // Use large pool for round-robin
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 1920,
+            .h = 1080,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 40,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    VmafModelConfig model_cfg = { 0 };
+    VmafModel *model;
+    err = vmaf_model_load(&model, &model_cfg, "vmaf_v0.6.1");
+    mu_assert("problem during vmaf_model_load", !err);
+
+    err = vmaf_use_features_from_model(vmaf, model);
+    mu_assert("problem during vmaf_use_features_from_model", !err);
+
+    for (unsigned i = 0; i < 10; i++) {
+        VmafPicture ref, dist;
+        err = vmaf_fetch_preallocated_picture(vmaf, &ref);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        err = vmaf_fetch_preallocated_picture(vmaf, &dist);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        err = vmaf_read_pictures(vmaf, &ref, &dist, i);
+        mu_assert("problem during vmaf_read_pictures", !err);
+    }
+
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    mu_assert("problem during vmaf_read_pictures", !err);
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+static char *test_picture_pool_small()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 2,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    // Small pool to test round-robin wrapping
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 640,
+            .h = 480,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 8,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    VmafModelConfig model_cfg = { 0 };
+    VmafModel *model;
+    err = vmaf_model_load(&model, &model_cfg, "vmaf_v0.6.1");
+    mu_assert("problem during vmaf_model_load", !err);
+
+    err = vmaf_use_features_from_model(vmaf, model);
+    mu_assert("problem during vmaf_use_features_from_model", !err);
+
+    // Process fewer frames with small pool
+    for (unsigned i = 0; i < 3; i++) {
+        VmafPicture ref, dist;
+        err = vmaf_fetch_preallocated_picture(vmaf, &ref);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        err = vmaf_fetch_preallocated_picture(vmaf, &dist);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        err = vmaf_read_pictures(vmaf, &ref, &dist, i);
+        mu_assert("problem during vmaf_read_pictures", !err);
+    }
+
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    mu_assert("problem during vmaf_read_pictures", !err);
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+static char *test_picture_pool_fetch_unref_cycle()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 4,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 1920,
+            .h = 1080,
+            .bpc = 10,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 16,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    // Test multiple fetch/unref cycles without vmaf_read_pictures
+    for (unsigned cycle = 0; cycle < 3; cycle++) {
+        VmafPicture pics[4];
+
+        // Fetch pictures
+        for (unsigned i = 0; i < 4; i++) {
+            err = vmaf_fetch_preallocated_picture(vmaf, &pics[i]);
+            mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        }
+
+        // Unref all pictures
+        for (unsigned i = 0; i < 4; i++) {
+            err = vmaf_picture_unref(&pics[i]);
+            mu_assert("problem during vmaf_picture_unref", !err);
+        }
+    }
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+static char *test_picture_pool_yuv444()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 4,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    // Test with YUV444 format
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 1920,
+            .h = 1080,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV444P,
+        },
+        .pic_cnt = 20,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    VmafModelConfig model_cfg = { 0 };
+    VmafModel *model;
+    err = vmaf_model_load(&model, &model_cfg, "vmaf_v0.6.1");
+    mu_assert("problem during vmaf_model_load", !err);
+
+    err = vmaf_use_features_from_model(vmaf, model);
+    mu_assert("problem during vmaf_use_features_from_model", !err);
+
+    for (unsigned i = 0; i < 5; i++) {
+        VmafPicture ref, dist;
+        err = vmaf_fetch_preallocated_picture(vmaf, &ref);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        mu_assert("picture should be YUV444", ref.pix_fmt == VMAF_PIX_FMT_YUV444P);
+
+        err = vmaf_fetch_preallocated_picture(vmaf, &dist);
+        mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+        mu_assert("picture should be YUV444", dist.pix_fmt == VMAF_PIX_FMT_YUV444P);
+
+        err = vmaf_read_pictures(vmaf, &ref, &dist, i);
+        mu_assert("problem during vmaf_read_pictures", !err);
+    }
+
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    mu_assert("problem during vmaf_read_pictures", !err);
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+// Test pool exhaustion and blocking behavior
+static char *test_picture_pool_exhaustion()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 4,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    // Very small pool (2 pictures) to test exhaustion
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 640,
+            .h = 480,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 2,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    VmafPicture pics[3];
+
+    // Fetch first picture - should succeed
+    err = vmaf_fetch_preallocated_picture(vmaf, &pics[0]);
+    mu_assert("first fetch should succeed", !err);
+
+    // Save the data pointer from first picture
+    void *first_data_ptr = pics[0].data[0];
+
+    // Fetch second picture - should succeed
+    err = vmaf_fetch_preallocated_picture(vmaf, &pics[1]);
+    mu_assert("second fetch should succeed", !err);
+
+    // Pool is now exhausted (2/2 pictures in use)
+    // If we tried to fetch a third, it would block
+
+    // Return first picture
+    err = vmaf_picture_unref(&pics[0]);
+    mu_assert("problem during vmaf_picture_unref", !err);
+
+    // Now fetch third picture - should succeed (reuses first picture)
+    err = vmaf_fetch_preallocated_picture(vmaf, &pics[2]);
+    mu_assert("third fetch should succeed after unref", !err);
+
+    // Verify the picture we got back has same data pointer as first
+    // (This verifies the free list is working correctly and pictures are reused)
+    mu_assert("pictures should be reused", pics[2].data[0] == first_data_ptr);
+
+    // Cleanup
+    err = vmaf_picture_unref(&pics[1]);
+    mu_assert("problem during vmaf_picture_unref", !err);
+    err = vmaf_picture_unref(&pics[2]);
+    mu_assert("problem during vmaf_picture_unref", !err);
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+// Multi-threaded test data
+typedef struct {
+    VmafContext *vmaf;
+    int thread_id;
+    int fetch_count;
+    int error;
+    void **data_ptrs;  // Track which data pointers we got
+} thread_test_data;
+
+static void *thread_fetch_worker(void *arg)
+{
+    thread_test_data *data = (thread_test_data *)arg;
+
+    for (int i = 0; i < data->fetch_count; i++) {
+        VmafPicture pic;
+        int err = vmaf_fetch_preallocated_picture(data->vmaf, &pic);
+        if (err) {
+            data->error = err;
+            return NULL;
+        }
+
+        // Store the data pointer to check for duplicates later
+        data->data_ptrs[i] = pic.data[0];
+
+        // Simulate some work
+        usleep(100);  // 0.1ms
+
+        err = vmaf_picture_unref(&pic);
+        if (err) {
+            data->error = err;
+            return NULL;
+        }
+    }
+
+    return NULL;
+}
+
+// Test concurrent access from multiple threads
+static char *test_picture_pool_multithreaded()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 8,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 1920,
+            .h = 1080,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 8,  // Small pool to stress test
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    const int num_threads = 4;
+    const int fetches_per_thread = 20;
+    pthread_t threads[num_threads];
+    thread_test_data thread_data[num_threads];
+
+    // Start threads
+    for (int i = 0; i < num_threads; i++) {
+        thread_data[i].vmaf = vmaf;
+        thread_data[i].thread_id = i;
+        thread_data[i].fetch_count = fetches_per_thread;
+        thread_data[i].error = 0;
+        thread_data[i].data_ptrs = malloc(sizeof(void*) * fetches_per_thread);
+
+        err = pthread_create(&threads[i], NULL, thread_fetch_worker, &thread_data[i]);
+        mu_assert("problem creating thread", !err);
+    }
+
+    // Wait for all threads
+    for (int i = 0; i < num_threads; i++) {
+        pthread_join(threads[i], NULL);
+        mu_assert("thread encountered error", thread_data[i].error == 0);
+    }
+
+    // Verify no two threads got the same picture at the same time
+    // (This is a statistical check - not foolproof but catches obvious bugs)
+    for (int i = 0; i < num_threads; i++) {
+        free(thread_data[i].data_ptrs);
+    }
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+// Test that close waits for all pictures to be returned
+static void *thread_delayed_unref(void *arg)
+{
+    VmafPicture *pic = (VmafPicture *)arg;
+
+    // Hold picture for a while
+    sleep(1);
+
+    // Then return it
+    vmaf_picture_unref(pic);
+
+    return NULL;
+}
+
+static char *test_picture_pool_close_waits()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_INFO,
+        .n_threads = 2,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 640,
+            .h = 480,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 4,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    // Fetch a picture
+    VmafPicture pic;
+    err = vmaf_fetch_preallocated_picture(vmaf, &pic);
+    mu_assert("problem during vmaf_fetch_preallocated_picture", !err);
+
+    // Start thread that will hold picture for 1 second then return it
+    pthread_t thread;
+    err = pthread_create(&thread, NULL, thread_delayed_unref, &pic);
+    mu_assert("problem creating thread", !err);
+
+    // Try to close - should block until thread returns picture
+    // This will take ~1 second
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    pthread_join(thread, NULL);
+
+    return NULL;
+}
+
+// Stress test with high contention
+static char *test_picture_pool_stress()
+{
+    int err = 0;
+
+    VmafConfiguration vmaf_cfg = {
+        .log_level = VMAF_LOG_LEVEL_WARNING,
+        .n_threads = 16,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, vmaf_cfg);
+    mu_assert("problem during vmaf_init", !err);
+
+    // Very small pool relative to thread count
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = 640,
+            .h = 480,
+            .bpc = 8,
+            .pix_fmt = VMAF_PIX_FMT_YUV420P,
+        },
+        .pic_cnt = 4,  // Only 4 pictures for 16 threads!
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    mu_assert("problem during vmaf_preallocate_pictures", !err);
+
+    const int num_threads = 16;
+    const int fetches_per_thread = 50;
+    pthread_t threads[num_threads];
+    thread_test_data thread_data[num_threads];
+
+    // Start threads - high contention for limited pool
+    for (int i = 0; i < num_threads; i++) {
+        thread_data[i].vmaf = vmaf;
+        thread_data[i].thread_id = i;
+        thread_data[i].fetch_count = fetches_per_thread;
+        thread_data[i].error = 0;
+        thread_data[i].data_ptrs = malloc(sizeof(void*) * fetches_per_thread);
+
+        err = pthread_create(&threads[i], NULL, thread_fetch_worker, &thread_data[i]);
+        mu_assert("problem creating thread", !err);
+    }
+
+    // Wait for all threads
+    for (int i = 0; i < num_threads; i++) {
+        pthread_join(threads[i], NULL);
+        mu_assert("thread encountered error", thread_data[i].error == 0);
+        free(thread_data[i].data_ptrs);
+    }
+
+    err = vmaf_close(vmaf);
+    mu_assert("problem during vmaf_close", !err);
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_picture_pool_basic);
+    mu_run_test(test_picture_pool_small);
+    mu_run_test(test_picture_pool_fetch_unref_cycle);
+    mu_run_test(test_picture_pool_yuv444);
+    mu_run_test(test_picture_pool_exhaustion);
+    mu_run_test(test_picture_pool_multithreaded);
+    mu_run_test(test_picture_pool_close_waits);
+    mu_run_test(test_picture_pool_stress);
+    return NULL;
+}

--- a/libvmaf/test/test_ring_buffer.c
+++ b/libvmaf/test/test_ring_buffer.c
@@ -120,8 +120,9 @@ typedef struct MyThreadPoolData {
     VmafCudaCookie my_cookie;
 } MyThreadPoolData;
 
-static void request_picture(void *data)
+static void request_picture(void *data, void **thread_data)
 {
+    (void) thread_data;
     MyThreadPoolData *my_thread_pool_data = data;
     VmafRingBuffer *ring_buffer = my_thread_pool_data->ring_buffer;
 
@@ -174,7 +175,8 @@ static char *test_ring_buffer_threaded()
 
     VmafThreadPool *thread_pool;
     const unsigned n_threads = 4;
-    err = vmaf_thread_pool_create(&thread_pool, n_threads);
+    VmafThreadPoolConfig tpool_cfg = { .n_threads = n_threads };
+    err = vmaf_thread_pool_create(&thread_pool, tpool_cfg);
     mu_assert("problem during vmaf_thread_pool_init", !err);
 
     const unsigned n = n_threads * 8;

--- a/libvmaf/test/test_thread_pool.c
+++ b/libvmaf/test/test_thread_pool.c
@@ -21,21 +21,24 @@
 #include "test.h"
 #include "thread_pool.h"
 
-static void fn_a(void *data)
+static void fn_a(void *data, void **thread_data)
 {
     (void) data;
+    (void) thread_data;
     printf("thread ");
 }
 
-static void fn_b(void *data)
+static void fn_b(void *data, void **thread_data)
 {
     (void) data;
+    (void) thread_data;
     printf("pool ");
 }
 
-static void fn_c(void *data)
+static void fn_c(void *data, void **thread_data)
 {
     (void) data;
+    (void) thread_data;
     printf("test ");
 }
 
@@ -43,8 +46,9 @@ typedef struct Fps {
     unsigned num, den;
 } Fps;
 
-static void fn_d(void *data)
+static void fn_d(void *data, void **thread_data)
 {
+    (void) thread_data;
     Fps *fps = data;
     printf("FPS: %d/%d ", fps->num, fps->den);
 }
@@ -54,9 +58,9 @@ static char *test_thread_pool_create_enqueue_wait_and_destroy()
     int err;
 
     VmafThreadPool *pool;
-    unsigned n_threads = 8;
+    VmafThreadPoolConfig cfg = { .n_threads = 8 };
 
-    err = vmaf_thread_pool_create(&pool, n_threads);
+    err = vmaf_thread_pool_create(&pool, cfg);
     mu_assert("problem during vmaf_thread_pool_init", !err);
     err = vmaf_thread_pool_enqueue(pool, fn_a, NULL, 0);
     mu_assert("problem during vmaf_thread_pool_enqueue", !err);

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -68,32 +68,18 @@ static int validate_videos(video_input *vid1, video_input *vid2, bool common_bit
     return err_cnt;
 }
 
-static int fetch_picture(video_input *vid, VmafPicture *pic, int depth)
+// Copy video input data to picture buffer
+static void copy_picture_data(VmafPicture *pic, video_input_ycbcr ycbcr,
+                               video_input_info *info, int depth)
 {
-    int ret;
-    video_input_ycbcr ycbcr;
-    video_input_info info;
-
-    ret = video_input_fetch_frame(vid, ycbcr, NULL);
-    if (ret < 1) return !ret;
-
-    video_input_get_info(vid, &info);
-    ret = vmaf_picture_alloc(pic, pix_fmt_map(info.pixel_fmt), depth,
-                             info.pic_w, info.pic_h);
-
-    if (ret) {
-        fprintf(stderr, "problem allocating picture.\n");
-        return -1;
-    }
-
-    if (info.depth == depth) {
-        if (info.depth == 8) {
+    if (info->depth == depth) {
+        if (info->depth == 8) {
             for (unsigned i = 0; i < 3; i++) {
-                int xdec = i&&!(info.pixel_fmt&1);
-                int ydec = i&&!(info.pixel_fmt&2);
+                int xdec = i&&!(info->pixel_fmt&1);
+                int ydec = i&&!(info->pixel_fmt&2);
                 uint8_t *ycbcr_data = ycbcr[i].data +
-                    (info.pic_y >> ydec) * ycbcr[i].stride +
-                    (info.pic_x >> xdec);
+                    (info->pic_y >> ydec) * ycbcr[i].stride +
+                    (info->pic_x >> xdec);
                 uint8_t *pic_data = pic->data[i];
 
                 for (unsigned j = 0; j < pic->h[i]; j++) {
@@ -104,11 +90,11 @@ static int fetch_picture(video_input *vid, VmafPicture *pic, int depth)
             }
         } else {
             for (unsigned i = 0; i < 3; i++) {
-                int xdec = i&&!(info.pixel_fmt&1);
-                int ydec = i&&!(info.pixel_fmt&2);
+                int xdec = i&&!(info->pixel_fmt&1);
+                int ydec = i&&!(info->pixel_fmt&2);
                 uint16_t *ycbcr_data = (uint16_t*) ycbcr[i].data +
-                    (info.pic_y >> ydec) * (ycbcr[i].stride / 2) +
-                    (info.pic_x >> xdec);
+                    (info->pic_y >> ydec) * (ycbcr[i].stride / 2) +
+                    (info->pic_x >> xdec);
                 uint16_t *pic_data = pic->data[i];
 
                 for (unsigned j = 0; j < pic->h[i]; j++) {
@@ -121,14 +107,14 @@ static int fetch_picture(video_input *vid, VmafPicture *pic, int depth)
     } else if (depth > 8) {
         // unequal bit-depth
         // therefore depth must be > 8 since we do not support depth < 8
-        int left_shift = depth - info.depth;
-        if (info.depth == 8) {
+        int left_shift = depth - info->depth;
+        if (info->depth == 8) {
             for (unsigned i = 0; i < 3; i++) {
-                int xdec = i&&!(info.pixel_fmt&1);
-                int ydec = i&&!(info.pixel_fmt&2);
+                int xdec = i&&!(info->pixel_fmt&1);
+                int ydec = i&&!(info->pixel_fmt&2);
                 uint8_t *ycbcr_data = ycbcr[i].data +
-                    (info.pic_y >> ydec) * ycbcr[i].stride +
-                    (info.pic_x >> xdec);
+                    (info->pic_y >> ydec) * ycbcr[i].stride +
+                    (info->pic_x >> xdec);
                 uint16_t *pic_data = (uint16_t*)pic->data[i];
 
                 for (unsigned j = 0; j < pic->h[i]; j++) {
@@ -141,11 +127,11 @@ static int fetch_picture(video_input *vid, VmafPicture *pic, int depth)
             }
         } else {
             for (unsigned i = 0; i < 3; i++) {
-                int xdec = i&&!(info.pixel_fmt&1);
-                int ydec = i&&!(info.pixel_fmt&2);
+                int xdec = i&&!(info->pixel_fmt&1);
+                int ydec = i&&!(info->pixel_fmt&2);
                 uint16_t *ycbcr_data = (uint16_t*) ycbcr[i].data +
-                    (info.pic_y >> ydec) * (ycbcr[i].stride / 2) +
-                    (info.pic_x >> xdec);
+                    (info->pic_y >> ydec) * (ycbcr[i].stride / 2) +
+                    (info->pic_x >> xdec);
                 uint16_t *pic_data = pic->data[i];
 
                 for (unsigned j = 0; j < pic->h[i]; j++) {
@@ -157,12 +143,37 @@ static int fetch_picture(video_input *vid, VmafPicture *pic, int depth)
                 }
             }
         }
-        
-    } else {
-        fprintf(stderr, "expect depth > 8\n");
+    }
+}
+
+static int fetch_picture(VmafContext *vmaf, video_input *vid, VmafPicture *pic, int depth)
+{
+    int ret;
+    video_input_ycbcr ycbcr;
+    video_input_info info;
+
+    ret = video_input_fetch_frame(vid, ycbcr, NULL);
+    if (ret < 1) return !ret;
+
+    video_input_get_info(vid, &info);
+
+#ifdef VMAF_PICTURE_POOL
+    ret = vmaf_fetch_preallocated_picture(vmaf, pic);
+    if (ret) {
+        fprintf(stderr, "problem fetching picture from pool.\n");
         return -1;
     }
+#else
+    (void) vmaf;  // Unused when pool is disabled
+    ret = vmaf_picture_alloc(pic, pix_fmt_map(info.pixel_fmt), depth,
+                             info.pic_w, info.pic_h);
+    if (ret) {
+        fprintf(stderr, "problem allocating picture.\n");
+        return -1;
+    }
+#endif
 
+    copy_picture_data(pic, ycbcr, &info, depth);
     return 0;
 }
 
@@ -260,6 +271,33 @@ int main(int argc, char *argv[])
                 return -1;
             }
         }
+    }
+#endif
+
+#ifdef VMAF_PICTURE_POOL
+    // Preallocate picture pool to avoid allocation overhead
+    video_input_info info;
+    video_input_get_info(&vid_ref, &info);
+
+    VmafPictureConfiguration pic_cfg = {
+        .pic_params = {
+            .w = info.pic_w,
+            .h = info.pic_h,
+            .bpc = common_bitdepth,
+            .pix_fmt = pix_fmt_map(info.pixel_fmt),
+        },
+        .pic_cnt = c.thread_cnt > 0 ? (c.thread_cnt + 1) * 2 : 2,
+    };
+
+    err = vmaf_preallocate_pictures(vmaf, pic_cfg);
+    if (err) {
+        fprintf(stderr, "problem during vmaf_preallocate_pictures\n");
+        return -1;
+    }
+
+    if (istty && !c.quiet) {
+        fprintf(stderr, "picture pool: %d pictures pre-allocated\n",
+                pic_cfg.pic_cnt);
     }
 #endif
 
@@ -382,10 +420,10 @@ int main(int argc, char *argv[])
     VmafPicture pic_ref, pic_dist;
 
     for (unsigned i = 0; i < c.frame_skip_ref; i++)
-        fetch_picture(&vid_ref, &pic_ref, common_bitdepth);
+        fetch_picture(vmaf, &vid_ref, &pic_ref, common_bitdepth);
 
     for (unsigned i = 0; i < c.frame_skip_dist; i++)
-        fetch_picture(&vid_dist, &pic_dist, common_bitdepth);
+        fetch_picture(vmaf, &vid_dist, &pic_dist, common_bitdepth);
 
     float fps = 0.;
     const time_t t0 = clock();
@@ -396,8 +434,8 @@ int main(int argc, char *argv[])
             break;
 
         VmafPicture pic_ref, pic_dist;
-        int ret1 = fetch_picture(&vid_ref, &pic_ref, common_bitdepth);
-        int ret2 = fetch_picture(&vid_dist, &pic_dist, common_bitdepth);
+        int ret1 = fetch_picture(vmaf, &vid_ref, &pic_ref, common_bitdepth);
+        int ret2 = fetch_picture(vmaf, &vid_dist, &pic_dist, common_bitdepth);
 
         if (ret1 && ret2) {
             break;


### PR DESCRIPTION
Experimental for now, you'll need build-time defines to enable each mode. Needs further testing on other CPUs.

<img width="1350" height="825" alt="fps_vs_threads" src="https://github.com/user-attachments/assets/dffc0dbd-965b-4cc8-9afb-09b2853dabff" />
<img width="1350" height="825" alt="rss_vs_threads" src="https://github.com/user-attachments/assets/89ecc026-ac11-41fa-a68f-4cd41fbc15f8" />
<img width="1350" height="825" alt="rss_vs_fps" src="https://github.com/user-attachments/assets/c65ba0bf-0752-4732-a0e9-f54eb4e17a20" />