### PR TITLE
libvmaf: add 2160p@1.5H CSF support (reuses 1080p@3H tables)

### DIFF
--- a/libvmaf/src/feature/barten_csf_tools.h
+++ b/libvmaf/src/feature/barten_csf_tools.h
@@ -221,6 +221,9 @@ static FORCE_INLINE inline float barten_watson_blend_csf_mae(int scale, int thet
         return BLENDED_CSF_1080_3H_MAE[theta][scale];
     } else if (adm_ref_display_height == 1080 && adm_norm_view_dist == 5.0) {
         return BLENDED_CSF_1080_5H_MAE[theta][scale];
+    } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 1.5) {
+        // 2160@1.5H has the same PPD as 1080@3H (1.5*2160 == 3.0*1080 == 56.55 ppd)
+        return BLENDED_CSF_1080_3H_MAE[theta][scale];
     } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 3.0) {
         return BLENDED_CSF_2160_3H_MAE[theta][scale];
     } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 5.0) {
@@ -248,6 +251,9 @@ static FORCE_INLINE inline float barten_watson_blend_csf(int scale, int theta, d
         return BLENDED_CSF_1080_3H[theta][scale];
     } else if (adm_ref_display_height == 1080 && adm_norm_view_dist == 5.0) {
         return BLENDED_CSF_1080_5H[theta][scale];
+    } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 1.5) {
+        // 2160@1.5H has the same PPD as 1080@3H (1.5*2160 == 3.0*1080 == 56.55 ppd)
+        return BLENDED_CSF_1080_3H[theta][scale];
     } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 3.0) {
         return BLENDED_CSF_2160_3H[theta][scale];
     } else if (adm_ref_display_height == 2160 && adm_norm_view_dist == 5.0) {

--- a/libvmaf/test/test_barten_csf.c
+++ b/libvmaf/test/test_barten_csf.c
@@ -56,6 +56,15 @@ static char *test_barten_csf()
     mu_assert("csf blend scale 2 D 1080p 3H", almost_equal(barten_watson_blend_csf(2, 1, 3.0, 1080), 0.023918));
     mu_assert("csf blend scale 3 H/V 1080p 3H", almost_equal(barten_watson_blend_csf(3, 0, 3.0, 1080), 0.058621));
     mu_assert("csf blend scale 3 D 1080p 3H", almost_equal(barten_watson_blend_csf(3, 1, 3.0, 1080), 0.035901));
+    // 2160@1.5H has the same PPD as 1080@3H (1.5*2160 == 3.0*1080 == 56.55 ppd), so values must match
+    mu_assert("csf blend scale 0 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(0, 0, 1.5, 2160), 0.01183));
+    mu_assert("csf blend scale 0 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(0, 1, 1.5, 2160), 0.004302));
+    mu_assert("csf blend scale 1 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(1, 0, 1.5, 2160), 0.025026));
+    mu_assert("csf blend scale 1 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(1, 1, 1.5, 2160), 0.011778));
+    mu_assert("csf blend scale 2 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(2, 0, 1.5, 2160), 0.04295));
+    mu_assert("csf blend scale 2 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(2, 1, 1.5, 2160), 0.023918));
+    mu_assert("csf blend scale 3 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(3, 0, 1.5, 2160), 0.058621));
+    mu_assert("csf blend scale 3 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf(3, 1, 1.5, 2160), 0.035901));
     return NULL;
 }
 
@@ -90,6 +99,16 @@ static char *test_barten_watson_blend_csf_v1_0_17()
     mu_assert("v1017 csf blend scale 2 D 2160p 3H", almost_equal(barten_watson_blend_csf_mae(2, 1, 3.0, 2160), 0.010921));
     mu_assert("v1017 csf blend scale 3 H/V 2160p 3H", almost_equal(barten_watson_blend_csf_mae(3, 0, 3.0, 2160), 0.035930));
     mu_assert("v1017 csf blend scale 3 D 2160p 3H", almost_equal(barten_watson_blend_csf_mae(3, 1, 3.0, 2160), 0.021430));
+
+    // 2160@1.5H has the same PPD as 1080@3H (1.5*2160 == 3.0*1080 == 56.55 ppd), so values must match
+    mu_assert("v1017 csf blend scale 0 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(0, 0, 1.5, 2160), 0.011249));
+    mu_assert("v1017 csf blend scale 0 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(0, 1, 1.5, 2160), 0.004097));
+    mu_assert("v1017 csf blend scale 1 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(1, 0, 1.5, 2160), 0.022606));
+    mu_assert("v1017 csf blend scale 1 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(1, 1, 1.5, 2160), 0.010921));
+    mu_assert("v1017 csf blend scale 2 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(2, 0, 1.5, 2160), 0.035930));
+    mu_assert("v1017 csf blend scale 2 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(2, 1, 1.5, 2160), 0.021430));
+    mu_assert("v1017 csf blend scale 3 H/V 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(3, 0, 1.5, 2160), 0.045673));
+    mu_assert("v1017 csf blend scale 3 D 2160p 1.5H == 1080p 3H", almost_equal(barten_watson_blend_csf_mae(3, 1, 1.5, 2160), 0.031313));
 
     // Test v1017 CSF coefficients for 2160p 5H
     mu_assert("v1017 csf blend scale 0 H/V 2160p 5H", almost_equal(barten_watson_blend_csf_mae(0, 0, 5.0, 2160), 0.000077));


### PR DESCRIPTION
## Summary

Adds support for a 2160p reference display viewed at 1.5× picture height (`adm_ref_display_height == 2160`, `adm_norm_view_dist == 1.5`) in the Barten/Watson blended-CSF lookups.

A 2160p display at 1.5H has the same angular resolution as 1080p at 3H:

```
1.5 * 2160 == 3.0 * 1080 == 56.55 pixels-per-degree
```

so this configuration reuses the existing `BLENDED_CSF_1080_3H` / `BLENDED_CSF_1080_3H_MAE` tables rather than introducing new constants. The change is two `else if` branches — one in `barten_watson_blend_csf` and one in `barten_watson_blend_csf_mae`.

## Tests

`test/test_barten_csf.c` gains asserts (scales 0–3 × H/V and Diagonal, for both the standard and MAE/v1.0.17 variants) confirming that `(1.5, 2160)` returns exactly the same values as `(3.0, 1080)`.

## Notes

No new tables, no behavior change for any existing display configuration.