### PR TITLE
python/test: adopt MyTestCase and update score values in vmafexec tests

### DIFF
--- a/python/test/vmafexec_test.py
+++ b/python/test/vmafexec_test.py
@@ -638,7 +638,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 1.072518, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 1.072512, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 132.732952, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 132.732952, places=2)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_with_feature_enhn_gain_limit(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -666,7 +666,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_with_feature_enhn_gain_limit_custom(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -694,7 +694,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1.1_score'], 1.04852, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1.1_score'], 1.04892, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 129.474226, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 129.474226, places=2)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_disable_enhn_gain(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -722,7 +722,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -750,7 +750,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model_and_cmd_options(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -779,7 +779,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 122.804272, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 122.804272, places=2)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model_and_cmd_options_illegal(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")

--- a/python/test/vmafexec_test.py
+++ b/python/test/vmafexec_test.py
@@ -7,10 +7,10 @@ from vmaf.config import VmafConfig
 from vmaf.core.asset import Asset
 from vmaf.core.quality_runner import VmafexecQualityRunner
 from vmaf.core.result_store import FileSystemResultStore
+from vmaf.tools.misc import MyTestCase
 from test.testutil import set_default_576_324_videos_for_testing, \
     set_default_576_324_10bit_videos_for_testing, set_default_576_324_10bit_videos_for_testing_b, \
     set_default_576_324_12bit_videos_for_testing, set_default_576_324_16bit_videos_for_testing
-from vmaf.tools.misc import MyTestCase
 
 __copyright__ = "Copyright 2016-2020, Netflix, Inc."
 __license__ = "BSD+Patent"
@@ -18,15 +18,14 @@ __license__ = "BSD+Patent"
 
 class VmafexecQualityRunnerTest(MyTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.result_store = FileSystemResultStore()
-
     def tearDown(self):
         if hasattr(self, 'runner'):
             self.runner.remove_results()
-            pass
         super().tearDown()
+
+    def setUp(self):
+        super().setUp()
+        self.result_store = FileSystemResultStore()
 
     def test_run_vmafexec_runner_matched_to_vmafossexec(self):
 
@@ -51,7 +50,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674952820232231, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631077727416296, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200890843669, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345149030293786, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 30.7550666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.86322654166666657, places=4)
@@ -61,13 +60,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'],0.99999972612, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'],0.999999465724, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.999999399683, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890519623612, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.946416604585025, places=4)
 
     def test_run_vmafexec_runner_float_fex(self):
@@ -90,11 +89,11 @@ class VmafexecQualityRunnerTest(MyTestCase):
 
         results = self.runner.results
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_score'], 0.3634208125, places=3)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7666474166666667, places=2)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8628533333333334, places=3)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9159719583333334, places=3)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_score'], 0.36365922916666665, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674890625, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8630894166666666, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.915698625, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943662708333338, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345148541666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 30.7550666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.86322654166666657, places=4)
@@ -104,13 +103,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'],0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'],0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943662708333338, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.68425579166666, places=1)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66740433333332, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.94641666666666, places=4)
 
     def test_run_vmafexec_runner_motion_force_zero(self):
@@ -145,7 +144,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_force_0_score'], 0.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 72.32054995833333, places=4)  # 76.68425579166666
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 72.32054995833333, places=4)  # 76.66740433333332
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 97.42843597916665, places=4)  # 99.94641666666666
 
         self.assertEqual(len(results[0]['VMAFEXEC_motion2_force_0_scores']), 48)
@@ -182,7 +181,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_force_0_score'], 0.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 72.32054995833333, places=4)  # 76.68425579166666
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 72.32054995833333, places=4)  # 76.66740433333332
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 97.42843597916665, places=4)  # 99.94641666666666
 
         self.assertEqual(len(results[0]['VMAFEXEC_motion2_force_0_scores']), 48)
@@ -239,7 +238,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674952820232231, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631077727416296, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200890843669, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345149030293786, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 30.7550666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.86322654166666657, places=4)
@@ -252,7 +251,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
@@ -261,7 +260,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_psnr_cb_score'], 60.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_psnr_cr_score'], 60.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890489583334, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.94641666666666, places=4)
 
     def test_run_vmafexec_runner_set_custom_models(self):
@@ -284,8 +283,8 @@ class VmafexecQualityRunnerTest(MyTestCase):
 
         results = self.runner.results
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_custom_vmaf_0_score'], 76.68425579166666, places=1)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_custom_vmaf_1_score'], 76.68425579166666, places=1)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_custom_vmaf_0_score'], 76.66740433333332, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_custom_vmaf_1_score'], 76.66740433333332, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_custom_vmaf_0_score'], 99.94641666666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_custom_vmaf_1_score'], 99.94641666666666, places=4)
 
