### PR TITLE
python: bump VmafFeatureExtractor to v0.2.21, add aim/adm3/motion3 atom features

### DIFF
--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -8,8 +8,8 @@ from vmaf.core.feature_extractor import VmafFeatureExtractor, \
     MomentFeatureExtractor, \
     PsnrFeatureExtractor, SsimFeatureExtractor, MsSsimFeatureExtractor, \
     VifFrameDifferenceFeatureExtractor, \
-    AnsnrFeatureExtractor, PypsnrFeatureExtractor, VmafIntegerFeatureExtractor, \
-    PypsnrMaxdb100FeatureExtractor
+    AnsnrFeatureExtractor, PyPsnrFeatureExtractor, VmafIntegerFeatureExtractor, \
+    PyPsnrMaxdb100FeatureExtractor, PypsnrFeatureExtractor
 from vmaf.core.asset import Asset
 from vmaf.tools.misc import MyTestCase
 
@@ -704,7 +704,7 @@ class FeatureExtractorTest(MyTestCase):
 
         ref_path, dis_path, asset, asset_original = set_default_576_324_16bit_videos_for_testing()
 
-        self.fextractor = PypsnrMaxdb100FeatureExtractor(
+        self.fextractor = PyPsnrMaxdb100FeatureExtractor(
             [asset, asset_original],
             None, fifo_mode=True,
             result_store=None,

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -15,16 +15,14 @@ from vmaf.tools.misc import MyTestCase
 
 from test.testutil import set_default_576_324_videos_for_testing, set_default_flat_1920_1080_videos_for_testing, \
     set_default_576_324_10bit_videos_for_testing, set_default_576_324_12bit_videos_for_testing, \
-    set_default_576_324_16bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b
+    set_default_576_324_16bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b, \
+    set_default_cambi_video_for_testing_b
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
 
 class FeatureExtractorTest(MyTestCase):
-
-    def setUp(self) -> None:
-        super().setUp()
 
     def tearDown(self):
         if hasattr(self, 'fextractor'):

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -36,7 +36,7 @@ class FeatureExtractorTest(MyTestCase):
                       ref_path="dir/refvideo.yuv", dis_path="dir/disvideo.yuv",
                       asset_dict={'width': 720, 'height': 480})
         fextractor = VmafFeatureExtractor([asset], None)
-        self.assertEqual(fextractor.executor_id, "VMAF_feature_V0.2.7")
+        self.assertEqual(fextractor.executor_id, "VMAF_feature_V0.2.21")
 
     def test_executor_id_long_opt_dict(self):
         asset = Asset(dataset="test", content_id=0, asset_id=1,
@@ -44,7 +44,7 @@ class FeatureExtractorTest(MyTestCase):
                       asset_dict={'width': 720, 'height': 480})
         fextractor = VmafFeatureExtractor([asset], None,
                                           optional_dict={"some_parameter": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-        self.assertEqual("VMAF_feature_V0.2.7_ab1db6ba9be857303e99cbb0ef38fc4753ef1040", fextractor.executor_id)
+        self.assertEqual("VMAF_feature_V0.2.21_ab1db6ba9be857303e99cbb0ef38fc4753ef1040", fextractor.executor_id)
 
     def test_get_log_file_path(self):
         import hashlib
@@ -57,7 +57,7 @@ class FeatureExtractorTest(MyTestCase):
         fextractor = VmafFeatureExtractor([asset], None)
         log_file_path = fextractor._get_log_file_path(asset)
         h = hashlib.sha1("test_0_1_refvideo_720x480_vs_disvideo_720x480_q_720x480".encode("utf-8")).hexdigest()
-        self.assertTrue(re.match(r"^my_workdir_root/[a-zA-Z0-9-]+/VMAF_feature_V0.2.7_{}$".format(h), log_file_path))
+        self.assertTrue(re.match(r"^my_workdir_root/[a-zA-Z0-9-]+/VMAF_feature_V0.2.21_{}$".format(h), log_file_path))
 
     def test_run_vmaf_fextractor(self):
 
@@ -72,41 +72,51 @@ class FeatureExtractorTest(MyTestCase):
 
         results = self.fextractor.results
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.4460930625, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.04982535417, places=2)
-        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44641939583333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0488208125, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_scores'][0], 0.0, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_scores'][1], 4.214337, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_scores'][2], 4.071614, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_scores'][3], 3.825699, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion2_score'], 3.894366229166667, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion3_scores'][0], 4.57945, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion3_scores'][1], 4.214337, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion3_scores'][2], 4.071614, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion3_scores'][3], 3.825699, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion3_score'], 3.9897714375, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_score'], 0.9345148541666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_aim_score'], 0.026559020833333336, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm2_score'], 0.9345148541666667, places=4) # at version 0.2.4b (ioannis adm fix), adm and adm2 are now identical
         self.assertAlmostEqual(results[0]['VMAF_feature_ansnr_score'], 23.5095715208, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_num_score'], 712650.023478, places=-3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_den_score'], 1597314.95249, places=-3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_adm_num_score'], 371.80645372916666, places=3)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_num_score'], 713112.1822103333, places=0)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_den_score'], 1597172.416483604, places=0)
