### PR TITLE
x86/adm: fix compilation for 32-bit clang

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -32,6 +32,10 @@ jobs:
             CC: ccache gcc
             CXX: ccache g++
             CROSS: ./libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
+          - os: ubuntu-latest
+            CC: ccache clang
+            CXX: ccache clang++
+            CROSS: ./libvmaf/test/meson-toolchains/i686-pc-linux-gnu-clang-cross.ini
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
@@ -58,7 +62,7 @@ jobs:
             sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
             sudo -E apt-get -yq install gcc-9 g++-9 nasm
             ;;
-          *clang) sudo -E apt-get -yq install clang nasm ;;
+          *clang) sudo -E apt-get -yq install clang llvm nasm ;;
           esac
           if [ -n "$CROSS" ]; then
             sudo -E apt-get -yq install gcc-multilib g++-multilib

--- a/libvmaf/src/feature/x86/adm_avx2.c
+++ b/libvmaf/src/feature/x86/adm_avx2.c
@@ -1362,9 +1362,26 @@ static inline int64_t extract_epi64(__m256i a, const int index)
 {
     // Fallback for 32-bit where _mm256_extract_epi64 is not available.
     // Based on how GCC implements _mm256_extract_epi64.
-    __m128i y = _mm256_extractf128_si256(a, index / 2);
-    const int i = index % 2;
-    return ((int64_t)_mm_extract_epi32(y, 2 * i + 1) << 32) | _mm_extract_epi32(y, 2 * i);
+    // Uses a switch to ensure constant indices since clang will complain.
+    switch (index) {
+    case 0: {
+        __m128i y = _mm256_extractf128_si256(a, 0);
+        return ((uint64_t)_mm_extract_epi32(y, 1) << 32) | (unsigned)_mm_extract_epi32(y, 0);
+    }
+    case 1: {
+        __m128i y = _mm256_extractf128_si256(a, 0);
+        return ((uint64_t)_mm_extract_epi32(y, 3) << 32) | (unsigned)_mm_extract_epi32(y, 2);
+    }
+    case 2: {
+        __m128i y = _mm256_extractf128_si256(a, 1);
+        return ((uint64_t)_mm_extract_epi32(y, 1) << 32) | (unsigned)_mm_extract_epi32(y, 0);
+    }
+    case 3: {
+        __m128i y = _mm256_extractf128_si256(a, 1);
+        return ((uint64_t)_mm_extract_epi32(y, 3) << 32) | (unsigned)_mm_extract_epi32(y, 2);
+    }
+    default: return 0;
+    }
 }
 #endif
 

--- a/libvmaf/src/feature/x86/adm_avx512.c
+++ b/libvmaf/src/feature/x86/adm_avx512.c
@@ -1125,9 +1125,26 @@ static inline int64_t extract_epi64(__m256i a, const int index)
 {
     // Fallback for 32-bit where _mm256_extract_epi64 is not available.
     // Based on how GCC implements _mm256_extract_epi64.
-    __m128i y = _mm256_extractf128_si256(a, index / 2);
-    const int i = index % 2;
-    return ((int64_t)_mm_extract_epi32(y, 2 * i + 1) << 32) | _mm_extract_epi32(y, 2 * i);
+    // Uses a switch to ensure constant indices since clang will complain.
+    switch (index) {
+    case 0: {
+        __m128i y = _mm256_extractf128_si256(a, 0);
+        return ((uint64_t)_mm_extract_epi32(y, 1) << 32) | (unsigned)_mm_extract_epi32(y, 0);
+    }
+    case 1: {
+        __m128i y = _mm256_extractf128_si256(a, 0);
+        return ((uint64_t)_mm_extract_epi32(y, 3) << 32) | (unsigned)_mm_extract_epi32(y, 2);
+    }
+    case 2: {
+        __m128i y = _mm256_extractf128_si256(a, 1);
+        return ((uint64_t)_mm_extract_epi32(y, 1) << 32) | (unsigned)_mm_extract_epi32(y, 0);
+    }
+    case 3: {
+        __m128i y = _mm256_extractf128_si256(a, 1);
+        return ((uint64_t)_mm_extract_epi32(y, 3) << 32) | (unsigned)_mm_extract_epi32(y, 2);
+    }
+    default: return 0;
+    }
 }
 #endif
 

--- a/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-clang-cross.ini
+++ b/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-clang-cross.ini
@@ -1,0 +1,17 @@
+[binaries]
+c = ['ccache', 'clang']
+cpp = ['ccache', 'clang++']
+ar = 'llvm-ar'
+strip = 'llvm-strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'x86'
+endian = 'little'
+
+[built-in options]
+c_args = ['-m32', '-mfpmath=sse', '-msse2']
+c_link_args = ['-m32']
+cpp_args = ['-m32', '-mfpmath=sse', '-msse2']
+cpp_link_args = ['-m32']


### PR DESCRIPTION
Addresses the issue reported in https://github.com/Netflix/vmaf/issues/1481#issuecomment-4344041294