### PR TITLE
python: add fps filter support in Asset and enc params to call_vmafexec

### DIFF
--- a/python/vmaf/__init__.py
+++ b/python/vmaf/__init__.py
@@ -214,7 +214,8 @@ class ExternalProgramCaller(object):
     def call_vmafexec(reference, distorted, width, height, pixel_format, bitdepth,
                     float_psnr, psnr, float_ssim, ssim, float_ms_ssim, ms_ssim, float_moment,
                     no_prediction, models, subsample, n_threads, disable_avx, output, exe, logger,
-                    vif_enhn_gain_limit=None, adm_enhn_gain_limit=None, motion_force_zero=False):
+                    vif_enhn_gain_limit=None, adm_enhn_gain_limit=None, motion_force_zero=False,
+                    enc_width=None, enc_height=None, enc_bitdepth=None):
 
         if exe is None:
             exe = required(ExternalProgram.vmafexec)
@@ -267,6 +268,12 @@ class ExternalProgramCaller(object):
                     assert isinstance(motion_force_zero, bool)
                     motion_force_zero = str(motion_force_zero).lower()
                     vmafexec_cmd += f':motion.motion_force_zero={motion_force_zero}:float_motion.motion_force_zero={motion_force_zero}'
+                if enc_width is not None:
+                    vmafexec_cmd += f':cambi.enc_width={enc_width}'
+                if enc_height is not None:
+                    vmafexec_cmd += f':cambi.enc_height={enc_height}'
+                if enc_bitdepth is not None:
+                    vmafexec_cmd += f':cambi.enc_bitdepth={enc_bitdepth}'
 
         assert isinstance(subsample, int) and subsample >= 1
         if subsample != 1:

--- a/python/vmaf/core/asset.py
+++ b/python/vmaf/core/asset.py
@@ -46,7 +46,7 @@ class Asset(WorkdirEnabled):
     SUPPORTED_RESAMPLING_TYPES = ['bilinear', 'bicubic', 'lanczos']
     DEFAULT_RESAMPLING_TYPE = 'bicubic'
 
-    ORDERED_FILTER_LIST = ['crop', 'pad', 'gblur', 'eq', 'lutyuv', 'yadif']
+    ORDERED_FILTER_LIST = ['crop', 'pad', 'gblur', 'eq', 'lutyuv', 'yadif', 'format', 'fps', 'select']
 
     # ==== constructor ====
 
@@ -837,12 +837,24 @@ class Asset(WorkdirEnabled):
         return self.get_filter_cmd('pad', None)
 
     @property
+    def fps_cmd(self):
+        return self.get_filter_cmd('fps', None)
+
+    @property
     def ref_pad_cmd(self):
         return self.get_filter_cmd('pad', 'ref')
 
     @property
     def dis_pad_cmd(self):
         return self.get_filter_cmd('pad', 'dis')
+
+    @property
+    def ref_fps_cmd(self):
+        return self.get_filter_cmd('fps', 'ref')
+
+    @property
+    def dis_fps_cmd(self):
+        return self.get_filter_cmd('fps', 'dis')
 
     def get_filter_cmd(self, key, target=None):
         assert key in self.ORDERED_FILTER_LIST, 'key {key} is not in SUPPORTED_FILTER_TYPES'.format(key=key)


### PR DESCRIPTION
## Summary

- Add `'format'`, `'fps'`, `'select'` to `Asset.ORDERED_FILTER_LIST`
- Add `fps_cmd`, `ref_fps_cmd`, `dis_fps_cmd` properties to `Asset`
- Add optional `enc_width`, `enc_height`, `enc_bitdepth` keyword args to `call_vmafexec` for passing CAMBI encode dimensions alongside a model run

All changes are backwards-compatible (new optional kwargs default to `None`, new properties are purely additive).

## Test plan
- [ ] Existing asset tests pass (`test/asset_test.py` — 41 tests)