### PR TITLE
x86/adm: add fallback for 32-bit for 64-bit only intrinsics

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -28,10 +28,15 @@ jobs:
           - os: ubuntu-24.04-arm
             CC: ccache clang
             CXX: ccache clang++
+          - os: ubuntu-latest
+            CC: ccache gcc
+            CXX: ccache g++
+            CROSS: ./libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
+      CROSS: ${{ matrix.CROSS }}
     steps:
       - name: Setup python
         uses: actions/setup-python@v6
@@ -55,6 +60,9 @@ jobs:
             ;;
           *clang) sudo -E apt-get -yq install clang nasm ;;
           esac
+          if [ -n "$CROSS" ]; then
+            sudo -E apt-get -yq install gcc-multilib g++-multilib
+          fi
           $CC --version
           meson --version
           ccache --version
@@ -71,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Run meson
         run: |
-          meson setup libvmaf libvmaf/build --buildtype release --prefix $PWD/install -Denable_float=true
+          meson setup libvmaf libvmaf/build --buildtype release --prefix $PWD/install -Denable_float=true ${CROSS:+--cross-file $CROSS}
       - name: Run ninja
         run: |
           sudo ninja -vC libvmaf/build install

--- a/libvmaf/src/feature/x86/adm_avx2.c
+++ b/libvmaf/src/feature/x86/adm_avx2.c
@@ -1355,6 +1355,19 @@ static inline __m256i sra_epi64(__m256i a, __m256i mask)
     return _mm256_or_si256(rl_shift, signmask);
 }
 
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)
+#define extract_epi64 _mm256_extract_epi64
+#else
+static inline int64_t extract_epi64(__m256i a, const int index)
+{
+    // Fallback for 32-bit where _mm256_extract_epi64 is not available.
+    // Based on how GCC implements _mm256_extract_epi64.
+    __m128i y = _mm256_extractf128_si256(a, index / 2);
+    const int i = index % 2;
+    return ((int64_t)_mm_extract_epi32(y, 2 * i + 1) << 32) | _mm_extract_epi32(y, 2 * i);
+}
+#endif
+
 // No lzcnt in avx2
 void adm_decouple_s123_avx2(AdmBuffer *buf, int w, int h, int stride,
                               double adm_enhn_gain_limit, int32_t* adm_div_lookup)