+        self.assertAlmostEqual(results[0]['VMAF_feature_adm_num_score'], 371.80645372916666, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_den_score'], 397.83378972916671, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_anpsnr_score'], 34.164776875, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale0_score'], 0.363420489439, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale1_score'], 0.766647542135, places=2)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale2_score'], 0.862854666902, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale3_score'], 0.915971778036, places=3)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale0_score'], 0.3636595790491415, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale1_score'], 0.7674891489570371, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale2_score'], 0.8630881475272494, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale3_score'], 0.9156988075602461, places=4)
 
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_scale0_score'], 0.90791933424090698, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_scale1_score'], 0.8938705209242691, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_scale2_score'], 0.9300123587874962, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_scale3_score'], 0.9649663148179196, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif2_score'], 0.72722361912801026, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_adm3_score'], 0.9241841443734412, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif2_score'], 0.7274839207734184, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_adm3_score'], 0.9539779375, places=4)
 
         self.assertAlmostEqual(results[1]['VMAF_feature_vif_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.04982535417, places=2)
-        self.assertAlmostEqual(results[1]['VMAF_feature_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0488208125, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion2_score'], 3.894366229166667, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_ansnr_score'], 31.2714392708, places=4)
 
-        self.assertAlmostEqual(results[1]['VMAF_feature_vif_num_score'], 1597314.86733, places=-3)
-        self.assertAlmostEqual(results[1]['VMAF_feature_vif_den_score'], 1597314.95249, places=-3)
+        self.assertAlmostEqual(results[1]['VMAF_feature_vif_num_score'], 1597172.416483604, places=0)
+        self.assertAlmostEqual(results[1]['VMAF_feature_vif_den_score'], 1597172.416483604, places=0)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm_num_score'], 397.83378972916671, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm_den_score'], 397.83378972916671, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_anpsnr_score'], 41.9266444375, places=4)
@@ -138,13 +148,10 @@ class FeatureExtractorTest(MyTestCase):
 
         results = self.fextractor.results
 
-        # scale0 is reported directly from float_vif with the snsq suffix;
-        # scales 1..3 are derived in _post_process_result from num/den and
-        # land on their usual non-suffixed keys but carry the snsq=1.5 values.
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale0_snsq_1.5_score'], 0.34616335416666666, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale1_score'], 0.7433470833333334, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale2_score'], 0.8450055416666666, places=4)
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale3_score'], 0.9031788124999999, places=3)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale0_snsq_1.5_score'], 0.34616335416666666, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale1_snsq_1.5_score'], 0.7433470833333334, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale2_snsq_1.5_score'], 0.8450055416666666, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_scale3_snsq_1.5_score'], 0.9031788124999999, places=4)
 
     def test_run_vmaf_integer_fextractor(self):
 
@@ -160,9 +167,19 @@ class FeatureExtractorTest(MyTestCase):
         results = self.fextractor.results
 
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_vif_score'], 0.44642331250000006, places=4)
-        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion_score'], 4.04982535417, places=2)
-        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion_score'], 4.048813375, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_scores'][0], 0.0, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_scores'][1], 4.214324, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_scores'][2], 4.071609, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_scores'][3], 3.825691, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion2_score'], 3.8943597291666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion3_scores'][0], 4.579442, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion3_scores'][1], 4.214324, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion3_scores'][2], 4.071609, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion3_scores'][3], 3.825691, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_motion3_score'], 3.9897647708333337, places=4)
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_adm_score'], 0.9345148541666667, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_aim_score'], 0.026560104166666664, places=4)
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_adm2_score'], 0.9345148541666667, places=4) # at version 0.2.4b (ioannis adm fix), adm and adm2 are now identical
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_ansnr_score'], 23.5095715208, places=4)
 
@@ -183,11 +200,11 @@ class FeatureExtractorTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_adm_scale3_score'], 0.9649663148179196, places=4)
 
         self.assertAlmostEqual(results[0]['VMAF_integer_feature_vif2_score'], 0.72749630372849, places=4)
