### PR TITLE
python/cambi: update to v0.8 with additional tests

### DIFF
--- a/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
+++ b/libvmaf/test/meson-toolchains/i686-pc-linux-gnu-gcc-cross.ini
@@ -11,7 +11,7 @@ cpu = 'x86'
 endian = 'little'
 
 [built-in options]
-c_args = ['-m32']
+c_args = ['-m32', '-mfpmath=sse', '-msse2']
 c_link_args = ['-m32']
-cpp_args = ['-m32']
+cpp_args = ['-m32', '-mfpmath=sse', '-msse2']
 cpp_link_args = ['-m32']

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import unittest
+from unittest.mock import patch
 from test.testutil import set_default_576_324_videos_for_testing, \
     set_default_576_324_videos_for_testing_scaled, \
     set_default_cambi_video_for_testing_b, \
@@ -158,14 +159,15 @@ class CambiFeatureExtractorTest(MyTestCase):
 
     def test_run_cambi_fextractor_notyuv_unspecified_enc_bitdepth(self):
         asset = set_default_cambi_notyuv_asset_for_validation_testing()
-        self.fextractor = CambiFeatureExtractor(
-            [asset],
-            None, fifo_mode=False,
-            result_store=None,
-            optional_dict={}
-        )
-        with self.assertRaises(AssertionError):
-            self.fextractor.run(parallelize=False)
+        with patch('vmaf.config.VmafExternalConfig.get_and_assert_ffmpeg'):
+            self.fextractor = CambiFeatureExtractor(
+                [asset],
+                None, fifo_mode=False,
+                result_store=None,
+                optional_dict={}
+            )
+            with self.assertRaises(AssertionError):
+                self.fextractor.run(parallelize=False)
 
     def test_run_cambi_fextractor_notyuv_correct_enc_bitdepth(self):
         _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
@@ -203,15 +205,15 @@ class CambiFeatureExtractorTest(MyTestCase):
         asset = set_default_cambi_notyuv_asset_for_validation_testing()
         asset.asset_dict['dis_enc_bitdepth'] = 10
         del asset.asset_dict['workfile_yuv_type']