@@ -1439,14 +1452,14 @@ void adm_decouple_s123_avx2(AdmBuffer *buf, int w, int h, int stride,
 
             // angle_flag as int64
             int64_t angle_flag[8];
-            calc_angle(_mm256_extract_epi64(ot_dp_lo_epi64, 0), _mm256_extract_epi64(o_mag_sq_lo_epi64, 0), _mm256_extract_epi64(t_mag_sq_lo_epi64, 0), angle_flag[0]);
-            calc_angle(_mm256_extract_epi64(ot_dp_lo_epi64, 1), _mm256_extract_epi64(o_mag_sq_lo_epi64, 1), _mm256_extract_epi64(t_mag_sq_lo_epi64, 1), angle_flag[1]);
-            calc_angle(_mm256_extract_epi64(ot_dp_lo_epi64, 2), _mm256_extract_epi64(o_mag_sq_lo_epi64, 2), _mm256_extract_epi64(t_mag_sq_lo_epi64, 2), angle_flag[2]);
-            calc_angle(_mm256_extract_epi64(ot_dp_lo_epi64, 3), _mm256_extract_epi64(o_mag_sq_lo_epi64, 3), _mm256_extract_epi64(t_mag_sq_lo_epi64, 3), angle_flag[3]);
-            calc_angle(_mm256_extract_epi64(ot_dp_hi_epi64, 0), _mm256_extract_epi64(o_mag_sq_hi_epi64, 0), _mm256_extract_epi64(t_mag_sq_hi_epi64, 0), angle_flag[4]);
-            calc_angle(_mm256_extract_epi64(ot_dp_hi_epi64, 1), _mm256_extract_epi64(o_mag_sq_hi_epi64, 1), _mm256_extract_epi64(t_mag_sq_hi_epi64, 1), angle_flag[5]);
-            calc_angle(_mm256_extract_epi64(ot_dp_hi_epi64, 2), _mm256_extract_epi64(o_mag_sq_hi_epi64, 2), _mm256_extract_epi64(t_mag_sq_hi_epi64, 2), angle_flag[6]);
-            calc_angle(_mm256_extract_epi64(ot_dp_hi_epi64, 3), _mm256_extract_epi64(o_mag_sq_hi_epi64, 3), _mm256_extract_epi64(t_mag_sq_hi_epi64, 3), angle_flag[7]);
+            calc_angle(extract_epi64(ot_dp_lo_epi64, 0), extract_epi64(o_mag_sq_lo_epi64, 0), extract_epi64(t_mag_sq_lo_epi64, 0), angle_flag[0]);
+            calc_angle(extract_epi64(ot_dp_lo_epi64, 1), extract_epi64(o_mag_sq_lo_epi64, 1), extract_epi64(t_mag_sq_lo_epi64, 1), angle_flag[1]);
+            calc_angle(extract_epi64(ot_dp_lo_epi64, 2), extract_epi64(o_mag_sq_lo_epi64, 2), extract_epi64(t_mag_sq_lo_epi64, 2), angle_flag[2]);
+            calc_angle(extract_epi64(ot_dp_lo_epi64, 3), extract_epi64(o_mag_sq_lo_epi64, 3), extract_epi64(t_mag_sq_lo_epi64, 3), angle_flag[3]);
+            calc_angle(extract_epi64(ot_dp_hi_epi64, 0), extract_epi64(o_mag_sq_hi_epi64, 0), extract_epi64(t_mag_sq_hi_epi64, 0), angle_flag[4]);
+            calc_angle(extract_epi64(ot_dp_hi_epi64, 1), extract_epi64(o_mag_sq_hi_epi64, 1), extract_epi64(t_mag_sq_hi_epi64, 1), angle_flag[5]);
+            calc_angle(extract_epi64(ot_dp_hi_epi64, 2), extract_epi64(o_mag_sq_hi_epi64, 2), extract_epi64(t_mag_sq_hi_epi64, 2), angle_flag[6]);
+            calc_angle(extract_epi64(ot_dp_hi_epi64, 3), extract_epi64(o_mag_sq_hi_epi64, 3), extract_epi64(t_mag_sq_hi_epi64, 3), angle_flag[7]);
             __m256i angle_flag_lo_epi64 = _mm256_loadu_si256((__m256i*) (&angle_flag[0]));
             __m256i angle_flag_hi_epi64 = _mm256_loadu_si256((__m256i*) (&angle_flag[4]));
 

--- a/libvmaf/src/feature/x86/adm_avx512.c
+++ b/libvmaf/src/feature/x86/adm_avx512.c
@@ -1118,6 +1118,19 @@ angle_flag = ((((float)ot_dp / 4096.0) >= 0.0f) && \
                     cos_1deg_sq * ((float)o_mag_sq / 4096.0) * ((float)t_mag_sq / 4096.0))); \
 } \
 
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)
+#define extract_epi64 _mm256_extract_epi64
+#else
+static inline int64_t extract_epi64(__m256i a, const int index)
+{
+    // Fallback for 32-bit where _mm256_extract_epi64 is not available.
+    // Based on how GCC implements _mm256_extract_epi64.
+    __m128i y = _mm256_extractf128_si256(a, index / 2);
+    const int i = index % 2;
+    return ((int64_t)_mm_extract_epi32(y, 2 * i + 1) << 32) | _mm_extract_epi32(y, 2 * i);
+}
+#endif
+
 void adm_decouple_s123_avx512(AdmBuffer *buf, int w, int h, int stride,
                               double adm_enhn_gain_limit, int32_t* adm_div_lookup)
 {
@@ -1202,22 +1215,22 @@ void adm_decouple_s123_avx512(AdmBuffer *buf, int w, int h, int stride,
 
             // angle_flag as int64
             int64_t angle_flag[16];
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 0), angle_flag[0]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 1), angle_flag[1]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 2), angle_flag[2]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 3), angle_flag[3]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 0), angle_flag[4]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 1), angle_flag[5]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 2), angle_flag[6]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 3), angle_flag[7]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 0), angle_flag[8]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 1), angle_flag[9]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 2), angle_flag[10]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 3), angle_flag[11]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 0), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 0), angle_flag[12]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 1), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 1), angle_flag[13]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 2), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 2), angle_flag[14]);
-            calc_angle(_mm256_extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 3), _mm256_extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 3), angle_flag[15]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 0), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 0), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 0), angle_flag[0]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 1), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 1), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 1), angle_flag[1]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 2), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 2), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 2), angle_flag[2]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 0), 3), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 0), 3), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 0), 3), angle_flag[3]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 0), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 0), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 0), angle_flag[4]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 1), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 1), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 1), angle_flag[5]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 2), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 2), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 2), angle_flag[6]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_lo_epi64, 1), 3), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_lo_epi64, 1), 3), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_lo_epi64, 1), 3), angle_flag[7]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 0), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 0), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 0), angle_flag[8]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 1), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 1), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 1), angle_flag[9]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 2), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 2), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 2), angle_flag[10]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 0), 3), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 0), 3), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 0), 3), angle_flag[11]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 0), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 0), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 0), angle_flag[12]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 1), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 1), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 1), angle_flag[13]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 2), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 2), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 2), angle_flag[14]);
+            calc_angle(extract_epi64(_mm512_extracti64x4_epi64(ot_dp_hi_epi64, 1), 3), extract_epi64(_mm512_extracti64x4_epi64(o_mag_sq_hi_epi64, 1), 3), extract_epi64(_mm512_extracti64x4_epi64(t_mag_sq_hi_epi64, 1), 3), angle_flag[15]);
 
             __m512i angle_flag_lo_epi64 = _mm512_loadu_si512((__m512i*) (&angle_flag[0]));
             __m512i angle_flag_hi_epi64 = _mm512_loadu_si512((__m512i*) (&angle_flag[8]));

--- a/libvmaf/src/x86/cpu.c
+++ b/libvmaf/src/x86/cpu.c
@@ -56,7 +56,7 @@ unsigned vmaf_get_cpu_flags_x86(void) {
                     flags |= VMAF_X86_CPU_FLAG_SSE41;
             }
         }
-#if ARCH_X86_64
+
         /* We only support >128-bit SIMD on x86-64. */
         if (X(r.ecx, 0x18000000)) /* OSXSAVE/AVX */ {
             const uint64_t xcr0 = vmaf_cpu_xgetbv(0);
@@ -75,7 +75,7 @@ unsigned vmaf_get_cpu_flags_x86(void) {
                 }
             }
         }
-#endif
+
     }
 
     return flags;

--- a/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
+++ b/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
@@ -1,0 +1,17 @@
+[binaries]
+c = ['ccache', 'gcc']
+cpp = ['ccache', 'g++']
+ar = 'gcc-ar'
+strip = 'strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'
+
+[built-in options]
+c_args = ['-m32']
+c_link_args = ['-m32']
+cpp_args = ['-m32']
+cpp_link_args = ['-m32']


### PR DESCRIPTION
Similar to https://github.com/Netflix/vmaf/pull/1495, but going a different route.

This also "unlocks" avx and above for 32-bit CPUs

Closes https://github.com/Netflix/vmaf/issues/1481