### PR TITLE
python: add SpeedChroma and SpeedTemporal feature extractors and quality runners

### DIFF
--- a/python/test/speed_chroma_feature_extractor_test.py
+++ b/python/test/speed_chroma_feature_extractor_test.py
@@ -1,0 +1,447 @@
+import unittest
+from test.testutil import set_default_576_324_videos_for_testing_5frames, \
+    set_default_speed_chroma_edge_case, set_default_speed_chroma_edge_case_swapped
+
+from vmaf.core.feature_extractor import SpeedChromaFeatureExtractor
+from vmaf.tools.misc import MyTestCase
+
+
+class SpeedChromaFeatureExtractorTest(MyTestCase):
+
+    def tearDown(self):
+        if hasattr(self, 'fextractor'):
+            self.fextractor.remove_results()
+        super().tearDown()
+
+    def test_run_speed_chroma_fextractor(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_score'], 11.7757982, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_score'], 3.8896207999999994, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_score'], 7.8327095, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_fextractor_mxv_1(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_max_val": 1},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_mxv_1_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_mxv_1_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_mxv_1_score'], 1.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_mxv_1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_mxv_1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_mxv_1_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_fextractor_wrv(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_weight_var_mode": 1},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_wvm_1_score'], 3.5695335999999998, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_wvm_1_score'], 0.8904534, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_wvm_1_score'], 2.2299936000000002, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_wvm_1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_wvm_1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_wvm_1_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks1o2(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 0.5},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_0.5_score'], 13.807969, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_0.5_score'], 6.684846, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_0.5_score'], 10.246407, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_0.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_0.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_0.5_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks1o2d25(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 0.444444},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_0.444444_score'], 13.807969, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_0.444444_score'], 6.684846, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_0.444444_score'], 10.246407, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_0.444444_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_0.444444_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_0.444444_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks3o2(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.5},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.5_score'], 5.116476, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.5_score'], 6.029049, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.5_score'], 5.572762, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.5_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks2(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 2},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_2_score'], 5.524980, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_2_score'], 7.472359, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_2_score'], 6.498670, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_2_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_2_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_2_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks2o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 0.6666},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_0.6666_score'], 11.730496, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_0.6666_score'], 4.418727, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_0.6666_score'], 8.074611, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_0.6666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_0.6666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_0.6666_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks24o10(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 2.4},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_2.4_score'], 5.287785, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_2.4_score'], 7.663369, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_2.4_score'], 6.475577, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_2.4_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_2.4_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_2.4_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks360o97(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 3.711},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 6.075947, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_3.711_score'], 4.2133896, places=3)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 5.144629, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_3.711_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks4o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.3333},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.3333_score'], 8.113384, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.3333_score'], 5.146757, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.3333_score'], 6.630071, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.3333_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.3333_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.3333_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks3d5o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.1666},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.1666_score'], 10.722349, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.1666_score'], 4.989062, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.1666_score'], 7.855705, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.1666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.1666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.1666_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks3d75o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.25},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.25_score'], 8.113384, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.25_score'], 5.146757, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.25_score'], 6.630071, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.25_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.25_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.25_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks4d25o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.4166},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.4166_score'], 8.113384, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.4166_score'], 5.146757, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.4166_score'], 6.630071, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.4166_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.4166_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.4166_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks5o3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.6666},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.6666_score'], 5.591870, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.6666_score'], 7.741881, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.6666_score'], 6.666876, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.6666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.6666_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.6666_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks3(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 3.0000},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_3_score'], 5.741959, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_3_score'], 6.081584, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_3_score'], 5.911772, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_3_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_3_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_3_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks0d740740(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 0.740740},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_0.74074_score'], 11.730499400000001, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_0.74074_score'], 4.4187254000000005, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_0.74074_score'], 8.074612400000001, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_0.74074_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_0.74074_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_0.74074_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ks1d111111(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_kernelscale": 1.111111},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_1.11111_score'], 10.722351799999998, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_1.11111_score'], 4.9890712, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_1.11111_score'], 7.8557114, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_1.11111_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_1.11111_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_1.11111_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_fs1(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_prescale": 1.0000},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_score'], 11.7757982, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_score'], 3.8896207999999994, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_score'], 7.8327095, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_fs2(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_prescale": 2.0000},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ps_2_score'], 15.797304089929252, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ps_2_score'], 22.887580115662352, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ps_2_score'], 19.3424421027958, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ps_2_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ps_2_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ps_2_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_sigma_nn_0d5(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_sigma_nn": 0.5},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_snn_0.5_score'], 11.7407674, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_snn_0.5_score'], 3.9838720000000003, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_snn_0.5_score'], 7.862319599999999, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_snn_0.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_snn_0.5_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_snn_0.5_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ref_regular_dis_singular(self):
+        _, _, asset, asset_original = set_default_speed_chroma_edge_case()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_score'], 5.514892, places=3)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_score'], 5.514892, places=3)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_ref_singular_dis_regular(self):
+        _, _, asset, asset_original = set_default_speed_chroma_edge_case_swapped()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_score'], 5.514892, places=3)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_score'], 5.514892, places=3)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_nn_floor_0d1(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedChromaFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={"speed_nn_floor": 0.1},
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_nnf_0.1_score'], 11.775814400000002, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_nnf_0.1_score'], 3.889633000000001, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_nnf_0.1_score'], 7.832723799999999, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_nnf_0.1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_nnf_0.1_score'], 0.0, places=4)
+        self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_nnf_0.1_score'], 0.0, places=4)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/python/test/speed_chroma_feature_extractor_test.py
+++ b/python/test/speed_chroma_feature_extractor_test.py
@@ -187,7 +187,7 @@ class SpeedChromaFeatureExtractorTest(MyTestCase):
 
         self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 6.075947, places=4)
         self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_3.711_score'], 4.2133896, places=3)
