### PR TITLE
Fix "context could not be synchronized" abort with CUDA + --threads

### DIFF
--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -191,6 +191,21 @@ int vmaf_cuda_import_state(VmafContext *vmaf, VmafCudaState *cu_state)
 
     vmaf->cuda.state = *cu_state;
 
+    /* GPU feature extraction is not threaded (see the "multithreading for GPU
+     * ... disabled for now" note at the read dispatch in vmaf_read_pictures).
+     * With a thread pool present, vmaf_read_pictures returns early via
+     * threaded_read_pictures_batch, which bypasses the HAVE_CUDA device-picture
+     * cleanup below it (the cuEventRecord(finished) + vmaf_picture_unref of
+     * ref_device/dist_device), and feature extractors flush from worker threads
+     * that lack the bound CUDA context. As a result `vmaf --gpumask 0 --threads N`
+     * aborts with "context could not be synchronized". Tear the pool down on
+     * CUDA import so CUDA runs take the single-threaded path (GPU feature
+     * threading yields no throughput benefit anyway). */
+    if (vmaf->thread_pool) {
+        vmaf_thread_pool_destroy(vmaf->thread_pool);
+        vmaf->thread_pool = NULL;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Running `vmaf --gpumask 0 --threads N` aborts at flush with
`context could not be synchronized` (exit 234), preceded by a flood of
`feature ... cannot be overwritten at index N` warnings.

## Cause

The read dispatch in `vmaf_read_pictures` carries the note *"multithreading for
GPU does not yield performance benefits / disabled for now"*, but GPU feature
threading is not actually disabled. When a thread pool is present,
`vmaf_read_pictures` returns early via `threaded_read_pictures_batch`, which:

- bypasses the `HAVE_CUDA` device-picture cleanup below it — the
  `cuEventRecord(finished)` and the `vmaf_picture_unref` of
  `ref_device`/`dist_device`; and
- flushes feature extractors from worker threads that lack the bound CUDA
  context.

The CUDA context is therefore left unsynchronized and `flush_context` fails.

## Fix

Tear the thread pool down in `vmaf_cuda_import_state` so CUDA runs take the
single-threaded path, matching the existing comment's intent. GPU feature
threading yields no throughput benefit (the GPU pipeline, not host
feature-extraction parallelism, is the bound).

## Validation

RTX 5090, CUDA 13.2, `vmaf_v0.6.1`, 1080p y4m:

| invocation | before | after |
|---|---|---|
| `--gpumask 0` (single-thread) | OK | OK |
| `--gpumask 0 --threads 4` | **exit 234** (`context could not be synchronized`) | OK, score identical to single-thread |

## Re-verified on the v3.2.0 release (master `ac9467ff`)

The bug still reproduces on current `master`, and this fix still applies
cleanly — `vmaf_cuda_import_state` is unchanged since this PR was opened, so the
patch cherry-picks without conflict. Built pure upstream `master` with CUDA
(`-Denable_cuda=true -Denable_float=true -Denable_nvcc=true`) on an RTX 5090 /
CUDA 13.3, 854p y4m:

| invocation | before fix | after fix |
|---|---|---|
| `--gpumask 0 --threads 0` | OK (vmaf `85.194703`) | OK |
| `--gpumask 0 --threads 4` | **exit 234** | OK, vmaf `85.194703` (bit-identical to single-thread) |
| `--threads 4` (CPU, no CUDA import) | OK | OK (no regression) |
