### PR TITLE
x86: move avx2+512 opts to 64-bit only

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -28,10 +28,15 @@ jobs:
           - os: ubuntu-24.04-arm
             CC: ccache clang
             CXX: ccache clang++
+          - os: ubuntu-latest
+            CC: ccache gcc
+            CXX: ccache g++
+            CROSS: ./libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
+      CROSS: ${{ matrix.CROSS }}
     steps:
       - name: Setup python
         uses: actions/setup-python@v6
@@ -55,6 +60,9 @@ jobs:
             ;;
           *clang) sudo -E apt-get -yq install clang nasm ;;
           esac
+          if [ -n "$CROSS" ]; then
+            sudo -E apt-get -yq install gcc-multilib g++-multilib
+          fi
           $CC --version
           meson --version
           ccache --version
@@ -71,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run meson
         run: |
-          meson setup libvmaf libvmaf/build --buildtype release --prefix $PWD/install -Denable_float=true
+          meson setup libvmaf libvmaf/build --buildtype release --prefix $PWD/install -Denable_float=true ${CROSS:+--cross-file $CROSS}
       - name: Run ninja
         run: |
           sudo ninja -vC libvmaf/build install

--- a/libvmaf/src/feature/cambi.c
+++ b/libvmaf/src/feature/cambi.c
@@ -31,7 +31,7 @@
 #include "mkdirp.h"
 #include "picture.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/cambi_avx2.h"
 #endif
 
@@ -601,7 +601,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->dec_range_callback = decrement_range;
     s->derivative_callback = get_derivative_data_for_row;
 
-#if ARCH_X86
+#if ARCH_X86_64
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         s->inc_range_callback = cambi_increment_range_avx2;