-        self.assertAlmostEqual(results[0]['VMAF_integer_feature_adm3_score'], 0.9241841443734412, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_integer_feature_adm3_score'], 0.9539728125, places=4)
 
         self.assertAlmostEqual(results[1]['VMAF_integer_feature_vif_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_integer_feature_motion_score'], 4.04982535417, places=2)
-        self.assertAlmostEqual(results[1]['VMAF_integer_feature_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[1]['VMAF_integer_feature_motion_score'], 4.048813375, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_integer_feature_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAF_integer_feature_adm_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_integer_feature_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_integer_feature_ansnr_score'], 31.2714392708, places=4)
@@ -713,12 +730,12 @@ class FeatureExtractorTest(MyTestCase):
 
         results = self.fextractor.results
 
-        self.assertAlmostEqual(results[0]['Pypsnr_maxdb100_feature_psnry_score'], 32.579806240311484, places=4)
-        self.assertAlmostEqual(results[0]['Pypsnr_maxdb100_feature_psnru_score'], 39.046949448281005, places=4)
-        self.assertAlmostEqual(results[0]['Pypsnr_maxdb100_feature_psnrv_score'], 41.288953934756215, places=4)
-        self.assertAlmostEqual(results[1]['Pypsnr_maxdb100_feature_psnry_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[1]['Pypsnr_maxdb100_feature_psnru_score'], 100.0, places=4)
-        self.assertAlmostEqual(results[1]['Pypsnr_maxdb100_feature_psnrv_score'], 100.0, places=4)
+        self.assertAlmostEqual(results[0]['PyPsnr_maxdb100_feature_psnry_score'], 32.579806240311484, places=4)
+        self.assertAlmostEqual(results[0]['PyPsnr_maxdb100_feature_psnru_score'], 39.046949448281005, places=4)
+        self.assertAlmostEqual(results[0]['PyPsnr_maxdb100_feature_psnrv_score'], 41.288953934756215, places=4)
+        self.assertAlmostEqual(results[1]['PyPsnr_maxdb100_feature_psnry_score'], 100.0, places=4)
+        self.assertAlmostEqual(results[1]['PyPsnr_maxdb100_feature_psnru_score'], 100.0, places=4)
+        self.assertAlmostEqual(results[1]['PyPsnr_maxdb100_feature_psnrv_score'], 100.0, places=4)
 
 
 if __name__ == '__main__':

--- a/python/test/feature_extractor_test.py
+++ b/python/test/feature_extractor_test.py
@@ -91,7 +91,7 @@ class FeatureExtractorTest(MyTestCase):
 
         self.assertAlmostEqual(results[0]['VMAF_feature_vif_num_score'], 713112.1822103333, places=0)
         self.assertAlmostEqual(results[0]['VMAF_feature_vif_den_score'], 1597172.416483604, places=0)
-        self.assertAlmostEqual(results[0]['VMAF_feature_adm_num_score'], 371.80645372916666, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_adm_num_score'], 371.80645372916666, places=3)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm_den_score'], 397.83378972916671, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_anpsnr_score'], 34.164776875, places=4)
 

--- a/python/test/quality_runner_test.py
+++ b/python/test/quality_runner_test.py
@@ -38,7 +38,7 @@ class QualityRunnerTest(MyTestCase):
                       ref_path="dir/refvideo.yuv", dis_path="dir/disvideo.yuv",
                       asset_dict={'width': 720, 'height': 480})
         runner = VmafLegacyQualityRunner([asset], None)
-        self.assertEqual(runner.executor_id, 'VMAF_legacy_VF0.2.7-1.1')
+        self.assertEqual(runner.executor_id, 'VMAF_legacy_VF0.2.21-1.1')
 
     def test_run_vmaf_legacy_runner(self):
 
@@ -1391,7 +1391,7 @@ class QualityRunnerTest(MyTestCase):
 
         self.runner = VmafQualityRunner(
             [asset, asset_original],
-            None, fifo_mode=False,
+            None, fifo_mode=True,
             delete_workdir=True,
             result_store=None,
             optional_dict={'model_filepath': VmafConfig.model_path('other_models', 'vmaf_v0.6.1mfz.json')}
@@ -1424,7 +1424,7 @@ class QualityRunnerTest(MyTestCase):
             self.assertAlmostEqual(results[1]['VMAF_integer_feature_motion_score'], 1.0, places=4)
 
         self.assertAlmostEqual(results[0]['VMAF_score'], 72.3205499536087, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_score'], 97.42843608965536, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_score'], 97.42835406898242, places=4)
 
     def test_run_vmaf_runner_neg_mode(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -1922,13 +1922,13 @@ class QualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAF_integer_feature_adm2_score'], 1.0, places=4)
 
         self.assertAlmostEqual(results[0]['VMAF_score'], 72.3205498755804, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_score'], 97.42843609144575, places=4)
+        self.assertAlmostEqual(results[1]['VMAF_score'], 97.42835406898269, places=4)
 
 
 class QualityRunnerVersionTest(unittest.TestCase):
 
     def test_vmaf_quality_runner_version(self):
-        self.assertEqual(VmafQualityRunner.VERSION, 'F0.2.7int-0.6.1')
+        self.assertEqual(VmafQualityRunner.VERSION, 'F0.2.21int-0.6.1')
         self.assertEqual(VmafQualityRunner.ALGO_VERSION, 4)
 
 

--- a/python/test/result_test.py
+++ b/python/test/result_test.py
@@ -54,19 +54,19 @@ class ResultTest(MyTestCase):
         df_ansnr = df.loc[df['scores_key'] == 'VMAF_feature_ansnr_scores']
         df_motion = df.loc[df['scores_key'] == 'VMAF_feature_motion_scores']
         df_adm_den = df.loc[df['scores_key'] == 'VMAF_feature_adm_den_scores']
-        self.assertEqual(len(df), 38)
+        self.assertEqual(len(df), 40)
         self.assertEqual(len(df_vmaf), 1)
         self.assertEqual(len(df_adm), 1)
         self.assertEqual(len(df_vif), 1)
         self.assertEqual(len(df_ansnr), 1)
         self.assertEqual(len(df_motion), 1)
-        self.assertAlmostEqual(np.mean(df_vmaf.iloc[0]['scores']), 40.421899030550769, places=3)
+        self.assertAlmostEqual(np.mean(df_vmaf.iloc[0]['scores']), 40.422179484077304, places=4)
         self.assertAlmostEqual(np.mean(df_adm.iloc[0]['scores']), 0.78533833333333336, places=4)
         self.assertAlmostEqual(np.mean(df_vif.iloc[0]['scores']), 0.156834666667, places=4)
         self.assertAlmostEqual(np.mean(df_ansnr.iloc[0]['scores']), 7.92623066667, places=4)
         self.assertAlmostEqual(np.mean(df_motion.iloc[0]['scores']), 12.5548366667, places=4)
         self.assertAlmostEqual(np.mean(df_adm_den.iloc[0]['scores']), 2773.8912249999998, places=3)
-        self.assertAlmostEqual(np.mean(Result.get_unique_from_dataframe(df, 'VMAF_legacy_scores', 'scores')), 40.421899030550769, places=3)
+        self.assertAlmostEqual(np.mean(Result.get_unique_from_dataframe(df, 'VMAF_legacy_scores', 'scores')), 40.422179484077304, places=4)
         self.assertAlmostEqual(np.mean(Result.get_unique_from_dataframe(df, 'VMAF_feature_adm_scores', 'scores')), 0.78533833333333336, places=4)
         self.assertAlmostEqual(np.mean(Result.get_unique_from_dataframe(df, 'VMAF_feature_vif_scores', 'scores')), 0.156834666667, places=4)
         self.assertAlmostEqual(np.mean(Result.get_unique_from_dataframe(df, 'VMAF_feature_ansnr_scores', 'scores')), 7.92623066667, places=4)
@@ -79,7 +79,7 @@ class ResultTest(MyTestCase):
         self.assertEqual(
             df.iloc[0]['asset'],
             '{"asset_dict": {"height": 1080, "use_path_as_workpath": 1, "use_workpath_as_procpath": 1, "width": 1920}, "asset_id": 0, "content_id": 0, "dataset": "test", "dis_path": "checkerboard_1920_1080_10_3_1_0.yuv", "ref_path": "checkerboard_1920_1080_10_3_0_0.yuv", "workdir": ""}') # noqa
-        self.assertEqual(df.iloc[0]['executor_id'], 'VMAF_legacy_VF0.2.7-1.1')
+        self.assertEqual(df.iloc[0]['executor_id'], 'VMAF_legacy_VF0.2.21-1.1')
 
         Result._assert_asset_dataframe(df)
 

--- a/python/test/vmafexec_test.py
+++ b/python/test/vmafexec_test.py
@@ -1135,7 +1135,7 @@ class VmafexecQualityRunnerSubsamplingTest(MyTestCase):
 class QualityRunnerVersionTest(unittest.TestCase):
 
     def test_vmafexec_quality_runner_version(self):
-        self.assertEqual(VmafexecQualityRunner.VERSION, 'F0.2.7-0.6.1')
+        self.assertEqual(VmafexecQualityRunner.VERSION, 'F0.2.21-0.6.1')
         self.assertEqual(VmafexecQualityRunner.ALGO_VERSION, 2)
 
 

--- a/python/vmaf/core/feature_extractor.py
+++ b/python/vmaf/core/feature_extractor.py
@@ -703,6 +703,15 @@ class PyPsnrMaxdb100FeatureExtractor(PyPsnrFeatureExtractor):
         self.optional_dict['max_db'] = 100.0
 
 
+class PypsnrMaxdb100FeatureExtractor(PyPsnrMaxdb100FeatureExtractor):
+
+    TYPE = "Pypsnr_maxdb100_feature"
+
+    @deprecated
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 class PsnrFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
     TYPE = "PSNR_feature"
@@ -972,6 +981,7 @@ class AnsnrFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
         ExternalProgramCaller.call_vmafexec_single_feature(
             'float_ansnr', yuv_type, ref_path, dis_path, w, h, log_file_path, logger,
             options={**optional_dict2})
+
 
 
 class SpeedChromaFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):

--- a/python/vmaf/core/feature_extractor.py
+++ b/python/vmaf/core/feature_extractor.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from xml.etree import ElementTree
 
-from vmaf.tools.decorator import override
+from vmaf.tools.decorator import override, deprecated
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -207,9 +207,23 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
     # VERSION = '0.2.4c'  # Modify by moving motion2 to c code
     # VERSION = '0.2.5'  # replace executable vmaf_feature with vmaf
     # VERSION = '0.2.6'  # incorporate adm_enhn_gain_limit and vif_enhn_gain_limit
-    VERSION = '0.2.7'  # move vif_enhn_gain_limit right before log calculation
+    # VERSION = '0.2.7'  # move vif_enhn_gain_limit right before log calculation
+    # VERSION = '0.2.8'  # add adm3 as an ATOM feature, adm3 is a linear combination (1/2 weights) between DLM and AIM
+    # VERSION = '0.2.9'  # add motion3 as an ATOM feature
+    # VERSION = '0.2.10'  # change the default value of adm_noise_weight to 1/32.0 = 0.03125
+    # VERSION = '0.2.11'  # fix filter mirroring for float features
+    # VERSION = '0.2.12'  # fix filter mirroring for integer motion
+    # VERSION = '0.2.13'  # expose AIM as an atom feature
+    # VERSION = '0.2.14'  # adding aliases for some float VIF params
+    # VERSION = '0.2.15'  # zero-out vif_scale0 when vif_skip_scale0 is set
+    # VERSION = '0.2.16'  # add alias for vif_skip_scale0
+    # VERSION = '0.2.17'  # introduce clipping for AIM values larger than 1 observed with large perceptual differences such as encoder not reproducing blur-out of the scene
+    # VERSION = '0.2.18'  # move vif_scale0, vif_scale1, vif_scale2 and vif_scale3 to ATOM features
+    # VERSION = '0.2.19'  # fix passing parameters to executable
+    # VERSION = '0.2.20'  # move adm2, adm_scale0, adm_scale1, adm_scale2 and adm_scale3 to ATOM features
+    VERSION = '0.2.21'  # add adm_skip_scale0 for skipping scale0 in ADM calculation
 
-    ATOM_FEATURES = ['vif', 'adm', 'ansnr', 'motion', 'motion2',
+    ATOM_FEATURES = ['vif', 'adm', 'adm2', 'aim', 'adm3', 'ansnr', 'motion', 'motion2', 'motion3',
                      'vif_num', 'vif_den', 'adm_num', 'adm_den', 'anpsnr',
                      'vif_num_scale0', 'vif_den_scale0',
                      'vif_num_scale1', 'vif_den_scale1',
@@ -219,16 +233,15 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
                      'adm_num_scale1', 'adm_den_scale1',
                      'adm_num_scale2', 'adm_den_scale2',
                      'adm_num_scale3', 'adm_den_scale3',
+                     'vif_scale0', 'vif_scale1', 'vif_scale2', 'vif_scale3',
+                     'adm_scale0', 'adm_scale1', 'adm_scale2', 'adm_scale3',
                      ]
 
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = dict(zip(ATOM_FEATURES, ATOM_FEATURES))
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT['ansnr'] = 'float_ansnr'
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT['anpsnr'] = 'float_anpsnr'
 
-    DERIVED_ATOM_FEATURES = ['vif_scale0', 'vif_scale1', 'vif_scale2', 'vif_scale3',
-                             'vif2', 'adm2', 'adm3',
-                             'adm_scale0', 'adm_scale1', 'adm_scale2', 'adm_scale3',
-                             ]
+    DERIVED_ATOM_FEATURES = ['vif2', ]
 
     ADM2_CONSTANT = 0
     ADM_SCALE_CONSTANT = 0
@@ -257,21 +270,83 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
         if self.optional_dict is not None:
             for opt in self.optional_dict:
                 if opt == 'vif_enhn_gain_limit':
-                    options['float_vif']['vif_enhn_gain_limit'] = self.optional_dict['vif_enhn_gain_limit']
+                    options['float_vif']['vif_enhn_gain_limit'] = self.optional_dict[opt]
                 elif opt == 'vif_kernelscale':
-                    options['float_vif']['vif_kernelscale'] = self.optional_dict['vif_kernelscale']
+                    options['float_vif']['vif_kernelscale'] = self.optional_dict[opt]
+                elif opt == 'vif_prescale':
+                    options['float_vif']['vif_prescale'] = self.optional_dict[opt]
+                elif opt == 'vif_prescale_method':
+                    options['float_vif']['vif_prescale_method'] = self.optional_dict[opt]
+                elif opt == 'vif_scale1_min_val':
+                    options['float_vif']['vif_scale1_min_val'] = self.optional_dict[opt]
+                elif opt == 'vif_scale2_min_val':
+                    options['float_vif']['vif_scale2_min_val'] = self.optional_dict[opt]
+                elif opt == 'vif_scale3_min_val':
+                    options['float_vif']['vif_scale3_min_val'] = self.optional_dict[opt]
                 elif opt == 'vif_sigma_nsq':
-                    options['float_vif']['vif_sigma_nsq'] = self.optional_dict['vif_sigma_nsq']
+                    options['float_vif']['vif_sigma_nsq'] = self.optional_dict[opt]
+                elif opt == 'vif_skip_scale0':
+                    options['float_vif']['vif_skip_scale0'] = self.optional_dict[opt]
                 elif opt == 'adm_csf_mode':
                     options['float_adm']['adm_csf_mode'] = self.optional_dict['adm_csf_mode']
+                elif opt == 'adm_noise_weight':
+                    options['float_adm']['adm_noise_weight'] = self.optional_dict[opt]
+                elif opt == 'adm_csf_scale':
+                    options['float_adm']['adm_csf_scale'] = self.optional_dict[opt]
+                elif opt == 'adm_csf_diag_scale':
+                    options['float_adm']['adm_csf_diag_scale'] = self.optional_dict[opt]
+                elif opt == 'adm_dlm_weight':
+                    options['float_adm']['adm_dlm_weight'] = self.optional_dict[opt]
                 elif opt == 'adm_enhn_gain_limit':
-                    options['float_adm']['adm_enhn_gain_limit'] = self.optional_dict['adm_enhn_gain_limit']
+                    options['float_adm']['adm_enhn_gain_limit'] = self.optional_dict[opt]
                 elif opt == 'adm_norm_view_dist':
-                    options['float_adm']['adm_norm_view_dist'] = self.optional_dict['adm_norm_view_dist']
+                    options['float_adm']['adm_norm_view_dist'] = self.optional_dict[opt]
                 elif opt == 'adm_ref_display_height':
-                    options['float_adm']['adm_ref_display_height'] = self.optional_dict['adm_ref_display_height']
+                    options['float_adm']['adm_ref_display_height'] = self.optional_dict[opt]
+                elif opt == 'adm_bypass_cm':
+                    options['float_adm']['adm_bypass_cm'] = self.optional_dict[opt]
+                elif opt == 'adm_adm3_apply_hm':
+                    options['float_adm']['adm_adm3_apply_hm'] = self.optional_dict[opt]
+                elif opt == 'adm_p_norm':
+                    options['float_adm']['adm_p_norm'] = self.optional_dict[opt]
+                elif opt == 'adm_min_val':
+                    options['float_adm']['adm_min_val'] = self.optional_dict[opt]
+                elif opt == 'adm_f1s0':
+                    options['float_adm']['adm_f1s0'] = self.optional_dict[opt]
+                elif opt == 'adm_f1s1':
+                    options['float_adm']['adm_f1s1'] = self.optional_dict[opt]
+                elif opt == 'adm_f1s2':
+                    options['float_adm']['adm_f1s2'] = self.optional_dict[opt]
+                elif opt == 'adm_f1s3':
+                    options['float_adm']['adm_f1s3'] = self.optional_dict[opt]
+                elif opt == 'adm_f2s0':
+                    options['float_adm']['adm_f2s0'] = self.optional_dict[opt]
+                elif opt == 'adm_f2s1':
+                    options['float_adm']['adm_f2s1'] = self.optional_dict[opt]
+                elif opt == 'adm_f2s2':
+                    options['float_adm']['adm_f2s2'] = self.optional_dict[opt]
+                elif opt == 'adm_f2s3':
+                    options['float_adm']['adm_f2s3'] = self.optional_dict[opt]
+                elif opt == 'adm_skip_aim_scale':
+                    options['float_adm']['adm_skip_aim_scale'] = self.optional_dict[opt]
+                elif opt == 'adm_skip_scale0':
+                    options['float_adm']['adm_skip_scale0'] = self.optional_dict[opt]
                 elif opt == 'motion_force_zero':
                     options['float_motion']['motion_force_zero'] = self.optional_dict['motion_force_zero']
+                elif opt == 'motion_fps_weight':
+                    options['float_motion']['motion_fps_weight'] = self.optional_dict['motion_fps_weight']
+                elif opt == 'motion_blend_factor':
+                    options['float_motion']['motion_blend_factor'] = self.optional_dict['motion_blend_factor']
+                elif opt == 'motion_blend_offset':
+                    options['float_motion']['motion_blend_offset'] = self.optional_dict['motion_blend_offset']
+                elif opt == 'motion_max_val':
+                    options['float_motion']['motion_max_val'] = self.optional_dict['motion_max_val']
+                elif opt == 'motion_filter_size':
+                    options['float_motion']['motion_filter_size'] = self.optional_dict['motion_filter_size']
+                elif opt == 'motion_add_scale1':
+                    options['float_motion']['motion_add_scale1'] = self.optional_dict['motion_add_scale1']
+                elif opt == 'motion_add_uv':
+                    options['float_motion']['motion_add_uv'] = self.optional_dict['motion_add_uv']
                 else:
                     pass
 
@@ -293,16 +368,6 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
         result = super(VmafFeatureExtractor, cls)._post_process_result(result)
 
-        # adm2 =
-        # (adm_num + ADM2_CONSTANT) / (adm_den + ADM2_CONSTANT)
-        adm2_scores_key = cls.get_scores_key('adm2')
-        adm_num_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_num'))
-        adm_den_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_den'))
-        result.result_dict[adm2_scores_key] = list(
-            (np.array(result.result_dict[adm_num_scores_key]) + cls.ADM2_CONSTANT) /
-            (np.array(result.result_dict[adm_den_scores_key]) + cls.ADM2_CONSTANT)
-        )
-
         # vif_scalei = vif_num_scalei / vif_den_scalei, i = 0, 1, 2, 3
         vif_num_scale0_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('vif_num_scale0'))
         vif_den_scale0_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('vif_den_scale0'))
@@ -312,26 +377,6 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
         vif_den_scale2_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('vif_den_scale2'))
         vif_num_scale3_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('vif_num_scale3'))
         vif_den_scale3_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('vif_den_scale3'))
