### PR TITLE
libvmaf/tools: add USE_DIRECT_READ, eliminate intermediate buffer and memcpy

### DIFF
--- a/libvmaf/tools/vidinput.c
+++ b/libvmaf/tools/vidinput.c
@@ -67,6 +67,10 @@ int video_input_fetch_frame(video_input *_vid,
   return (*_vid->vtbl->fetch_frame)(_vid->ctx,_vid->fin,_ycbcr,_tag);
 }
 
+int video_input_fetch_into_vmaf_picture(video_input *_vid, VmafPicture *pic) {
+  return (*_vid->vtbl->fetch_into_vmaf_picture)(_vid->ctx, _vid->fin, pic);
+}
+
 void video_input_close(video_input *_vid) {
   (*_vid->vtbl->close)(_vid->ctx);
   free(_vid->ctx);

--- a/libvmaf/tools/vidinput.h
+++ b/libvmaf/tools/vidinput.h
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 # endif
 # include <stdio.h>
 # include <stdint.h>
+# include "libvmaf/picture.h"
 
 # if defined(__cplusplus)
 extern "C" {
@@ -61,6 +62,9 @@ typedef void* (*raw_input_open_func)(FILE *_fin,
                                      int pix_fmt,
                                      unsigned bitdepth);
 
+typedef int (*video_input_fetch_into_vmaf_picture_func)(void *_ctx, FILE *_fin,
+                                                   VmafPicture *pic);
+
 /**Pluggable method table for accessing different formats.*/
 struct video_input_vtbl {
   raw_input_open_func           open_raw;
@@ -68,6 +72,7 @@ struct video_input_vtbl {
   video_input_get_info_func     get_info;
   video_input_fetch_frame_func  fetch_frame;
   video_input_close_func        close;
+  video_input_fetch_into_vmaf_picture_func fetch_into_vmaf_picture;
 };
 
 struct video_input {
@@ -86,6 +91,7 @@ void video_input_close(video_input *_vid);
 void video_input_get_info(video_input *_vid, video_input_info *_ti);
 int video_input_fetch_frame(video_input *_vid, video_input_ycbcr _ycbcr,
                             char _tag[5]);
+int video_input_fetch_into_vmaf_picture(video_input *_vid, VmafPicture *pic);
 
 typedef enum {
   /** Chroma decimation by 2 in both the X and Y directions (4:2:0).

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -146,25 +146,22 @@ static void copy_picture_data(VmafPicture *pic, video_input_ycbcr ycbcr,
     }
 }
 
-static int fetch_picture(VmafContext *vmaf, video_input *vid, VmafPicture *pic, int depth)
+static int fetch_picture(VmafContext *vmaf, video_input *vid, VmafPicture *pic,
+                         int depth)
 {
     int ret;
-    video_input_ycbcr ycbcr;
     video_input_info info;
-
-    ret = video_input_fetch_frame(vid, ycbcr, NULL);
-    if (ret < 1) return !ret;
-
     video_input_get_info(vid, &info);
 
 #ifdef VMAF_PICTURE_POOL
+    (void) depth;
     ret = vmaf_fetch_preallocated_picture(vmaf, pic);
     if (ret) {
         fprintf(stderr, "problem fetching picture from pool.\n");
         return -1;
     }
 #else
-    (void) vmaf;  // Unused when pool is disabled
+    (void) vmaf;
     ret = vmaf_picture_alloc(pic, pix_fmt_map(info.pixel_fmt), depth,
                              info.pic_w, info.pic_h);
     if (ret) {
@@ -173,7 +170,15 @@ static int fetch_picture(VmafContext *vmaf, video_input *vid, VmafPicture *pic, 
     }
 #endif
 
-    copy_picture_data(pic, ycbcr, &info, depth);
+#ifdef USE_DIRECT_READ
+    ret = video_input_fetch_into_vmaf_picture(vid, pic);
+    if (ret < 1) return !ret;
+#else
+    video_input_ycbcr ycbcr;
+    ret = video_input_fetch_frame(vid, ycbcr, NULL);
+    if (ret < 1) return !ret;
+    copy_picture_data(pic, ycbcr, &info, info.depth);
+#endif
     return 0;
 }
 
@@ -286,7 +291,7 @@ int main(int argc, char *argv[])
             .bpc = common_bitdepth,
             .pix_fmt = pix_fmt_map(info.pixel_fmt),
         },
-        .pic_cnt = c.thread_cnt > 0 ? (c.thread_cnt + 1) * 2 : 2,
+        .pic_cnt = c.thread_cnt > 0 ? (c.thread_cnt + 1) * 2 : 3,
     };
 
     err = vmaf_preallocate_pictures(vmaf, pic_cfg);

--- a/libvmaf/tools/y4m_input.c
+++ b/libvmaf/tools/y4m_input.c
@@ -25,6 +25,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 #include "vidinput.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 typedef struct y4m_input y4m_input;
 
@@ -829,10 +830,59 @@ static void y4m_input_close(y4m_input *_y4m){
   free(_y4m->aux_buf);
 }
 
+static int y4m_fetch_into_vmaf_picture(y4m_input *_y4m, FILE *_fin, VmafPicture *pic) {
+  if (_y4m->convert != y4m_convert_null) {
+    fprintf(stderr, "y4m format requires conversion; direct read not supported.\n");
+    return -1;
+  }
+
+  /* Read and skip the frame header. */
+  char frame[6];
+  int ret = fread(frame, 1, 6, _fin);
+  if (ret < 6) return 0;
+  if (memcmp(frame, "FRAME", 5)) {
+    fprintf(stderr, "Loss of framing in YUV input data\n");
+    return -1;
+  }
+  if (frame[5] != '\n') {
+    char c;
+    int j;
+    for (j = 0; j < 79 && fread(&c, 1, 1, _fin) && c != '\n'; j++);
+    if (j == 79) {
+      fprintf(stderr, "Error parsing YUV frame header\n");
+      return -1;
+    }
+  }
+
+  size_t bytes_per_sample = (pic->bpc + 7) / 8;
+
+  for (unsigned i = 0; i < 3; i++) {
+    size_t row_bytes = (size_t)pic->w[i] * bytes_per_sample;
+    if (pic->stride[i] == (ptrdiff_t)row_bytes) {
+      if (fread(pic->data[i], 1, row_bytes * pic->h[i], _fin) != row_bytes * pic->h[i]) {
+        fprintf(stderr, "Error reading YUV frame data.\n");
+        return -1;
+      }
+    } else {
+      uint8_t *dst = pic->data[i];
+      for (unsigned j = 0; j < pic->h[i]; j++) {
+        if (fread(dst, 1, row_bytes, _fin) != row_bytes) {
+          fprintf(stderr, "Error reading YUV frame data.\n");
+          return -1;
+        }
+        dst += pic->stride[i];
+      }
+    }
+  }
+
+  return 1;
+}
+
 OC_EXTERN const video_input_vtbl Y4M_INPUT_VTBL={
   (raw_input_open_func)NULL,
   (video_input_open_func)y4m_input_open,
   (video_input_get_info_func)y4m_input_get_info,
   (video_input_fetch_frame_func)y4m_input_fetch_frame,
-  (video_input_close_func)y4m_input_close
+  (video_input_close_func)y4m_input_close,
+  (video_input_fetch_into_vmaf_picture_func)y4m_fetch_into_vmaf_picture
 };

--- a/libvmaf/tools/yuv_input.c
+++ b/libvmaf/tools/yuv_input.c
@@ -140,10 +140,42 @@ static void yuv_input_close(yuv_input *_yuv){
   free(_yuv->dst_buf);
 }
 
+static int yuv_fetch_into_vmaf_picture(yuv_input *yuv, FILE *fin, VmafPicture *pic) {
+  (void) yuv;
+  size_t bytes_per_sample = (pic->bpc + 7) / 8;
+
+  for (unsigned i = 0; i < 3; i++) {
+    size_t row_bytes = (size_t)pic->w[i] * bytes_per_sample;
+    if (pic->stride[i] == (ptrdiff_t)row_bytes) {
+      size_t total = row_bytes * pic->h[i];
+      size_t bytes_read = fread(pic->data[i], 1, total, fin);
+      if (bytes_read == 0 && i == 0) return 0;
+      if (bytes_read != total) {
+        fprintf(stderr, "Error reading YUV frame data.\n");
+        return -1;
+      }
+    } else {
+      uint8_t *dst = pic->data[i];
+      for (unsigned j = 0; j < pic->h[i]; j++) {
+        size_t bytes_read = fread(dst, 1, row_bytes, fin);
+        if (bytes_read == 0 && i == 0 && j == 0) return 0;
+        if (bytes_read != row_bytes) {
+          fprintf(stderr, "Error reading YUV frame data.\n");
+          return -1;
+        }
+        dst += pic->stride[i];
+      }
+    }
+  }
+
+  return 1;
+}
+
 OC_EXTERN const video_input_vtbl YUV_INPUT_VTBL={
   (raw_input_open_func)yuv_input_open,
   (video_input_open_func)NULL,
   (video_input_get_info_func)yuv_input_get_info,
   (video_input_fetch_frame_func)yuv_input_fetch_frame,
-  (video_input_close_func)yuv_input_close
+  (video_input_close_func)yuv_input_close,
+  (video_input_fetch_into_vmaf_picture_func)yuv_fetch_into_vmaf_picture
 };


### PR DESCRIPTION
Avoids the y4m reader memcpy into VmafPicture. Quite the improvement for 4k, 10-bit, high thread count. These benchmarks were run with VMAF_BATCH_THREADING and VMAF_PICTURE_POOL enabled (#1482).

<img width="1350" height="750" alt="throughput" src="https://github.com/user-attachments/assets/de0ce01c-a97e-4d5a-af34-147d7bc6f818" />
<img width="1350" height="750" alt="memory" src="https://github.com/user-attachments/assets/c566a3f1-8c71-4808-ac35-50ebfddbf081" />
