### PR TITLE
python/test: adopt MyTestCase and update score values in test files

### DIFF
--- a/python/test/command_line_test.py
+++ b/python/test/command_line_test.py
@@ -4,14 +4,14 @@ import unittest
 import subprocess
 
 from vmaf.config import VmafConfig
-from vmaf.tools.misc import run_process
-from vmaf import ExternalProgram
+from vmaf.tools.misc import MyTestCase
+from vmaf import ExternalProgram, run_process
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
 
-class RunProcessTest(unittest.TestCase):
+class RunProcessTest(MyTestCase):
 
     def test_run_process(self):
         ret = run_process('echo hello', shell=True)
@@ -24,9 +24,10 @@ class RunProcessTest(unittest.TestCase):
         self.assertTrue('not found' in e.exception.args[0])
 
 
-class CommandLineTest(unittest.TestCase):
+class CommandLineTest(MyTestCase):
 
     def setUp(self):
+        super().setUp()
         self.dataset_filename = VmafConfig.test_resource_path('example_dataset.py')
         self.raw_dataset_filename = VmafConfig.test_resource_path('example_raw_dataset.py')
         self.out_model_filepath = VmafConfig.workdir_path('tmp.json')
@@ -40,6 +41,7 @@ class CommandLineTest(unittest.TestCase):
             os.remove(self.out_model_filepath + '.model')
         if os.path.exists(self.batch_filename):
             os.remove(self.batch_filename)
+        super().tearDown()
 
     def test_run_testing_vmaf(self):
         exe = VmafConfig.root_path('python', 'vmaf', 'script', 'run_testing.py')
@@ -162,16 +164,18 @@ class CommandLineTest(unittest.TestCase):
         self.assertEqual(ret, 0)
 
 
-class VmafexecCommandLineTest(unittest.TestCase):
+class VmafexecCommandLineTest(MyTestCase):
 
     RC_SUCCESS = 0
 
     def setUp(self) -> None:
+        super().setUp()
         self.output_file_path = tempfile.NamedTemporaryFile().name
 
     def tearDown(self) -> None:
         if os.path.exists(self.output_file_path):
             os.remove(self.output_file_path)
+        super().tearDown()
 
     def test_run_vmafexec(self):
         exe = ExternalProgram.vmafexec
@@ -217,6 +221,19 @@ class VmafexecCommandLineTest(unittest.TestCase):
         with open(self.output_file_path, 'rt') as fo:
             fc = fo.read()
             self.assertTrue('<metric name="psnr_y" min="19.019327" max="21.084954" mean="20.269606" harmonic_mean="20.258113" />' in fc)
+
+
+class VmafossexecCommandLineTest(MyTestCase):
+
+    RC_SUCCESS = 0
+    RC_VMAF_EXCEPTION = 256 - 2
+    RC_RUNTIME_ERROR = 256 - 3
+    RC_LOGIC_ERROR = 256 - 4
+    RC_SEGMENTATION_FAULT = 139
+    RC_ARGUMENT_ISSUE = 1
+    RC_MORE_ARGUMENT_ISSUE = 256 - 1
+    RC_ENOMEM = 244
+    RC_EINVAL = 234
 
 
 if __name__ == '__main__':

--- a/python/test/command_line_test.py
+++ b/python/test/command_line_test.py
@@ -223,18 +223,5 @@ class VmafexecCommandLineTest(MyTestCase):
             self.assertTrue('<metric name="psnr_y" min="19.019327" max="21.084954" mean="20.269606" harmonic_mean="20.258113" />' in fc)
 
 
-class VmafossexecCommandLineTest(MyTestCase):
-
-    RC_SUCCESS = 0
-    RC_VMAF_EXCEPTION = 256 - 2
-    RC_RUNTIME_ERROR = 256 - 3
-    RC_LOGIC_ERROR = 256 - 4
-    RC_SEGMENTATION_FAULT = 139
-    RC_ARGUMENT_ISSUE = 1
-    RC_MORE_ARGUMENT_ISSUE = 256 - 1
-    RC_ENOMEM = 244
-    RC_EINVAL = 234
-
-
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/python/test/feature_assembler_test.py
+++ b/python/test/feature_assembler_test.py
@@ -8,6 +8,7 @@ import unittest
 from vmaf.core.feature_assembler import FeatureAssembler
 from vmaf.core.feature_extractor import VmafFeatureExtractor, FeatureExtractor, \
     MomentFeatureExtractor