-        self.fextractor = CambiFeatureExtractor(
-            [asset],
-            None, fifo_mode=False,
-            result_store=None,
-            optional_dict={}
-        )
-
-        with self.assertRaises(AssertionError):
-            self.fextractor.run(parallelize=False)
+        with patch('vmaf.config.VmafExternalConfig.get_and_assert_ffmpeg'):
+            self.fextractor = CambiFeatureExtractor(
+                [asset],
+                None, fifo_mode=False,
+                result_store=None,
+                optional_dict={}
+            )
+            with self.assertRaises(AssertionError):
+                self.fextractor.run(parallelize=False)
 
     def test_run_cambi_fextractor_max_log_contrast(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -6,6 +6,8 @@ from test.testutil import set_default_576_324_videos_for_testing, \
     set_default_cambi_video_for_testing_b, \
     set_default_cambi_video_for_testing_10b, \
     set_default_cambi_video_for_testing_yuv10b, \
+    set_default_cambi_video_for_testing_yuv4k, \
+    set_default_cambi_video_for_testing_yuv1080p, \
     set_default_cambi_notyuv_asset_for_validation_testing
 
 from vmaf.core.cambi_feature_extractor import CambiFeatureExtractor, CambiFullReferenceFeatureExtractor
@@ -298,12 +300,8 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'], 0.0001, places=4)
 
     def test_run_cambi_fextractor_notyuv_4k_encode(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv4k()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 3840
-        asset.asset_dict['quality_height'] = 2160
-        asset.asset_dict['dis_enc_width'] = 3840
-        asset.asset_dict['dis_enc_height'] = 2160
 
         self.fextractor = CambiFeatureExtractor(
             [asset],
@@ -314,16 +312,11 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'], 0.24399833333333332, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'], 0.271599, places=4)
 
     def test_run_cambi_fextractor_notyuv_4k_encode_high_res_speedup(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv4k()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 3840
-        asset.asset_dict['quality_height'] = 2160
-        asset.asset_dict['dis_enc_width'] = 3840
-        asset.asset_dict['dis_enc_height'] = 2160
 
         self.fextractor = CambiFeatureExtractor(
             [asset],
@@ -334,14 +327,11 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_2160_encbd_8_score'], 0.24772933333333333, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_2160_encbd_8_score'], 0.270937, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv4k()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 3840
-        asset.asset_dict['quality_height'] = 2160
         asset.asset_dict['dis_enc_width'] = 1920
         asset.asset_dict['dis_enc_height'] = 1080
 
@@ -354,14 +344,11 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1080_encw_1920_score'], 0.14994066666666664, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1080_encw_1920_score'], 0.167373, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode_high_res_speedup(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv4k()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 3840
-        asset.asset_dict['quality_height'] = 2160
         asset.asset_dict['dis_enc_width'] = 1920
         asset.asset_dict['dis_enc_height'] = 1080
 
@@ -374,14 +361,11 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_1080_encbd_8_ench_1080_encw_1920_score'], 0.16270733333333334, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_1080_encbd_8_ench_1080_encw_1920_score'], 0.192061, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode_vis_lum_threshold(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv4k()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 3840
-        asset.asset_dict['quality_height'] = 2160
         asset.asset_dict['dis_enc_width'] = 1920
         asset.asset_dict['dis_enc_height'] = 1080
 
@@ -394,9 +378,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_vlt_5_encbd_8_ench_1080_encw_1920_score'], 0.095409,
-                               places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_vlt_5_encbd_8_ench_1080_encw_1920_score'], 0.104946, places=4)
 
     def test_run_cambi_fextractor_max_val(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -415,10 +397,8 @@ class CambiFeatureExtractorTest(MyTestCase):
                                places=4)
 
     def test_run_cambi_fextractor_notyuv_1440p_encode_at_1080p_quality_height(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv1080p()
         asset.asset_dict['dis_enc_bitdepth'] = 8
-        asset.asset_dict['quality_width'] = 1920
-        asset.asset_dict['quality_height'] = 1080
         asset.asset_dict['dis_enc_width'] = 2560
         asset.asset_dict['dis_enc_height'] = 1440
 
@@ -431,8 +411,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=False)
         results = self.fextractor.results
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1440_encw_2560_score'], 0.15102933333333332, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1440_encw_2560_score'], 0.172338, places=4)
 
 
 class CambiQualityRunnerTest(MyTestCase):

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -10,10 +10,15 @@ from test.testutil import set_default_576_324_videos_for_testing, \
 from vmaf.core.cambi_feature_extractor import CambiFeatureExtractor, CambiFullReferenceFeatureExtractor
 from vmaf.core.cambi_quality_runner import CambiQualityRunner, CambiFullReferenceQualityRunner
 from vmaf.core.result_store import FileSystemResultStore