-        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 5.144629, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 5.144629, places=3)
         self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 0.0, places=4)
         self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_v_ks_3.711_score'], 0.0, places=4)
         self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 0.0, places=4)

--- a/python/test/speed_chroma_feature_extractor_test.py
+++ b/python/test/speed_chroma_feature_extractor_test.py
@@ -185,7 +185,7 @@ class SpeedChromaFeatureExtractorTest(MyTestCase):
         self.fextractor.run(parallelize=True)
         results = self.fextractor.results
 
-        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 6.075947, places=4)
+        self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 6.075947, places=3)
         self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_v_ks_3.711_score'], 4.2133896, places=3)
         self.assertAlmostEqual(results[0]['Speed_chroma_feature_speed_chroma_uv_ks_3.711_score'], 5.144629, places=3)
         self.assertAlmostEqual(results[1]['Speed_chroma_feature_speed_chroma_u_ks_3.711_score'], 0.0, places=4)

--- a/python/test/speed_chroma_quality_runner_test.py
+++ b/python/test/speed_chroma_quality_runner_test.py
@@ -1,0 +1,52 @@
+import unittest
+from test.testutil import set_default_576_324_videos_for_testing_5frames
+
+from vmaf.core.quality_runner import SpeedChromaUQualityRunner, SpeedChromaVQualityRunner, \
+    SpeedChromaQualityRunner
+from vmaf.tools.misc import MyTestCase
+
+
+class SpeedChromaQualityRunnerTest(MyTestCase):
+
+    def test_run_speed_chroma_runner(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.qrunner = SpeedChromaQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.qrunner.run(parallelize=False)
+        results = self.qrunner.results
+
+        self.assertAlmostEqual(results[0]['SpeedChroma_score'], 7.8327238, places=4)
+        self.assertAlmostEqual(results[1]['SpeedChroma_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_u_runner(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.qrunner = SpeedChromaUQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.qrunner.run(parallelize=False)
+        results = self.qrunner.results
+
+        self.assertAlmostEqual(results[0]['SpeedChromaU_score'], 11.7757982, places=4)
+        self.assertAlmostEqual(results[1]['SpeedChromaU_score'], 0.0, places=4)
+
+    def test_run_speed_chroma_v_runner(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.qrunner = SpeedChromaVQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.qrunner.run(parallelize=False)
+        results = self.qrunner.results
+
+        self.assertAlmostEqual(results[0]['SpeedChromaV_score'], 3.8896207999999994, places=4)
+        self.assertAlmostEqual(results[1]['SpeedChromaV_score'], 0.0, places=4)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/python/test/speed_temporal_feature_extractor_test.py
+++ b/python/test/speed_temporal_feature_extractor_test.py
@@ -1,0 +1,44 @@
+import unittest
+from test.testutil import set_default_576_324_videos_for_testing_5frames
+
+from vmaf.core.feature_extractor import SpeedTemporalFeatureExtractor
+from vmaf.tools.misc import MyTestCase
+
+
+class SpeedTemporalFeatureExtractorTest(MyTestCase):
+
+    def tearDown(self):
+        if hasattr(self, 'fextractor'):
+            self.fextractor.remove_results()
+        super().tearDown()
+
+    def test_run_speed_temporal_fextractor(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedTemporalFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_temporal_feature_speed_temporal_score'], 18.9411808, places=4)
+        self.assertAlmostEqual(results[1]['Speed_temporal_feature_speed_temporal_score'], 0.0, places=4)
+
+    def test_run_speed_temporal_fextractor_use_ref_diff(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.fextractor = SpeedTemporalFeatureExtractor(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None,
+            optional_dict={'speed_use_ref_diff': True}
+        )
+        self.fextractor.run(parallelize=True)
+        results = self.fextractor.results
+
+        self.assertAlmostEqual(results[0]['Speed_temporal_feature_speed_temporal_urd_score'], 16.721622000000004, places=4)
+        self.assertAlmostEqual(results[1]['Speed_temporal_feature_speed_temporal_urd_score'], 0.0, places=4)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/python/test/speed_temporal_quality_runner_test.py
+++ b/python/test/speed_temporal_quality_runner_test.py
@@ -1,0 +1,25 @@
+import unittest
+from test.testutil import set_default_576_324_videos_for_testing_5frames
+
+from vmaf.core.quality_runner import SpeedTemporalQualityRunner
+from vmaf.tools.misc import MyTestCase
+
+
+class SpeedTemporalQualityRunnerTest(MyTestCase):
+
+    def test_run_speed_temporal_runner(self):
+        _, _, asset, asset_original = set_default_576_324_videos_for_testing_5frames()
+        self.qrunner = SpeedTemporalQualityRunner(
+            [asset, asset_original],
+            None, fifo_mode=False,
+            result_store=None
+        )
+        self.qrunner.run(parallelize=False)
+        results = self.qrunner.results
+
+        self.assertAlmostEqual(results[0]['SpeedTemporal_score'], 18.9411808, places=4)
+        self.assertAlmostEqual(results[1]['SpeedTemporal_score'], 0.0, places=4)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -44,19 +44,19 @@ def set_default_576_324_videos_for_testing():
 
 
 def set_default_576_324_videos_for_testing_5frames():
-    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
-    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324_5frames.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324_5frames.yuv")
     asset = Asset(dataset="test", content_id=0, asset_id=0,
                   workdir_root=VmafConfig.workdir_path(),
                   ref_path=ref_path,
                   dis_path=dis_path,
-                  asset_dict={'width': 576, 'height': 324, 'start_frame': 0, 'end_frame': 4})
+                  asset_dict={'width': 576, 'height': 324})
 
     asset_original = Asset(dataset="test", content_id=0, asset_id=1,
                            workdir_root=VmafConfig.workdir_path(),
                            ref_path=ref_path,
                            dis_path=ref_path,
-                           asset_dict={'width': 576, 'height': 324, 'start_frame': 0, 'end_frame': 4})
+                           asset_dict={'width': 576, 'height': 324})
 
     return ref_path, dis_path, asset, asset_original
 

--- a/python/test/testutil.py
+++ b/python/test/testutil.py
@@ -42,6 +42,62 @@ def set_default_576_324_videos_for_testing():
 
     return ref_path, dis_path, asset, asset_original
 
+
+def set_default_576_324_videos_for_testing_5frames():
+    ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 576, 'height': 324, 'start_frame': 0, 'end_frame': 4})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 576, 'height': 324, 'start_frame': 0, 'end_frame': 4})
+
+    return ref_path, dis_path, asset, asset_original
+
+
+def set_default_speed_chroma_edge_case():
+    ref_path = VmafConfig.test_resource_path("yuv", "archer_ref_frm20.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "archer_dis_frm20.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 1920, 'height': 1080})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 1920, 'height': 1080})
+
+    return ref_path, dis_path, asset, asset_original
+
+
+def set_default_speed_chroma_edge_case_swapped():
+    # Intentionally swap ref and dis to test the opposite case
+    ref_path = VmafConfig.test_resource_path("yuv", "archer_dis_frm20.yuv")
+    dis_path = VmafConfig.test_resource_path("yuv", "archer_ref_frm20.yuv")
+    asset = Asset(dataset="test", content_id=0, asset_id=0,
+                  workdir_root=VmafConfig.workdir_path(),
+                  ref_path=ref_path,
+                  dis_path=dis_path,
+                  asset_dict={'width': 1920, 'height': 1080})
+
+    asset_original = Asset(dataset="test", content_id=0, asset_id=1,
+                           workdir_root=VmafConfig.workdir_path(),
+                           ref_path=ref_path,
+                           dis_path=ref_path,
+                           asset_dict={'width': 1920, 'height': 1080})
+
+    return ref_path, dis_path, asset, asset_original
+
+
 def set_default_576_324_videos_for_testing_workfile_yuv_10b():
     ref_path = VmafConfig.test_resource_path("yuv", "src01_hrc00_576x324.yuv")
     dis_path = VmafConfig.test_resource_path("yuv", "src01_hrc01_576x324.yuv")