+from vmaf.tools.misc import MyTestCase
 
 from test.testutil import set_default_576_324_videos_for_testing
 
@@ -18,6 +19,7 @@ class FeatureAssemblerTest(unittest.TestCase):
         if hasattr(self, 'fassembler'):
             self.fassembler.remove_results()
         pass
+
 
     def test_get_fextractor_subclasses(self):
         fextractor_subclasses = FeatureExtractor.get_subclasses_recursively()
@@ -46,13 +48,13 @@ class FeatureAssemblerTest(unittest.TestCase):
 
         results = self.fassembler.results
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44609306249999997, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44641922916666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0488208125, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm2_score'], 0.9345149030293786, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_ansnr_score'], 23.509571520833333, places=4)
 
         self.assertAlmostEqual(results[1]['VMAF_feature_vif_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0488208125, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_ansnr_score'], 31.271439270833337, places=4)
 
@@ -78,13 +80,13 @@ class FeatureAssemblerTest(unittest.TestCase):
 
         results = self.fassembler.results
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44609306249999997, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44641922916666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0488208125, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_adm2_score'], 0.9345149030293786, places=4)
         self.assertAlmostEqual(results[0]['VMAF_feature_ansnr_score'], 23.509571520833333, places=4)
 
         self.assertAlmostEqual(results[1]['VMAF_feature_vif_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0488208125, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAF_feature_ansnr_score'], 31.271439270833337, places=4)
 
@@ -109,11 +111,11 @@ class FeatureAssemblerTest(unittest.TestCase):
 
         results = self.fassembler.results
 
-        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44609306249999997, places=3)
-        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[0]['VMAF_feature_vif_score'], 0.44641922916666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAF_feature_motion_score'], 4.0488208125, places=4)
 
         self.assertAlmostEqual(results[1]['VMAF_feature_vif_score'], 1.0, places=4)
-        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0498253541666669, places=2)
+        self.assertAlmostEqual(results[1]['VMAF_feature_motion_score'], 4.0488208125, places=4)
 
         with self.assertRaises(KeyError):
             _ = results[0]['VMAF_feature_ansnr_scores']
@@ -125,7 +127,7 @@ class FeatureAssemblerTest(unittest.TestCase):
             _ = results[0]['VMAF_feature_adm_score']
 
 
-class FeatureAssemblerUnitTest(unittest.TestCase):
+class FeatureAssemblerUnitTest(MyTestCase):
 
     def test_feature_assembler_get_fextractor_instance(self):
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()

--- a/python/test/noref_feature_extractor_test.py
+++ b/python/test/noref_feature_extractor_test.py
@@ -25,6 +25,7 @@ class NorefFeatureExtractorTest(unittest.TestCase):
             self.fextractor.remove_results()
             pass
 
+
     def test_noref_moment_fextractor(self):
 
         ref_path, dis_path, asset, asset_original = set_default_576_324_videos_for_testing()