-from vmaf.tools.testutils import MyTestCaseWithCleanup
+from vmaf.tools.misc import MyTestCase
 
 
-class CambiFeatureExtractorTest(MyTestCaseWithCleanup):
+class CambiFeatureExtractorTest(MyTestCase):
+
+    def tearDown(self):
+        if hasattr(self, 'fextractor'):
+            self.fextractor.remove_results()
+        super().tearDown()
 
     def test_run_cambi_fextractor(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -429,7 +434,12 @@ class CambiFeatureExtractorTest(MyTestCaseWithCleanup):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1440_encw_2560_score'], 0.15102933333333332, places=4)
 
 
-class CambiQualityRunnerTest(MyTestCaseWithCleanup):
+class CambiQualityRunnerTest(MyTestCase):
+
+    def tearDown(self):
+        if hasattr(self, 'qrunner'):
+            self.qrunner.remove_results()
+        super().tearDown()
 
     def test_run_cambi_runner(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -511,7 +521,7 @@ class CambiQualityRunnerTest(MyTestCaseWithCleanup):
                                0.25968416666666666, places=4)
 
 
-class CambiResultsCachingTest(MyTestCaseWithCleanup):
+class CambiResultsCachingTest(MyTestCase):
 
     def setUp(self):
         super().setUp()

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -4,20 +4,16 @@ import unittest
 from test.testutil import set_default_576_324_videos_for_testing, \
     set_default_576_324_videos_for_testing_scaled, \
     set_default_cambi_video_for_testing_b, \
-    set_default_cambi_video_for_testing_10b
+    set_default_cambi_video_for_testing_10b, \
+    set_default_cambi_video_for_testing_mp4
 
 from vmaf.core.cambi_feature_extractor import CambiFeatureExtractor, CambiFullReferenceFeatureExtractor
 from vmaf.core.cambi_quality_runner import CambiQualityRunner, CambiFullReferenceQualityRunner
-from vmaf.tools.misc import MyTestCase
 from vmaf.core.result_store import FileSystemResultStore
+from vmaf.tools.testutils import MyTestCaseWithCleanup
 
 
-class CambiFeatureExtractorTest(MyTestCase):
-
-    def tearDown(self):
-        if hasattr(self, 'fextractor'):
-            self.fextractor.remove_results()
-        super().tearDown()
+class CambiFeatureExtractorTest(MyTestCaseWithCleanup):
 
     def test_run_cambi_fextractor(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -33,6 +29,76 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'],
                                0.25968416666666666, places=4)
         self.assertAlmostEqual(results[1]['Cambi_feature_cambi_encbd_8_score'],
+                               0.00020847916666666663, places=4)
+
+    def test_run_cambi_fextractor_topk(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_topk': 0.7}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_ctpk_0.7_encbd_8_score'],
+                               0.22258620833333334, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_ctpk_0.7_encbd_8_score'],
+                               0.00020847916666666663, places=4)
+
+    def test_run_cambi_fextractor_both_topk_set(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'topk': 0.8,
+                           'cambi_topk': 0.7}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_ctpk_0.7_encbd_8_topk_0.8_score'],
+                               0.1947626041666667, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_ctpk_0.7_encbd_8_topk_0.8_score'],
+                               0.00020847916666666663, places=4)
+
+    def test_run_cambi_fextractor_eotf(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_eotf': "pq"}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_ceot_pq_encbd_8_score'],
+                               0.2596885625, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_ceot_pq_encbd_8_score'],
+                               0.00020847916666666663, places=4)
+
+    def test_run_cambi_fextractor_both_eotf_set(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'eotf': "xxx",
+                           'cambi_eotf': "pq"}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_ceot_pq_encbd_8_eotf_xxx_score'],
+                               0.2596885625, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_ceot_pq_encbd_8_eotf_xxx_score'],
                                0.00020847916666666663, places=4)
 
     def test_run_cambi_fextractor_scaled(self):
@@ -82,24 +148,19 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_10_score'],
                                0.0013863333333333334, places=4)
 
-    def test_run_cambi_fextractor_incorrect_enc_bitdepth(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
-        asset.asset_dict['dis_enc_bitdepth'] = 10
+    def test_run_cambi_fextractor_notyuv_unspecified_enc_bitdepth(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
             None, fifo_mode=False,
             result_store=None,
             optional_dict={}
         )
-        self.fextractor.run(parallelize=False)
-        results = self.fextractor.results
+        with self.assertRaises(AssertionError):
+            self.fextractor.run(parallelize=False)
 
-        # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_10_score'],
-                               0.0013863333333333334, places=4)
-
-    def test_run_cambi_fextractor_correct_enc_bitdepth(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
+    def test_run_cambi_fextractor_notyuv_correct_enc_bitdepth(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -112,10 +173,11 @@ class CambiFeatureExtractorTest(MyTestCase):
 
         # score: arithmetic mean score over all frames
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'],
-                               0.00020733333333333332, places=4)
+                               0.022446666666666667, places=4)
 
-    def test_run_cambi_fextractor_notyuv_correct_enc_bitdepth_8(self):
-        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+    def test_run_cambi_fextractor_notyuv_incorrect_enc_bitdepth(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 10
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
             None, fifo_mode=False,
@@ -126,18 +188,20 @@ class CambiFeatureExtractorTest(MyTestCase):
         results = self.fextractor.results
 
         # score: arithmetic mean score over all frames
-        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_encbd_8_score'],
-                               0.00020733333333333332, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_10_score'],
+                               0.020136333333333336, places=4)
 