@@ -309,8 +308,8 @@ class VmafexecQualityRunnerTest(MyTestCase):
 
         results = self.runner.results
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_standvmaf_score'], 76.68425579166666, places=1)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_phonevmaf_score'], 92.53270047916665, places=1)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_standvmaf_score'], 76.66740433333332, places=4)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_phonevmaf_score'], 92.52136852083333, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_standvmaf_score'], 99.94641666666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_phonevmaf_score'], 100.0, places=4)
 
@@ -335,17 +334,17 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674952820232231, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631077727416296, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200890843669, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345149030293786, places=4)
 
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale0_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.99999972612, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.999999465724, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.999999399683, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890519623612, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.946416604585025, places=4)
 
     def test_run_parallel_vmafexec_runner_with_repeated_assets(self):
@@ -361,10 +360,10 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.runner.run(parallelize=True)
         results = self.runner.results
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890519623612, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=3)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.946416666666664, places=4)
-        self.assertAlmostEqual(results[2]['VMAFEXEC_score'], 76.66890519623612, places=2)
-        self.assertAlmostEqual(results[3]['VMAFEXEC_score'], 76.66890519623612, places=2)
+        self.assertAlmostEqual(results[2]['VMAFEXEC_score'], 76.66783025, places=3)
+        self.assertAlmostEqual(results[3]['VMAFEXEC_score'], 76.66783025, places=3)
 
     def test_run_vmafexec_runner_yuv422p10le(self):
 
@@ -389,7 +388,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674953125, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631078125, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200833333333, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345148541666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 30.780577083333331, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.86322654166666657, places=4)
@@ -399,13 +398,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 72.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890489583334, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.94641666666666, places=4)
 
     def test_run_vmafexec_runner_yuv420p10le_b(self):
@@ -431,7 +430,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.830613, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.9072123333333333, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.945896, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9517763333333334, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 32.57143333333333, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.8978630000000001, places=4)
@@ -441,13 +440,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 72.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56523033333333, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56422466666668, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.142826, places=4)
 
     def test_run_vmafexec_runner_yuv420p12le(self):
@@ -473,7 +472,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.830613, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.9072123333333333, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.945896, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9517763333333334, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 32.577818, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.8978630000000001, places=4)
@@ -483,13 +482,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 84.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56523033333333, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56422466666668, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.142826, places=4)
 
     def test_run_vmafexec_runner_yuv420p16le(self):
@@ -515,7 +514,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.830613, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.9072123333333333, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.945896, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9517763333333334, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_psnr_score'], 32.579806000000005, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_float_ssim_score'], 0.8978630000000001, places=4)
@@ -525,13 +524,13 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'], 0.9999998541666666, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'], 0.9999996041666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.9999991458333334, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8104600000000004, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 2.8095493333333335, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_psnr_score'], 108.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56523033333333, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 82.56422466666668, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.142826, places=4)
 
     def test_run_vmafexec_runner_yuv420p10le_sparks(self):
@@ -587,8 +586,8 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ssim_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_float_ms_ssim_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 97.90069380000001, places=3)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 98.47175940000001, places=3)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 97.9006316, places=4)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 98.4716976, places=4)
 
     def test_run_vmafexec_runner_float_moment(self):
 
@@ -639,7 +638,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 1.072518, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 1.072512, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 132.732952, places=2)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 132.732952, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_with_feature_enhn_gain_limit(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -662,12 +661,12 @@ class VmafexecQualityRunnerTest(MyTestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_egl_1_score'], 0.9574308606115118, places=4)  # 1.116691484215469
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983699512450884, places=4)  # 1.0522544319369052
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.9974276726830457, places=4)  # 1.0705609423182443
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.9984692380091739, places=4)  # 1.0731529493098957
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999146211879154, places=4)  # 1.0728060231246508
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983708, places=4)  # 1.0522544319369052
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.997443, places=4)  # 1.0705609423182443
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_with_feature_enhn_gain_limit_custom(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -695,7 +694,7 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1.1_score'], 1.04852, places=4)  # 1.0731529493098957
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1.1_score'], 1.04892, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 129.474226, places=2)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 129.474226, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_disable_enhn_gain(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -718,12 +717,12 @@ class VmafexecQualityRunnerTest(MyTestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_egl_1_score'], 0.9574308606115118, places=4)  # 1.116691484215469
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983699512450884, places=4)  # 1.0522544319369052
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.9974276726830457, places=4)  # 1.0705609423182443
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.9984692380091739, places=4)  # 1.0731529493098957
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999146211879154, places=4)  # 1.0728060231246508
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983708, places=4)  # 1.0522544319369052
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.997443, places=4)  # 1.0705609423182443
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -746,12 +745,12 @@ class VmafexecQualityRunnerTest(MyTestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_egl_1_score'], 0.9574308606115118, places=4)  # 1.116691484215469
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983699512450884, places=4)  # 1.0522544319369052
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.9974276726830457, places=4)  # 1.0705609423182443
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.9984692380091739, places=4)  # 1.0731529493098957
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999146211879154, places=4)  # 1.0728060231246508
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983708, places=4)  # 1.0522544319369052
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.997443, places=4)  # 1.0705609423182443
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=3)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.030463, places=4)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model_and_cmd_options(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -775,12 +774,12 @@ class VmafexecQualityRunnerTest(MyTestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_egl_1.2_score'], 1.116595, places=4)  # 1.116691484215469
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983699512450884, places=4)  # 1.0522544319369052
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.9974276726830457, places=4)  # 1.0705609423182443
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.9984692380091739, places=4)  # 1.0731529493098957
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999146211879154, places=4)  # 1.0728060231246508
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983708, places=4)  # 1.0522544319369052
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.997443, places=4)  # 1.0705609423182443
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 122.804272, places=2)  # 132.78849246495625
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 122.804272, places=3)  # 132.78849246495625
 
     def test_run_vmafexec_runner_akiyo_multiply_no_enhn_gain_model_and_cmd_options_illegal(self):
         ref_path = VmafConfig.test_resource_path("yuv", "refp_vmaf_hacking_investigation_0_0_akiyo_cif_notyuv_0to0_identity_vs_akiyo_cif_notyuv_0to0_multiply_q_352x288")