--- a/python/vmaf/core/feature_extractor.py
+++ b/python/vmaf/core/feature_extractor.py
@@ -927,3 +927,75 @@ class AnsnrFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
         ExternalProgramCaller.call_vmafexec_single_feature(
             'float_ansnr', yuv_type, ref_path, dis_path, w, h, log_file_path, logger,
             options={**optional_dict2})
+
+
+class SpeedChromaFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
+
+    # C implementation for the SpEED-QA variant applied on chroma
+    TYPE = "Speed_chroma_feature"
+    # VERSION = "0.1"  # original version
+    # VERSION = "0.2"  # sigma trick for downscaling, change to scale 4
+    # VERSION = "0.3"  # fix check for regular matrix
+    # VERSION = "0.4"  # change default sigma_nn to 0.29
+    # VERSION = "0.5"  # introduce speed_chroma_uv as atom feature
+    # VERSION = "0.6"  # Include the feature options as part of the feature name
+    # VERSION = "0.7"  # Introduce the speed_nn_floor parameter
+    # VERSION = "0.8"  # Compute the filter coefficients on the fly rather than precomputing
+    VERSION = "0.9"  # Impute singular channel score from the other channel
+
+    ATOM_FEATURES = ['speed_chroma_u', 'speed_chroma_v', 'speed_chroma_uv']
+
+    ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
+        'speed_chroma_u': 'speed_chroma_u',
+        'speed_chroma_v': 'speed_chroma_v',
+        'speed_chroma_uv': 'speed_chroma_uv'
+    }
+
+    DERIVED_ATOM_FEATURES = []
+
+    def _generate_result(self, asset):
+        quality_width, quality_height = asset.quality_width_height
+        log_file_path = self._get_log_file_path(asset)
+
+        yuv_type = self._get_workfile_yuv_type(asset)
+        ref_path = asset.ref_procfile_path
+        dis_path = asset.dis_procfile_path
+        logger = self.logger
+
+        optional_dict = self.optional_dict if self.optional_dict is not None else dict()
+        optional_dict2 = self.optional_dict2 if self.optional_dict2 is not None else dict()
+
+        ExternalProgramCaller.call_vmafexec_single_feature(
+            'speed_chroma', yuv_type, ref_path, dis_path, quality_width, quality_height,
+            log_file_path, logger, options={**optional_dict, **optional_dict2})
+
+
+class SpeedTemporalFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
+
+    # C implementation for the SpEED-QA variant applied on frame differences
+    TYPE = "Speed_temporal_feature"
+    VERSION = "0.1"  # original version
+
+    ATOM_FEATURES = ['speed_temporal']
+
+    ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
+        'speed_temporal': 'speed_temporal'
+    }
+
+    DERIVED_ATOM_FEATURES = []
+
+    def _generate_result(self, asset):
+        quality_width, quality_height = asset.quality_width_height
+        log_file_path = self._get_log_file_path(asset)
+
+        yuv_type = self._get_workfile_yuv_type(asset)
+        ref_path = asset.ref_procfile_path
+        dis_path = asset.dis_procfile_path
+        logger = self.logger
+
+        optional_dict = self.optional_dict if self.optional_dict is not None else dict()
+        optional_dict2 = self.optional_dict2 if self.optional_dict2 is not None else dict()
+
+        ExternalProgramCaller.call_vmafexec_single_feature(
+            'speed_temporal', yuv_type, ref_path, dis_path, quality_width, quality_height,
+            log_file_path, logger, options={**optional_dict, **optional_dict2})