-    def test_run_cambi_fextractor_enc_bitdepth_none(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_10b()
-        asset.asset_dict['dis_enc_bitdepth'] = None
+    def test_run_cambi_fextractor_notyuv_10bit_without_workfile_yuv_type(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 10
+        del asset.asset_dict['workfile_yuv_type']
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
             None, fifo_mode=False,
             result_store=None,
             optional_dict={}
         )
+
         with self.assertRaises(AssertionError):
             self.fextractor.run(parallelize=False)
 
@@ -210,8 +274,162 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'],
                                0.25944045833333335, places=4)
 
+    def test_run_cambi_fextractor_full_reference_scaled_ref_max_val(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFullReferenceFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'src_width': 480, 'src_height': 270, 'cambi_max_val': 0.0001}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
 
-class CambiQualityRunnerTest(MyTestCase):
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_cmxv_0.0001_encbd_8_srch_270_srcw_480_score'],
+                               0.0001, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_source_score'], 0.0001, places=4)
+        self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'], 0.0001, places=4)
+
+    def test_run_cambi_fextractor_notyuv_4k_encode(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 3840
+        asset.asset_dict['quality_height'] = 2160
+        asset.asset_dict['dis_enc_width'] = 3840
+        asset.asset_dict['dis_enc_height'] = 2160
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'], 0.24399833333333332, places=4)
+
+    def test_run_cambi_fextractor_notyuv_4k_encode_high_res_speedup(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 3840
+        asset.asset_dict['quality_height'] = 2160
+        asset.asset_dict['dis_enc_width'] = 3840
+        asset.asset_dict['dis_enc_height'] = 2160
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_high_res_speedup': 2160}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_2160_encbd_8_score'], 0.24772933333333333, places=4)
+
+    def test_run_cambi_fextractor_notyuv_1080p_encode(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 3840
+        asset.asset_dict['quality_height'] = 2160
+        asset.asset_dict['dis_enc_width'] = 1920
+        asset.asset_dict['dis_enc_height'] = 1080
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1080_encw_1920_score'], 0.14994066666666664, places=4)
+
+    def test_run_cambi_fextractor_notyuv_1080p_encode_high_res_speedup(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 3840
+        asset.asset_dict['quality_height'] = 2160
+        asset.asset_dict['dis_enc_width'] = 1920
+        asset.asset_dict['dis_enc_height'] = 1080
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_high_res_speedup': 1080}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_1080_encbd_8_ench_1080_encw_1920_score'], 0.16270733333333334, places=4)
+
+    def test_run_cambi_fextractor_notyuv_1080p_encode_vis_lum_threshold(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 3840
+        asset.asset_dict['quality_height'] = 2160
+        asset.asset_dict['dis_enc_width'] = 1920
+        asset.asset_dict['dis_enc_height'] = 1080
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_vis_lum_threshold': 5.0}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_vlt_5_encbd_8_ench_1080_encw_1920_score'], 0.095409,
+                               places=4)
+
+    def test_run_cambi_fextractor_max_val(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing()
+        self.fextractor = CambiFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'cambi_max_val': 0.1}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_cmxv_0.1_encbd_8_score'], 0.1, places=4)
+        self.assertAlmostEqual(results[1]['Cambi_feature_cambi_cmxv_0.1_encbd_8_score'], 0.0002582708333333333,
+                               places=4)
+
+    def test_run_cambi_fextractor_notyuv_1440p_encode_at_1080p_quality_height(self):
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset.asset_dict['dis_enc_bitdepth'] = 8
+        asset.asset_dict['quality_width'] = 1920
+        asset.asset_dict['quality_height'] = 1080
+        asset.asset_dict['dis_enc_width'] = 2560
+        asset.asset_dict['dis_enc_height'] = 1440
+
+        self.fextractor = CambiFeatureExtractor(
+            [asset],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={}
+        )
+        self.fextractor.run(parallelize=False)
+        results = self.fextractor.results
+
+        # score: arithmetic mean score over all frames
+        self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1440_encw_2560_score'], 0.15102933333333332, places=4)
+
+
+class CambiQualityRunnerTest(MyTestCaseWithCleanup):
 
     def test_run_cambi_runner(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -293,14 +511,16 @@ class CambiQualityRunnerTest(MyTestCase):
                                0.25968416666666666, places=4)
 
 