--- a/libvmaf/src/feature/common/convolution.c
+++ b/libvmaf/src/feature/common/convolution.c
@@ -81,7 +81,7 @@ void convolution_f32_c_s(const float *filter, int filter_width, const float *src
 {
     /* if support avx */
 
-#if ARCH_X86
+#if ARCH_X86_64
     const unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         convolution_f32_avx_s(filter, filter_width, src, dst, tmp, width,

--- a/libvmaf/src/feature/cuda/integer_vif_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_vif_cuda.c
@@ -33,7 +33,7 @@
 #include "cuda/integer_vif_cuda.h"
 #include "picture_cuda.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/vif_avx2.h"
 #if HAVE_AVX512
 #include "x86/vif_avx512.h"

--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -25,7 +25,7 @@
 #include "integer_adm.h"
 #include "log.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/adm_avx2.h"
 #if HAVE_AVX512
 #include "x86/adm_avx512.h"
@@ -3077,7 +3077,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->i4_adm_cm = i4_adm_cm;
     s->adm_dwt2_s123_combined = adm_dwt2_s123_combined;
 
-#if ARCH_X86
+#if ARCH_X86_64
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         if (!(w % 8)) s->dwt2_8 = adm_dwt2_8_avx2;

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -32,7 +32,7 @@
 #include "motion_blend_tools.h"
 #include "picture.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/motion_avx2.h"
 #if HAVE_AVX512
 #include "x86/motion_avx512.h"
@@ -364,7 +364,9 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
 
     MotionState *s = fex->priv;
     int err = 0;
+#if ARCH_X86_64
     unsigned flags = vmaf_get_cpu_flags();
+#endif
 
     s->feature_name_dict =
         vmaf_feature_name_dict_from_provided_features(fex->provided_features,
@@ -390,7 +392,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->x_convolution = x_convolution_16;
     s->sad = sad_c;
 
-#if ARCH_X86
+#if ARCH_X86_64
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         s->y_convolution = bpc == 8 ? y_convolution_8_avx2 : y_convolution_16_avx2;
         s->x_convolution = x_convolution_16_avx2;

--- a/libvmaf/src/feature/integer_motion_v2.c
+++ b/libvmaf/src/feature/integer_motion_v2.c
@@ -37,7 +37,7 @@
 #include "feature_extractor.h"
 #include "integer_motion.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/motion_v2_avx2.h"
 #if HAVE_AVX512
 #include "x86/motion_v2_avx512.h"
@@ -178,7 +178,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     else
         s->pipeline = motion_score_pipeline_16;
 
-#if ARCH_X86
+#if ARCH_X86_64
     if (vmaf_get_cpu_flags() & VMAF_X86_CPU_FLAG_AVX2) {
         if (bpc == 8)
             s->pipeline = motion_score_pipeline_8_avx2;

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -32,7 +32,7 @@
 #include "picture.h"
 #include "integer_vif.h"
 
-#if ARCH_X86
+#if ARCH_X86_64
 #include "x86/vif_avx2.h"
 #if HAVE_AVX512
 #include "x86/vif_avx512.h"
@@ -585,7 +585,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     s->vif_statistic_8 = vif_statistic_8;
     s->vif_statistic_16 = vif_statistic_16;
 
-#if ARCH_X86
+#if ARCH_X86_64
     unsigned flags = vmaf_get_cpu_flags();
     if (flags & VMAF_X86_CPU_FLAG_AVX2) {
         s->subsample_rd_8 = vif_subsample_rd_8_avx2;

--- a/libvmaf/src/feature/vif_tools.c
+++ b/libvmaf/src/feature/vif_tools.c
@@ -403,7 +403,7 @@ void vif_filter1d_s(const float *f, const float *src, float *dst, float *tmpbuf,
 
     /* if support avx */
 
-#if ARCH_X86
+#if ARCH_X86_64
     const unsigned flags = vmaf_get_cpu_flags();
     if ((flags & VMAF_X86_CPU_FLAG_AVX2) && fwidth <= MAX_FWIDTH_AVX_CONV) {
         convolution_f32_avx_s(f, fwidth, src, dst, tmpbuf, w, h,
@@ -470,8 +470,8 @@ void vif_filter1d_sq_s(const float *f, const float *src, float *dst, float *tmpb
     int dst_px_stride = dst_stride / sizeof(float);
 
     /* if support avx */
-    
-#if ARCH_X86
+
+#if ARCH_X86_64
     const unsigned flags = vmaf_get_cpu_flags();
     if ((flags & VMAF_X86_CPU_FLAG_AVX2) && fwidth <= MAX_FWIDTH_AVX_CONV) {
         convolution_f32_avx_sq_s(f, fwidth, src, dst, tmpbuf, w, h,
@@ -537,7 +537,7 @@ void vif_filter1d_xy_s(const float *f, const float *src1, const float *src2, flo
 
     /* if support avx */
 
-#if ARCH_X86
+#if ARCH_X86_64
     const unsigned flags = vmaf_get_cpu_flags();
     if ((flags & VMAF_X86_CPU_FLAG_AVX2) && fwidth <= MAX_FWIDTH_AVX_CONV) {
         convolution_f32_avx_xy_s(f, fwidth, src1, src2, dst, tmpbuf, w, h,

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -235,7 +235,7 @@ if is_asm_enabled
         platform_specific_cpu_objects += arm64_static_lib.extract_all_objects()
     endif
 
-    if host_machine.cpu_family().startswith('x86')
+    if host_machine.cpu_family() == 'x86_64'
       x86_avx2_sources = [
           feature_src_dir + 'common/convolution_avx.c',
           feature_src_dir + 'x86/motion_avx2.c',

--- a/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
+++ b/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
@@ -1,0 +1,17 @@
+[binaries]
+c = ['ccache', 'gcc']
+cpp = ['ccache', 'g++']
+ar = 'gcc-ar'
+strip = 'strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'
+
+[built-in options]
+c_args = ['-m32']
+c_link_args = ['-m32']
+cpp_args = ['-m32']
+cpp_link_args = ['-m32']

--- a/libvmaf/test/test_cpu.c
+++ b/libvmaf/test/test_cpu.c
@@ -29,7 +29,7 @@ static char *test_cpu()
     mu_assert("flags should be zero before vmaf_init_cpu()", !flags);
     vmaf_init_cpu();
 
-#if ARCH_X86
+#if ARCH_X86_64
     /*
     flags = vmaf_get_cpu_flags();
     mu_assert("flags should include AVX2", flags & VMAF_X86_CPU_FLAG_AVX2);


### PR DESCRIPTION
This matches the compiling and linking of avx2 and avx512 code to match the checks in cpu.c, since either way, avx2 and above is disabled for 32-bit.


Closes https://github.com/Netflix/vmaf/issues/1481