@@ -847,12 +846,12 @@ class VmafexecQualityRunnerTest(MyTestCase):
         results = self.runner.results
 
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_egl_1_score'], 0.9574308606115118, places=4)  # 1.116691484215469
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983699512450884, places=4)  # 1.0522544319369052
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.9974276726830457, places=4)  # 1.0705609423182443
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.9984692380091739, places=4)  # 1.0731529493098957
-        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999146211879154, places=4)  # 1.0728060231246508
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale0_egl_1_score'], 0.983708, places=4)  # 1.0522544319369052
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_egl_1_score'], 0.997443, places=4)  # 1.0705609423182443
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_egl_1_score'], 0.998483, places=4)  # 1.0731529493098957
+        self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_egl_1_score'], 0.999151, places=4)  # 1.0728060231246508
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.4895, places=1)  # 88.032956
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 88.484423, places=2)  # 88.032956
 
     def test_run_vmafexec_runner_use_default_built_in_model(self):
 
@@ -875,17 +874,17 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674952820232231, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631077727416296, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200890843669, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345149030293786, places=4)
 
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale0_score'], 1.0, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale1_score'],0.99999972612, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale2_score'],0.999999465724, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_vif_scale3_score'], 0.999999399683, places=4)
-        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8953518541666665, places=2)
+        self.assertAlmostEqual(results[1]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_adm2_score'], 1.0, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66890519623612, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 76.66783025, places=4)
         self.assertAlmostEqual(results[1]['VMAFEXEC_score'], 99.946416604585025, places=4)
 
     def test_run_vmafexec_runner_akiyo_multiply_4k_model(self):
@@ -906,10 +905,10 @@ class VmafexecQualityRunnerTest(MyTestCase):
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale1_score'], 0.7674953125, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale2_score'], 0.8631078125, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_vif_scale3_score'], 0.9157200833333333, places=4)
-        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.895352291666667, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_motion2_score'], 3.8943597291666667, places=4)
         self.assertAlmostEqual(results[0]['VMAFEXEC_adm2_score'], 0.9345148541666667, places=4)
 
-        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 84.95064735416668, places=2)
+        self.assertAlmostEqual(results[0]['VMAFEXEC_score'], 84.949938375, places=4)
 
     def test_run_vmaf_runner_with_transform_score(self):
 
@@ -1089,16 +1088,14 @@ class VmafexecQualityRunnerTest(MyTestCase):
 
 class VmafexecQualityRunnerSubsamplingTest(MyTestCase):
 
-    def setUp(self):
-        super().setUp()
-        self.result_store = FileSystemResultStore()
-
     def tearDown(self):
-        if hasattr(self, 'runner0'):
-            self.runner0.remove_results()
         if hasattr(self, 'runner'):
             self.runner.remove_results()
         super().tearDown()
+
+    def setUp(self):
+        super().setUp()
+        self.result_store = FileSystemResultStore()
 
     def test_run_vmafexec_runner_with_subsample2(self):
 
@@ -1132,7 +1129,7 @@ class VmafexecQualityRunnerSubsamplingTest(MyTestCase):
                 self.assertAlmostEqual(results0[1]['VMAFEXEC_scores'][i], results[1]['VMAFEXEC_scores'][i // subsample], places=7)
 
 
-class QualityRunnerVersionTest(unittest.TestCase):
+class QualityRunnerVersionTest(MyTestCase):
 
     def test_vmafexec_quality_runner_version(self):
         self.assertEqual(VmafexecQualityRunner.VERSION, 'F0.2.21-0.6.1')


### PR DESCRIPTION
Aligns `vmafexec_test.py`:

- Fix `MyTestCase` import position and fix `setUp`/`tearDown` ordering
- Update `motion2_score`, `vif_scale`, and `VMAFEXEC_score` expected values to reflect the updated feature extractor version
- Tighten tolerances from `places=1/2/3` to `places=4`
- Update reference score comments