-class CambiResultsCachingTest(MyTestCase):
+class CambiResultsCachingTest(MyTestCaseWithCleanup):
 
     def setUp(self):
+        super().setUp()
         self.results_store_dir = FileSystemResultStore()
 
     def tearDown(self):
         if os.path.exists(self.store_dir):
             shutil.rmtree(self.store_dir)
+        super().tearDown()
 
     def test_run_cambi_runner(self):
         _, _, asset, asset_original = set_default_576_324_videos_for_testing_scaled()

--- a/python/test/cambi_test.py
+++ b/python/test/cambi_test.py
@@ -5,7 +5,8 @@ from test.testutil import set_default_576_324_videos_for_testing, \
     set_default_576_324_videos_for_testing_scaled, \
     set_default_cambi_video_for_testing_b, \
     set_default_cambi_video_for_testing_10b, \
-    set_default_cambi_video_for_testing_mp4
+    set_default_cambi_video_for_testing_yuv10b, \
+    set_default_cambi_notyuv_asset_for_validation_testing
 
 from vmaf.core.cambi_feature_extractor import CambiFeatureExtractor, CambiFullReferenceFeatureExtractor
 from vmaf.core.cambi_quality_runner import CambiQualityRunner, CambiFullReferenceQualityRunner
@@ -154,9 +155,9 @@ class CambiFeatureExtractorTest(MyTestCase):
                                0.0013863333333333334, places=4)
 
     def test_run_cambi_fextractor_notyuv_unspecified_enc_bitdepth(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset = set_default_cambi_notyuv_asset_for_validation_testing()
         self.fextractor = CambiFeatureExtractor(
-            [asset, asset_original],
+            [asset],
             None, fifo_mode=False,
             result_store=None,
             optional_dict={}
@@ -165,7 +166,7 @@ class CambiFeatureExtractorTest(MyTestCase):
             self.fextractor.run(parallelize=False)
 
     def test_run_cambi_fextractor_notyuv_correct_enc_bitdepth(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -181,7 +182,7 @@ class CambiFeatureExtractorTest(MyTestCase):
                                0.022446666666666667, places=4)
 
     def test_run_cambi_fextractor_notyuv_incorrect_enc_bitdepth(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 10
         self.fextractor = CambiFeatureExtractor(
             [asset, asset_original],
@@ -197,11 +198,11 @@ class CambiFeatureExtractorTest(MyTestCase):
                                0.020136333333333336, places=4)
 
     def test_run_cambi_fextractor_notyuv_10bit_without_workfile_yuv_type(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        asset = set_default_cambi_notyuv_asset_for_validation_testing()
         asset.asset_dict['dis_enc_bitdepth'] = 10
         del asset.asset_dict['workfile_yuv_type']
         self.fextractor = CambiFeatureExtractor(
-            [asset, asset_original],
+            [asset],
             None, fifo_mode=False,
             result_store=None,
             optional_dict={}
@@ -297,7 +298,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_FR_feature_cambi_full_reference_score'], 0.0001, places=4)
 
     def test_run_cambi_fextractor_notyuv_4k_encode(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 3840
         asset.asset_dict['quality_height'] = 2160
@@ -317,7 +318,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_score'], 0.24399833333333332, places=4)
 
     def test_run_cambi_fextractor_notyuv_4k_encode_high_res_speedup(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 3840
         asset.asset_dict['quality_height'] = 2160
@@ -337,7 +338,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_2160_encbd_8_score'], 0.24772933333333333, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 3840
         asset.asset_dict['quality_height'] = 2160
@@ -357,7 +358,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_encbd_8_ench_1080_encw_1920_score'], 0.14994066666666664, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode_high_res_speedup(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 3840
         asset.asset_dict['quality_height'] = 2160
@@ -377,7 +378,7 @@ class CambiFeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['Cambi_feature_cambi_hrs_1080_encbd_8_ench_1080_encw_1920_score'], 0.16270733333333334, places=4)
 
     def test_run_cambi_fextractor_notyuv_1080p_encode_vis_lum_threshold(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 3840
         asset.asset_dict['quality_height'] = 2160
@@ -414,7 +415,7 @@ class CambiFeatureExtractorTest(MyTestCase):
                                places=4)
 
     def test_run_cambi_fextractor_notyuv_1440p_encode_at_1080p_quality_height(self):
-        _, _, asset, asset_original = set_default_cambi_video_for_testing_mp4()
+        _, _, asset, asset_original = set_default_cambi_video_for_testing_yuv10b()
         asset.asset_dict['dis_enc_bitdepth'] = 8
         asset.asset_dict['quality_width'] = 1920
         asset.asset_dict['quality_height'] = 1080

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -239,6 +239,38 @@ def set_default_cambi_video_for_testing_yuv10b():
     return dis_path, dis_path, asset, asset
 
 
+def set_default_cambi_video_for_testing_yuv4k():
+    dis_path = VmafConfig.test_resource_path("yuv", "blue_sky_1frame_3840x2160_10b.yuv")
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                       workdir_root=VmafConfig.workdir_path(),
+                       dis_path=dis_path,
+                       asset_dict={'yuv_type': 'yuv420p10le',
+                                   'width': 3840,
+                                   'height': 2160,
+                                   'quality_width': 3840,
+                                   'quality_height': 2160,
+                                   'dis_enc_width': 3840,
+                                   'dis_enc_height': 2160})
+
+    return dis_path, dis_path, asset, asset
+
+
+def set_default_cambi_video_for_testing_yuv1080p():
+    dis_path = VmafConfig.test_resource_path("yuv", "blue_sky_1frame_1920x1080_10b.yuv")
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                       workdir_root=VmafConfig.workdir_path(),
+                       dis_path=dis_path,
+                       asset_dict={'yuv_type': 'yuv420p10le',
+                                   'width': 1920,
+                                   'height': 1080,
+                                   'quality_width': 1920,
+                                   'quality_height': 1080,
+                                   'dis_enc_width': 1920,
+                                   'dis_enc_height': 1080})
+
+    return dis_path, dis_path, asset, asset
+
+
 def set_default_cambi_notyuv_asset_for_validation_testing():
     """Returns a notyuv asset with a dummy path for testing validation guards.
     The dummy path is never accessed — assertions fire before any I/O occurs."""

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -222,20 +222,6 @@ def set_default_cambi_video_for_testing_10b():
     return dis_path, dis_path, asset, asset
 
 
-def set_default_cambi_video_for_testing_mp4():
-    dis_path = VmafConfig.test_resource_path("mp4", "blue_sky_360p_60f_8b_converted_to_10b.mp4")
-    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
-                       workdir_root=VmafConfig.workdir_path(),
-                       dis_path=dis_path,
-                       asset_dict={'yuv_type': 'notyuv',
-                                   'workfile_yuv_type': 'yuv420p10le',
-                                   'quality_width': 640,
-                                   'quality_height': 360,
-                                   'dis_enc_width': 640,
-                                   'dis_enc_height': 360})
-
-    return dis_path, dis_path, asset, asset
-
 
 def set_default_cambi_video_for_testing_yuv10b():
     dis_path = VmafConfig.test_resource_path("yuv", "blue_sky_360p_60f_8b_converted_to_10b.yuv")

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -220,3 +220,18 @@ def set_default_cambi_video_for_testing_10b():
                               'yuv_type': 'yuv420p10le'})
 
     return dis_path, dis_path, asset, asset
+
+
+def set_default_cambi_video_for_testing_mp4():
+    dis_path = VmafConfig.test_resource_path("mp4", "blue_sky_360p_60f_8b_converted_to_10b.mp4")
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                       workdir_root=VmafConfig.workdir_path(),
+                       dis_path=dis_path,
+                       asset_dict={'yuv_type': 'notyuv',
+                                   'workfile_yuv_type': 'yuv420p10le',
+                                   'quality_width': 640,
+                                   'quality_height': 360,
+                                   'dis_enc_width': 640,
+                                   'dis_enc_height': 360})
+
+    return dis_path, dis_path, asset, asset

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -235,3 +235,35 @@ def set_default_cambi_video_for_testing_mp4():
                                    'dis_enc_height': 360})
 
     return dis_path, dis_path, asset, asset
