### PR TITLE
python/config: make download_reactively race-safe under parallel exec…

### DIFF
--- a/python/vmaf/config.py
+++ b/python/vmaf/config.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os
 import ssl
+import tempfile
 import urllib.request
 import urllib.error
 
@@ -19,7 +20,21 @@ def download_reactively(local_path, remote_path):
         print(f'download {local_path} from {remote_path}')
         try:
             ssl._create_default_https_context = ssl._create_unverified_context
-            urllib.request.urlretrieve(remote_path, local_path)
+            # Download to a sibling tempfile then atomically rename, so
+            # concurrent readers (e.g. pytest-xdist workers sharing the
+            # cache) cannot observe a partially-written local_path.
+            fd, tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(local_path),
+                prefix=os.path.basename(local_path) + '.',
+                suffix='.part',
+            )
+            os.close(fd)
+            try:
+                urllib.request.urlretrieve(remote_path, tmp_path)
+                os.replace(tmp_path, local_path)
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
         except urllib.error.HTTPError as e:
             print(f"error downloading from {remote_path}")
             raise e


### PR DESCRIPTION
…ution

download_reactively() invokes urllib.request.urlretrieve(remote_path, local_path) which writes incrementally to local_path. Concurrent processes that share the same fixture cache (e.g. pytest-xdist workers) check os.path.exists(local_path) and short-circuit, but between the moment urlretrieve creates the file and the moment it finishes writing, the file exists and is partial. A second worker that arrives in that window opens local_path, reads garbage, and proceeds. For YUV fixtures consumed by feature extractors, the visible failure is non-deterministic feature scores -- the same test produces different actuals on different runs.

Fix: download into a sibling tempfile via tempfile.mkstemp() then os.replace() onto local_path. os.replace() is atomic on POSIX, so concurrent writers can only ever overwrite a complete file with another complete file; readers never observe a partial file. The unique sibling name (mkstemp suffix) also prevents a second race between two workers writing to the same tempfile.

Behaviour preserved:
  - same early-return when local_path already exists,
  - same os.makedirs(parent, exist_ok=True),
  - same urllib.error.HTTPError handling and re-raise.