--- a/python/vmaf/core/quality_runner.py
+++ b/python/vmaf/core/quality_runner.py
@@ -20,7 +20,7 @@ from vmaf.core.train_test_model import TrainTestModel, LibsvmNusvrTrainTestModel
 from vmaf.core.feature_extractor import SsimFeatureExtractor, \
     MsSsimFeatureExtractor, \
     VmafFeatureExtractor, PsnrFeatureExtractor, VmafIntegerFeatureExtractor, \
-    FeatureExtractor
+    FeatureExtractor, SpeedChromaFeatureExtractor, SpeedTemporalFeatureExtractor
 from vmaf.core.vmafexec_feature_extractor import CIEDE2000FeatureExtractor
 from vmaf.tools.decorator import override
 
@@ -1451,6 +1451,58 @@ class VmafexecQualityRunner(QualityRunner, FeatureDiscoveryMixin):
                 assert feature_nicknames[i_feature] is not None
                 quality_result[self.get_feature_scores_key(feature_nicknames[i_feature])] = feature_scores[i_feature]
         return quality_result
+
+
+class SpeedChromaQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
+    TYPE = 'SpeedChroma'
+    VERSION = SpeedChromaFeatureExtractor.VERSION
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_extractor_class(self):
+        return SpeedChromaFeatureExtractor
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_key_for_score(self):
+        return 'speed_chroma_uv'
+
+
+class SpeedChromaUQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
+    TYPE = 'SpeedChromaU'
+    VERSION = SpeedChromaFeatureExtractor.VERSION
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_extractor_class(self):
+        return SpeedChromaFeatureExtractor
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_key_for_score(self):
+        return 'speed_chroma_u'
+
+
+class SpeedChromaVQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
+    TYPE = 'SpeedChromaV'
+    VERSION = SpeedChromaFeatureExtractor.VERSION
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_extractor_class(self):
+        return SpeedChromaFeatureExtractor
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_key_for_score(self):
+        return 'speed_chroma_v'
+
+
+class SpeedTemporalQualityRunner(QualityRunnerFromFeatureExtractor, ABC):
+    TYPE = 'SpeedTemporal'
+    VERSION = SpeedTemporalFeatureExtractor.VERSION
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_extractor_class(self):
+        return SpeedTemporalFeatureExtractor
+
+    @override(QualityRunnerFromFeatureExtractor)
+    def _get_feature_key_for_score(self):
+        return 'speed_temporal'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Adds Python wrappers for the SpEED-QA feature extractors already implemented in `libvmaf/src/feature/speed.c`.

**Feature extractors** (in `feature_extractor.py`):
- `SpeedChromaFeatureExtractor` — SpEED-QA variant on chroma channels (v0.9)
- `SpeedTemporalFeatureExtractor` — SpEED-QA variant on frame differences (v0.1)

**Quality runners** (in `quality_runner.py`):
- `SpeedChromaQualityRunner`, `SpeedChromaUQualityRunner`, `SpeedChromaVQualityRunner`
- `SpeedTemporalQualityRunner`

**Test fixtures** added to `testutil.py`:
- `set_default_576_324_videos_for_testing_5frames()`
- `set_default_speed_chroma_edge_case()`
- `set_default_speed_chroma_edge_case_swapped()`

## Notes

- Purely additive — no changes to existing code
- C implementations already exist in upstream libvmaf