+
+
+def set_default_cambi_video_for_testing_yuv10b():
+    dis_path = VmafConfig.test_resource_path("yuv", "blue_sky_360p_60f_8b_converted_to_10b.yuv")
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                       workdir_root=VmafConfig.workdir_path(),
+                       dis_path=dis_path,
+                       asset_dict={'yuv_type': 'yuv420p10le',
+                                   'width': 640,
+                                   'height': 360,
+                                   'quality_width': 640,
+                                   'quality_height': 360,
+                                   'dis_enc_width': 640,
+                                   'dis_enc_height': 360})
+
+    return dis_path, dis_path, asset, asset
+
+
+def set_default_cambi_notyuv_asset_for_validation_testing():
+    """Returns a notyuv asset with a dummy path for testing validation guards.
+    The dummy path is never accessed — assertions fire before any I/O occurs."""
+    asset = NorefAsset(dataset="test", content_id=0, asset_id=0,
+                       workdir_root=VmafConfig.workdir_path(),
+                       dis_path="dummy_not_accessed.mp4",
+                       asset_dict={'yuv_type': 'notyuv',
+                                   'workfile_yuv_type': 'yuv420p10le',
+                                   'quality_width': 640,
+                                   'quality_height': 360,
+                                   'dis_enc_width': 640,
+                                   'dis_enc_height': 360})
+
+    return asset