@@ -232,14 +233,14 @@ class NorefFeatureExtractorTest(unittest.TestCase):
 
 class FeatureExtractorSaveWorkfilesTest(MyTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.result_store = FileSystemResultStore()
-
     def tearDown(self):
         if hasattr(self, 'fextractor'):
             self.fextractor.remove_results()
         super().tearDown()
+
+    def setUp(self):
+        super().setUp()
+        self.result_store = FileSystemResultStore()
 
     def test_noref_moment_fextractor(self):
 

--- a/python/test/perf_metric_test.py
+++ b/python/test/perf_metric_test.py
@@ -7,18 +7,11 @@ import scipy.io
 from vmaf.config import VmafConfig
 from vmaf.core.perf_metric import RmsePerfMetric, SrccPerfMetric, PccPerfMetric, \
     KendallPerfMetric, AucPerfMetric, ResolvingPowerPerfMetric
-
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
 
 class AggrScorePerfMetricTest(unittest.TestCase):
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
 
     def test_rmse_perf_metric(self):
         groundtruths = [1, 2, 3, 4]

--- a/python/test/train_test_model_test.py
+++ b/python/test/train_test_model_test.py
@@ -4,23 +4,24 @@ import unittest
 import numpy as np
 
 from vmaf.config import VmafConfig
+from vmaf.core.noref_feature_extractor import MomentNorefFeatureExtractor
+from vmaf.core.raw_extractor import DisYUVRawVideoExtractor
 from vmaf.core.train_test_model import TrainTestModel, \
     LibsvmNusvrTrainTestModel, SklearnRandomForestTrainTestModel, \
     MomentRandomForestTrainTestModel, SklearnExtraTreesTrainTestModel, \
     SklearnLinearRegressionTrainTestModel, Logistic5PLRegressionTrainTestModel
-from vmaf.core.noref_feature_extractor import MomentNorefFeatureExtractor
 from vmaf.routine import read_dataset
 from vmaf.tools.misc import import_python_file
-from vmaf.core.raw_extractor import DisYUVRawVideoExtractor
+from vmaf.tools.misc import MyTestCase
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
 
 
-class TrainTestModelTest(unittest.TestCase):
+class TrainTestModelTest(MyTestCase):
 
     def setUp(self):
-
+        super().setUp()
         train_dataset_path = VmafConfig.test_resource_path('test_image_dataset_diffdim2.py')
         train_dataset = import_python_file(train_dataset_path)
         train_assets = read_dataset(train_dataset)
@@ -42,6 +43,7 @@ class TrainTestModelTest(unittest.TestCase):
     def tearDown(self):
         if hasattr(self, 'model'):
             self.model.delete(self.model_filename)
+        super().tearDown()
 
     def test_get_xs_ys(self):
         xs = TrainTestModel.get_xs_from_results(self.features, [0, 1, 2])
@@ -325,10 +327,10 @@ class TrainTestModelTest(unittest.TestCase):
         self.assertAlmostEqual(result['RMSE'], 0.3603374311919728, places=4)
 
 
-class TrainTestModelWithDisYRawVideoExtractorTest(unittest.TestCase):
+class TrainTestModelWithDisYRawVideoExtractorTest(MyTestCase):
 
     def setUp(self):
-
+        super().setUp()
         train_dataset_path = VmafConfig.test_resource_path('test_image_dataset_diffdim2.py')
         train_dataset = import_python_file(train_dataset_path)
         train_assets = read_dataset(train_dataset)
@@ -358,6 +360,7 @@ class TrainTestModelWithDisYRawVideoExtractorTest(unittest.TestCase):
             os.remove(self.h5py_filepath)
         if os.path.exists(self.model_filename):
             os.remove(self.model_filename)
+        super().tearDown()
 
     def test_extracted_features(self):
         self.assertAlmostEqual(np.mean(self.features[0]['dis_y']), 160.617204551784, places=4)
@@ -476,10 +479,10 @@ class TrainTestModelWithDisYRawVideoExtractorTest(unittest.TestCase):
         self.assertAlmostEqual(result['RMSE'], 0.51128487038576109, places=4)
 
 
-class TrainTestModelTestJson(unittest.TestCase):
+class TrainTestModelTestJson(MyTestCase):
 
     def setUp(self):
-
+        super().setUp()
         train_dataset_path = VmafConfig.test_resource_path('test_image_dataset_diffdim2.py')
         train_dataset = import_python_file(train_dataset_path)
         train_assets = read_dataset(train_dataset)
@@ -501,6 +504,7 @@ class TrainTestModelTestJson(unittest.TestCase):
     def tearDown(self):
         if hasattr(self, 'model'):
             self.model.delete(self.model_filename_json, format='json')
+        super().tearDown()
 
     def test_train_save_load_predict_libsvmnusvr_json(self):
 


### PR DESCRIPTION
Aligns 5 test files with the internal repo:

- Replace `unittest.TestCase` with `MyTestCase` in `train_test_model_test.py`, `feature_assembler_test.py`, and `command_line_test.py` for soft-assertion collection (all failures reported per test run rather than stopping at the first)
- Update `vif_score` and `motion_score` expected values in `feature_assembler_test.py` to reflect the updated feature extractor version; tighten tolerances from `places=2/3` to `places=4`
- Clean up empty `setUp`/`tearDown` in `perf_metric_test.py`
- Fix `setUp` position in `noref_feature_extractor_test.py`
- Reorder imports in `train_test_model_test.py` and `command_line_test.py`