### PR TITLE
Fix null deref crash on prev_ref update in pure CUDA pipelines

### DIFF
--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -1013,7 +1013,9 @@ int vmaf_read_pictures(VmafContext *vmaf, VmafPicture *ref, VmafPicture *dist,
 
     if (vmaf->prev_ref.ref)
         vmaf_picture_unref(&vmaf->prev_ref);
-    vmaf_picture_ref(&vmaf->prev_ref, ref);
+    
+    if (ref && ref->ref)
+        vmaf_picture_ref(&vmaf->prev_ref, ref);
 #ifdef HAVE_CUDA
     if (ref_host.priv)
         err |= vmaf_picture_unref(&ref_host);


### PR DESCRIPTION
#1482 introduced a segfault to libvmaf_cuda when using ffmpeg.

Pure CUDA pipelines leave `ref_host` zero-initialized. This adds a null check before `vmaf_picture_ref` to prevent crashes. 

Skipping this update seems safe because pure CUDA extractors don't appear to consume it