-        vif_scale0_scores_key = cls.get_scores_key('vif_scale0')
-        vif_scale1_scores_key = cls.get_scores_key('vif_scale1')
-        vif_scale2_scores_key = cls.get_scores_key('vif_scale2')
-        vif_scale3_scores_key = cls.get_scores_key('vif_scale3')
-        result.result_dict[vif_scale0_scores_key] = list(
-            (np.array(result.result_dict[vif_num_scale0_scores_key])
-             / np.array(result.result_dict[vif_den_scale0_scores_key]))
-        )
-        result.result_dict[vif_scale1_scores_key] = list(
-            (np.array(result.result_dict[vif_num_scale1_scores_key])
-             / np.array(result.result_dict[vif_den_scale1_scores_key]))
-        )
-        result.result_dict[vif_scale2_scores_key] = list(
-            (np.array(result.result_dict[vif_num_scale2_scores_key])
-             / np.array(result.result_dict[vif_den_scale2_scores_key]))
-        )
-        result.result_dict[vif_scale3_scores_key] = list(
-            (np.array(result.result_dict[vif_num_scale3_scores_key])
-             / np.array(result.result_dict[vif_den_scale3_scores_key]))
-        )
 
         # vif2 =
         # ((vif_num_scale0 / vif_den_scale0) + (vif_num_scale1 / vif_den_scale1) +