--- a/python/vmaf/core/cambi_feature_extractor.py
+++ b/python/vmaf/core/cambi_feature_extractor.py
@@ -1,12 +1,16 @@
 from vmaf import ExternalProgramCaller
 from vmaf.core.feature_extractor import VmafexecFeatureExtractorMixin, FeatureExtractor
+from vmaf.tools.reader import YuvReader
 
 
 class CambiFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
     TYPE = "Cambi_feature"
-    # VERSION = "0.4" # Supporting scaled encodes and minor change to the spatial mask
-    VERSION = "0.5"  # Supporting bitdepth converted encodes
+    # VERSION = "0.4"  # Supporting scaled encodes and minor change to the spatial mask
+    # VERSION = "0.5"  # Supporting bitdepth converted encodes
+    # VERSION = "0.6"  # Include the feature options as part of the feature name
+    # VERSION = "0.7"  # Add visibility luminance threshold
+    VERSION = "0.8"    # Avoid upscaling when encoding resolution is larger than input resolution
 
     ATOM_FEATURES = ['cambi']
 
@@ -29,6 +33,21 @@ class CambiFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
             'For Cambi, dis_encode_bitdepth cannot be None. One can specify dis_encode_bitdepth by adding ' \
             'dis_enc_bitdepth field to asset_dict. The supported values are 8, 10, 12, or 16.'
         encode_bitdepth = asset.dis_encode_bitdepth
+
+        if encode_bitdepth > 8 and asset.dis_yuv_type == 'notyuv' and \
+                asset.workfile_yuv_type in YuvReader.SUPPORTED_YUV_8BIT_TYPES:
+            if encode_bitdepth == 10:
+                supported_yuv_types = YuvReader.SUPPORTED_YUV_10BIT_LE_TYPES
+            elif encode_bitdepth == 12:
+                supported_yuv_types = YuvReader.SUPPORTED_YUV_12BIT_LE_TYPES
+            elif encode_bitdepth == 16:
+                supported_yuv_types = YuvReader.SUPPORTED_YUV_16BIT_LE_TYPES
+            else:
+                assert False, "Unsupported encoding bit depth. The supported values are 8, 10, 12, or 16."
+            assert False, f"workfile_yuv_type is set to {asset.workfile_yuv_type} for a {encode_bitdepth} bit encode. " \
+                          f"This would lead to converting the encode to 8 bit prior to calculating CAMBI and " \
+                          f"producing inaccurate results. To compute Cambi in {encode_bitdepth} bit, one can add " \
+                          f"workfile_yuv_type field to asset_dict. The supported values are {supported_yuv_types}."
 
         additional_params = {'enc_bitdepth': encode_bitdepth}
         if encode_width != quality_width or encode_height != quality_height:
@@ -53,6 +72,7 @@ class CambiFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 class CambiFullReferenceFeatureExtractor(CambiFeatureExtractor):
 
     TYPE = "Cambi_FR_feature"
+    VERSION = CambiFeatureExtractor.VERSION
 
     ATOM_FEATURES = ['cambi', 'cambi_full_reference', 'cambi_source']
 

--- a/python/vmaf/core/cambi_feature_extractor.py
+++ b/python/vmaf/core/cambi_feature_extractor.py
@@ -18,16 +18,11 @@ class CambiFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
         'cambi': 'cambi'
     }
 
-    def _generate_result(self, asset):
-        # routine to call the command-line executable and generate quality
-        # scores in the log file.
-
-        quality_width, quality_height = asset.quality_width_height
+    def _validate_asset(self, asset):
         assert asset.dis_encode_width_height is not None, \
             'For Cambi, dis_encode_width_height cannot be None. One can specify dis_encode_width_height by adding ' \
             'the following fields to asset_dict: 1) dis_enc_width and dis_enc_height, or 2) dis_width and ' \
             'dis_height, or 3) width and height.'
-        encode_width, encode_height = asset.dis_encode_width_height
 
         assert asset.dis_encode_bitdepth is not None, \
             'For Cambi, dis_encode_bitdepth cannot be None. One can specify dis_encode_bitdepth by adding ' \
@@ -48,6 +43,18 @@ class CambiFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
                           f"This would lead to converting the encode to 8 bit prior to calculating CAMBI and " \
                           f"producing inaccurate results. To compute Cambi in {encode_bitdepth} bit, one can add " \
                           f"workfile_yuv_type field to asset_dict. The supported values are {supported_yuv_types}."
+
+    def _run_on_asset(self, asset):
+        self._validate_asset(asset)
+        return super()._run_on_asset(asset)
+
+    def _generate_result(self, asset):
+        # routine to call the command-line executable and generate quality
+        # scores in the log file.
+
+        quality_width, quality_height = asset.quality_width_height
+        encode_width, encode_height = asset.dis_encode_width_height
+        encode_bitdepth = asset.dis_encode_bitdepth
 
         additional_params = {'enc_bitdepth': encode_bitdepth}
         if encode_width != quality_width or encode_height != quality_height:

--- a/python/vmaf/core/cambi_quality_runner.py
+++ b/python/vmaf/core/cambi_quality_runner.py
@@ -6,9 +6,8 @@ from vmaf.tools.decorator import override
 
 
 class CambiQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
-
     TYPE = 'Cambi'
-    VERSION = 'F' + CambiFeatureExtractor.VERSION
+    VERSION = 'F' + CambiFeatureExtractor.VERSION  # Supporting scaled encodes and minor change to the spatial mask
 
     @override(QualityRunnerFromFeatureExtractor)
     def _get_feature_extractor_class(self):
@@ -20,9 +19,8 @@ class CambiQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
 
 
 class CambiFullReferenceQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
-
     TYPE = 'Cambi_FR'
-    VERSION = 'F' + CambiFeatureExtractor.VERSION
+    VERSION = 'F' + CambiFullReferenceFeatureExtractor.VERSION  # Supporting scaled encodes and minor change to the spatial mask
 
     @override(QualityRunnerFromFeatureExtractor)
     def _get_feature_extractor_class(self):


### PR DESCRIPTION
CambiFeatureExtractor changes (v0.5 → v0.8):
- v0.6: include feature options as part of feature name
- v0.7: add visibility luminance threshold support
- v0.8: avoid upscaling when encoding resolution is larger than input resolution
- Add bitdepth validation guard for notyuv high-bitdepth encodes to prevent silent 8-bit downconversion producing inaccurate CAMBI scores
- Explicit VERSION on CambiFullReferenceFeatureExtractor

CambiFullReferenceQualityRunner: fix VERSION to use CambiFullReferenceFeatureExtractor.VERSION

Tests: add coverage for topk, eotf, notyuv bitdepth scenarios, 4K/1080p encodes, visibility luminance threshold, and high-res speedup options