### PR TITLE
resource/doc: add cambi_high_res_speedup parameter and update motion2 score

### DIFF
--- a/resource/doc/cambi.md
+++ b/resource/doc/cambi.md
@@ -60,6 +60,7 @@ The CAMBI feature extractor also supports additional optional parameters as list
 - `full_ref`: optional flag (default: false) to run CAMBI as a full-reference metric, outputting the per-frame difference between the encoded and source images as well as the existing no-reference score.
 - `enc_width` and `enc_height`: Encoding/processing resolution to compute the banding score, useful in cases where scaling was applied to the input prior to the computation of metrics
 - `src_width` and `src_height`: Encoding/processing resolution to compute the banding score on the reference image, only used if `full_ref=true`.
+- `cambi_high_res_speedup` to speed up by downsampling post spatial mask for resolutions >= 1080p. However, some loss of accuracy is expected in metric. Possible min resolutions for the speed-up = [1080, 1440, 3840, 0]. Default: 0 (not applied).
 - `heatmaps_path`: Set to a folder where the heatmaps for different scales will be stored as `.gray` files
 
 An example using the `enc_width` and `enc_height` options on the input video [`KristenAndSara_1280x720_8bit_processed.yuv`](https://github.com/Netflix/vmaf_resource/blob/master/python/test/resource/yuv/KristenAndSara_1280x720_8bit_processed.yuv) which has been encoded at 540p and later upscaled to 1280p (specifying the accurate encoding width and height as input allows CAMBI to more accurately assess the banding artifact):

--- a/resource/doc/conf_interval.md
+++ b/resource/doc/conf_interval.md
@@ -33,7 +33,7 @@ yields:
         "BOOTSTRAP_VMAF_score": 75.44304785910772,
         "BOOTSTRAP_VMAF_stddev_score": 1.31289244504376,
         "VMAF_feature_adm2_score": 0.9345878041226809,
-        "VMAF_feature_motion2_score": 3.8953518541666665,
+        "VMAF_feature_motion2_score": 3.8943597291666667,
         "VMAF_feature_vif_scale0_score": 0.36342081156994926,
         "VMAF_feature_vif_scale1_score": 0.7666473878461729,
         "VMAF_feature_vif_scale2_score": 0.8628533892781629,

--- a/resource/doc/python.md
+++ b/resource/doc/python.md
@@ -140,7 +140,7 @@ This will generate JSON output like:
     ...
     "aggregate": {
         "VMAF_feature_adm2_score": 0.93458780776205741, 
-        "VMAF_feature_motion2_score": 3.8953518541666665, 
+        "VMAF_feature_motion2_score": 3.8943597291666667, 
         "VMAF_feature_vif_scale0_score": 0.36342081156994926, 
         "VMAF_feature_vif_scale1_score": 0.76664738784617292, 
         "VMAF_feature_vif_scale2_score": 0.86285338927816291, 


### PR DESCRIPTION
- Add `cambi_high_res_speedup` parameter documentation to `cambi.md`
- Update `VMAF_feature_motion2_score` example value in `conf_interval.md` and `python.md` to reflect the current feature extractor version