@@ -347,55 +392,6 @@ class VmafFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
                  / np.array(result.result_dict[vif_den_scale2_scores_key])) +
                 (np.array(result.result_dict[vif_num_scale3_scores_key])
                  / np.array(result.result_dict[vif_den_scale3_scores_key]))
-            ) / 4.0
-        )
-
-        # adm_scalei = adm_num_scalei / adm_den_scalei, i = 0, 1, 2, 3
-        adm_num_scale0_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_num_scale0'))
-        adm_den_scale0_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_den_scale0'))
-        adm_num_scale1_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_num_scale1'))
-        adm_den_scale1_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_den_scale1'))
-        adm_num_scale2_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_num_scale2'))
-        adm_den_scale2_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_den_scale2'))
-        adm_num_scale3_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_num_scale3'))
-        adm_den_scale3_scores_key = BasicResult.scores_key_wildcard_match(result.result_dict, cls.get_scores_key('adm_den_scale3'))
-        adm_scale0_scores_key = cls.get_scores_key('adm_scale0')
-        adm_scale1_scores_key = cls.get_scores_key('adm_scale1')
-        adm_scale2_scores_key = cls.get_scores_key('adm_scale2')
-        adm_scale3_scores_key = cls.get_scores_key('adm_scale3')
-        result.result_dict[adm_scale0_scores_key] = list(
-            (np.array(result.result_dict[adm_num_scale0_scores_key]) + cls.ADM_SCALE_CONSTANT)
-            / (np.array(result.result_dict[adm_den_scale0_scores_key]) + cls.ADM_SCALE_CONSTANT)
-        )
-        result.result_dict[adm_scale1_scores_key] = list(
-            (np.array(result.result_dict[adm_num_scale1_scores_key]) + cls.ADM_SCALE_CONSTANT)
-            / (np.array(result.result_dict[adm_den_scale1_scores_key]) + cls.ADM_SCALE_CONSTANT)
-        )
-        result.result_dict[adm_scale2_scores_key] = list(
-            (np.array(result.result_dict[adm_num_scale2_scores_key]) + cls.ADM_SCALE_CONSTANT)
-            / (np.array(result.result_dict[adm_den_scale2_scores_key]) + cls.ADM_SCALE_CONSTANT)
-        )
-        result.result_dict[adm_scale3_scores_key] = list(
-            (np.array(result.result_dict[adm_num_scale3_scores_key]) + cls.ADM_SCALE_CONSTANT)
-            / (np.array(result.result_dict[adm_den_scale3_scores_key]) + cls.ADM_SCALE_CONSTANT)
-        )
-
-        # adm3 = \
-        # (((adm_num_scale0 + ADM_SCALE_CONSTANT) / (adm_den_scale0 + ADM_SCALE_CONSTANT))
-        #  + ((adm_num_scale1 + ADM_SCALE_CONSTANT) / (adm_den_scale1 + ADM_SCALE_CONSTANT))
-        #  + ((adm_num_scale2 + ADM_SCALE_CONSTANT) / (adm_den_scale2 + ADM_SCALE_CONSTANT))
-        #  + ((adm_num_scale3 + ADM_SCALE_CONSTANT) / (adm_den_scale3 + ADM_SCALE_CONSTANT))) / 4.0
-        adm3_scores_key = cls.get_scores_key('adm3')
-        result.result_dict[adm3_scores_key] = list(
-            (
-                ((np.array(result.result_dict[adm_num_scale0_scores_key]) + cls.ADM_SCALE_CONSTANT)
-                 / (np.array(result.result_dict[adm_den_scale0_scores_key]) + cls.ADM_SCALE_CONSTANT)) +
-                ((np.array(result.result_dict[adm_num_scale1_scores_key]) + cls.ADM_SCALE_CONSTANT)
-                 / (np.array(result.result_dict[adm_den_scale1_scores_key]) + cls.ADM_SCALE_CONSTANT)) +
-                ((np.array(result.result_dict[adm_num_scale2_scores_key]) + cls.ADM_SCALE_CONSTANT)
-                 / (np.array(result.result_dict[adm_den_scale2_scores_key]) + cls.ADM_SCALE_CONSTANT)) +
-                ((np.array(result.result_dict[adm_num_scale3_scores_key]) + cls.ADM_SCALE_CONSTANT)
-                 / (np.array(result.result_dict[adm_den_scale3_scores_key]) + cls.ADM_SCALE_CONSTANT))
             ) / 4.0
         )
 
@@ -439,14 +435,44 @@ class VmafIntegerFeatureExtractor(VmafFeatureExtractor):
             for opt in self.optional_dict:
                 if opt == 'vif_enhn_gain_limit':
                     options['vif']['vif_enhn_gain_limit'] = self.optional_dict['vif_enhn_gain_limit']
+                elif opt == 'vif_skip_scale0':
+                    options['vif']['vif_skip_scale0'] = self.optional_dict['vif_skip_scale0']
                 elif opt == 'adm_enhn_gain_limit':
                     options['adm']['adm_enhn_gain_limit'] = self.optional_dict['adm_enhn_gain_limit']
                 elif opt == 'adm_norm_view_dist':
                     options['adm']['adm_norm_view_dist'] = self.optional_dict['adm_norm_view_dist']
                 elif opt == 'adm_ref_display_height':
                     options['adm']['adm_ref_display_height'] = self.optional_dict['adm_ref_display_height']
+                elif opt == 'adm_skip_aim':
+                    options['adm']['adm_skip_aim'] = self.optional_dict['adm_skip_aim']
+                elif opt == 'adm_csf_scale':
+                    options['adm']['adm_csf_scale'] = self.optional_dict['adm_csf_scale']
+                elif opt == 'adm_csf_diag_scale':
+                    options['adm']['adm_csf_diag_scale'] = self.optional_dict['adm_csf_diag_scale']
+                elif opt == 'adm_csf_mode':
+                    options['adm']['adm_csf_mode'] = self.optional_dict['adm_csf_mode']
+                elif opt == 'adm_dlm_weight':
+                    options['adm']['adm_dlm_weight'] = self.optional_dict['adm_dlm_weight']
+                elif opt == 'adm_noise_weight':
+                    options['adm']['adm_noise_weight'] = self.optional_dict['adm_noise_weight']
+                elif opt == 'adm_min_val':
+                    options['adm']['adm_min_val'] = self.optional_dict['adm_min_val']
+                elif opt == 'adm_skip_scale0':
+                    options['adm']['adm_skip_scale0'] = self.optional_dict['adm_skip_scale0']
                 elif opt == 'motion_force_zero':
                     options['motion']['motion_force_zero'] = self.optional_dict['motion_force_zero']
+                elif opt == 'motion_fps_weight':
+                    options['motion']['motion_fps_weight'] = self.optional_dict['motion_fps_weight']
+                elif opt == 'motion_blend_offset':
+                    options['motion']['motion_blend_offset'] = self.optional_dict['motion_blend_offset']
+                elif opt == 'motion_blend_factor':
+                    options['motion']['motion_blend_factor'] = self.optional_dict['motion_blend_factor']
+                elif opt == 'motion_max_val':
+                    options['motion']['motion_max_val'] = self.optional_dict['motion_max_val']
+                elif opt == 'motion_five_frame_window':
+                    options['motion']['motion_five_frame_window'] = self.optional_dict['motion_five_frame_window']
+                elif opt == 'motion_moving_average':
+                    options['motion']['motion_moving_average'] = self.optional_dict['motion_moving_average']
                 else:
                     pass
 
@@ -571,9 +597,9 @@ class PyFeatureExtractorMixin(object):
         return feature_result
 
 
-class PypsnrFeatureExtractor(PyFeatureExtractorMixin, FeatureExtractor):
+class PyPsnrFeatureExtractor(PyFeatureExtractorMixin, FeatureExtractor):
 
-    TYPE = "Pypsnr_feature"
+    TYPE = "PyPsnr_feature"
     VERSION = "1.0"
 
     ATOM_FEATURES = ['psnry', 'psnru', 'psnrv']
@@ -654,9 +680,18 @@ class PypsnrFeatureExtractor(PyFeatureExtractorMixin, FeatureExtractor):
             log_file.write(str(log_dicts))
 
 
-class PypsnrMaxdb100FeatureExtractor(PypsnrFeatureExtractor):
+class PypsnrFeatureExtractor(PyPsnrFeatureExtractor):
 
-    TYPE = "Pypsnr_maxdb100_feature"
+    TYPE = "Pypsnr_feature"
+
+    @deprecated
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class PyPsnrMaxdb100FeatureExtractor(PyPsnrFeatureExtractor):
+
+    TYPE = "PyPsnr_maxdb100_feature"
 
     @override(Executor)
     def _custom_init(self):
@@ -964,6 +999,9 @@ class SpeedChromaFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtracto
     DERIVED_ATOM_FEATURES = []
 
     def _generate_result(self, asset):
+        # routine to call the command-line executable and generate quality
+        # scores in the log file.
+
         quality_width, quality_height = asset.quality_width_height
         log_file_path = self._get_log_file_path(asset)
 
@@ -995,6 +1033,9 @@ class SpeedTemporalFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtrac
     DERIVED_ATOM_FEATURES = []
 
     def _generate_result(self, asset):
+        # routine to call the command-line executable and generate quality
+        # scores in the log file.
+
         quality_width, quality_height = asset.quality_width_height
         log_file_path = self._get_log_file_path(asset)
 

--- a/python/vmaf/core/vmafexec_feature_extractor.py
+++ b/python/vmaf/core/vmafexec_feature_extractor.py
@@ -6,13 +6,17 @@ class FloatMotionFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtracto
 
     TYPE = "float_motion_feature"
     # VERSION = "1.0"
-    VERSION = "1.1"  # add debug features
+    # VERSION = "1.1"  # add debug features
+    # VERSION = "1.2"  # add motion3
+    VERSION = "1.3"  # fix filter mirroring
 
     ATOM_FEATURES = ['motion2',
+                     'motion3',
                      'motion',
                      ]
 
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
+        'motion3': 'motion3',
         'motion2': 'motion2',
         'motion': 'motion',
     }
@@ -44,13 +48,17 @@ class IntegerMotionFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtrac
     TYPE = "integer_motion_feature"
     # VERSION = "1.0"
     # VERSION = "1.1"  # vectorization
-    VERSION = "1.2"  # add debug features
+    # VERSION = "1.2"  # add debug features
+    # VERSION = "1.3"  # add motion3
+    VERSION = "1.4"  # fix filter mirroring
 
     ATOM_FEATURES = ['motion2',
+                     'motion3',
                      'motion',
                      ]
 
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
+        'motion3': 'integer_motion3',
         'motion2': 'integer_motion2',
         'motion': 'integer_motion',
     }
@@ -82,7 +90,9 @@ class FloatVifFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
     TYPE = "float_VIF_feature"
     # VERSION = "1.0"
-    VERSION = "1.1"  # add debug features
+    # VERSION = "1.1"  # add debug features
+    # VERSION = "1.2"  # fix filter mirroring
+    VERSION = "1.3"  # compute the filter coefficients on the fly rather than precomputing
 
     ATOM_FEATURES = [
                      'vif_scale0', 'vif_scale1', 'vif_scale2', 'vif_scale3',
@@ -204,9 +214,13 @@ class FloatAdmFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
     TYPE = "float_ADM_feature"
     # VERSION = "1.0"
-    VERSION = "1.1"  # add debug features
+    # VERSION = "1.1"  # add debug features
+    # VERSION = "1.2"  # add adm3 feature, which combines DLM and AIM using a simple linear combination (equal weights)
+    VERSION = "1.3"  # expose AIM feature
 
     ATOM_FEATURES = ['adm2',
+                     'aim',
+                     'adm3',
                      'adm_scale0',
                      'adm_scale1',
                      'adm_scale2',
@@ -226,6 +240,8 @@ class FloatAdmFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor):
 
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
         'adm2': 'adm2',
+        'aim': 'aim',
+        'adm3': 'adm3',
         'adm_scale0': 'adm_scale0',
         'adm_scale1': 'adm_scale1',
         'adm_scale2': 'adm_scale2',
@@ -305,9 +321,13 @@ class IntegerAdmFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor
     TYPE = "integer_ADM_feature"
     # VERSION = "1.0"
     # VERSION = "1.1"  # vectorization; small numerical diff introduced by adm_enhn_gain_limit
-    VERSION = "1.2"  # add debug features
+    # VERSION = "1.2"  # add debug features
+    # VERSION = "1.3"  # adm3
+    VERSION = "1.4"  # expose AIM feature
 
     ATOM_FEATURES = ['adm2',
+                     'aim',
+                     'adm3',
                      'adm_scale0',
                      'adm_scale1',
                      'adm_scale2',
@@ -327,6 +347,8 @@ class IntegerAdmFeatureExtractor(VmafexecFeatureExtractorMixin, FeatureExtractor
 
     ATOM_FEATURES_TO_VMAFEXEC_KEY_DICT = {
         'adm2': 'integer_adm2',
+        'aim': 'integer_aim',
+        'adm3': 'integer_adm3',
         'adm_scale0': 'integer_adm_scale0',
         'adm_scale1': 'integer_adm_scale1',
         'adm_scale2': 'integer_adm_scale2',


### PR DESCRIPTION
Bump `VmafFeatureExtractor` from v0.2.7 to v0.2.21 and expose new atom features already present in libvmaf.