### PR TITLE
adm and speed simd

### DIFF
--- a/libvmaf/src/feature/integer_adm.c
+++ b/libvmaf/src/feature/integer_adm.c
@@ -3083,7 +3083,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         if (!(w % 8)) s->dwt2_8 = adm_dwt2_8_avx2;
         s->dwt2_16 = adm_dwt2_16_avx2;
         s->adm_decouple = adm_decouple_avx2;
-        //s->adm_decouple_s123 = adm_decouple_s123_avx2;
+        s->adm_decouple_s123 = adm_decouple_s123_avx2;
         s->adm_csf = adm_csf_avx2;
         s->i4_adm_csf = i4_adm_csf_avx2;
         s->adm_csf_den_scale = adm_csf_den_scale_avx2;
@@ -3097,7 +3097,7 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
         s->dwt2_8 = adm_dwt2_8_avx512;
         s->dwt2_16 = adm_dwt2_16_avx512;
         s->adm_decouple = adm_decouple_avx512;
-        //s->adm_decouple_s123 = adm_decouple_s123_avx512;
+        s->adm_decouple_s123 = adm_decouple_s123_avx512;
         s->adm_csf = adm_csf_avx512;
         s->i4_adm_csf = i4_adm_csf_avx512;
         s->adm_csf_den_scale = adm_csf_den_scale_avx512;

--- a/libvmaf/src/feature/speed.c
+++ b/libvmaf/src/feature/speed.c
@@ -34,6 +34,20 @@
 #include "picture_copy.h"
 #include "vif_tools.h"
 
+#include "cpu.h"
+#if ARCH_X86
+#include "x86/cpu.h"
+#include "x86/speed_avx2.h"
+#if HAVE_AVX512
+#include "x86/speed_avx512.h"
+#endif
+#endif
+
+typedef double (*compute_cov_kernel_fn)(const float *data_x, const float *data_y,
+                                        size_t stride_px, size_t height,
+                                        size_t width, double mean_x,
+                                        double mean_y);
+
 typedef struct SpeedDimensions {
     size_t original_height;
     size_t original_width;
@@ -86,6 +100,7 @@ typedef struct SpeedState {
     SpeedResultBuffers dis_results;
     SpeedBuffers buffers;
     size_t float_stride;
+    compute_cov_kernel_fn compute_cov_kernel;
 } SpeedState;
 
 #define DEFAULT_BLOCK_SIZE (5)
@@ -660,6 +675,24 @@ static float compute_mean(SpeedDimensions dim, const float *data,
     return result / (dim.submatrix_width * dim.submatrix_height);
 }
 
+// Scalar reference implementation of the covariance-sum kernel.
+// Returns the un-normalized sum; the /N division happens in compute_covariance.
+static double compute_cov_kernel_scalar(const float *data_x, const float *data_y,
+                                        size_t stride_px, size_t height,
+                                        size_t width, double mean_x,
+                                        double mean_y)
+{
+    double result = 0;
+    for (size_t i = 0; i < height; i++) {
+        for (size_t j = 0; j < width; j++) {
+            double val_x = data_x[i * stride_px + j];
+            double val_y = data_y[i * stride_px + j];
+            result += (val_x - mean_x) * (val_y - mean_y);
+        }
+    }
+    return result;
+}
+
 // Computes the covariance between two arrays of the same given size
 // The arrays are stored as submatrices of the input data, starting at
 // (start_row_x, start_col_x) and (start_row_y, start_col_y)
@@ -667,26 +700,23 @@ static float compute_mean(SpeedDimensions dim, const float *data,
 static float compute_covariance(SpeedDimensions dim, const float *data,
                                 const float *means, size_t stride_px,
                                 int start_row_x, int start_col_x,
-                                int start_row_y, int start_col_y)
+                                int start_row_y, int start_col_y,
+                                compute_cov_kernel_fn kernel)
 {
     double mean_x = means[start_row_x * dim.block_size + start_col_x];
     double mean_y = means[start_row_y * dim.block_size + start_col_y];
-    double result = 0;
-    for (size_t i = 0; i < dim.submatrix_height; i++) {
-        for (size_t j = 0; j < dim.submatrix_width; j++) {
-            double val_x =
-                data[(start_row_x + i) * stride_px + (start_col_x + j)];
-            double val_y =
-                data[(start_row_y + i) * stride_px + (start_col_y + j)];
-            result += (val_x - mean_x) * (val_y - mean_y);
-        }
-    }
+    const float *data_x = data + start_row_x * stride_px + start_col_x;
+    const float *data_y = data + start_row_y * stride_px + start_col_y;
+    double result = kernel(data_x, data_y, stride_px,
+                           dim.submatrix_height, dim.submatrix_width,
+                           mean_x, mean_y);
     return result / (dim.submatrix_width * dim.submatrix_height);
 }
 
 static void compute_covariance_matrix(SpeedDimensions dim, const float *data,
                                       float *cov_mat, float *means,
-                                      size_t stride_px)
+                                      size_t stride_px,
+                                      compute_cov_kernel_fn kernel)
 {
     for (size_t start_row = 0; start_row < dim.block_size; start_row++) {
         for (size_t start_col = 0; start_col < dim.block_size; start_col++) {
@@ -704,7 +734,8 @@ static void compute_covariance_matrix(SpeedDimensions dim, const float *data,
             size_t start_col_y = y_index % dim.block_size;
             float covariance =
                 compute_covariance(dim, data, means, stride_px, start_row_x,
-                                   start_col_x, start_row_y, start_col_y);
+                                   start_col_x, start_row_y, start_col_y,
+                                   kernel);
             cov_mat[x_index * elements_in_block + y_index] = covariance;
             cov_mat[y_index * elements_in_block + x_index] = covariance;
         }
@@ -781,9 +812,13 @@ static int est_params(SpeedState *s, const float *data, float sigma_nn,
 
     // Step 1: Compute the covariance matrix K
     // We use the eigenvalues array as a temporary array to store the means
-    // needed for the covariance
+    // needed for the covariance.
+    // Default to the scalar kernel if speed_init() wasn't called (e.g. unit
+    // tests that construct SpeedState via struct literal).
+    compute_cov_kernel_fn kernel = s->compute_cov_kernel
+        ? s->compute_cov_kernel : compute_cov_kernel_scalar;
     compute_covariance_matrix(dim, data, s->buffers.cov_mat,
-                              s->buffers.eigenvalues, stride_px);
+                              s->buffers.eigenvalues, stride_px, kernel);
 
     // Step 2: Compute the eigenvalues of the covariance matrix
     compute_eigenvalues(s->buffers.cov_mat, s->buffers.eigenvalues,
@@ -1061,6 +1096,19 @@ int speed_init(SpeedState *s, SpeedOptions *opt, int w, int h)
     s->dis_results.variances = aligned_malloc(sizeof(float) * dim->num_blocks, 32);
     if (!s->dis_results.variances)
         return -ENOMEM;
+
+    s->compute_cov_kernel = compute_cov_kernel_scalar;
+#if ARCH_X86
+    unsigned flags = vmaf_get_cpu_flags();
+    if (flags & VMAF_X86_CPU_FLAG_AVX2) {
+        s->compute_cov_kernel = compute_cov_kernel_avx2;
+    }
+#if HAVE_AVX512
+    if (flags & VMAF_X86_CPU_FLAG_AVX512) {
+        s->compute_cov_kernel = compute_cov_kernel_avx512;
+    }
+#endif
+#endif
 
     return 0;
 }

--- a/libvmaf/src/feature/x86/adm_avx2.c
+++ b/libvmaf/src/feature/x86/adm_avx2.c
@@ -1507,7 +1507,11 @@ void adm_decouple_s123_avx2(AdmBuffer *buf, int w, int h, int stride,
             __m256i tmp_kh_msb_epi32 = _mm256_setr_epi32(tmp_kh_msb[0], tmp_kh_msb[1], tmp_kh_msb[2], tmp_kh_msb[3], tmp_kh_msb[4], tmp_kh_msb[5], tmp_kh_msb[6], tmp_kh_msb[7]);
 
             __m256i mask_kh_msb_epi32 = _mm256_cmpgt_epi32(const_32768_epi32, abs_oh_epi32);
-            __m256i kh_msb_epi32 = blend(const_32768_epi32, tmp_kh_msb_epi32, mask_kh_msb_epi32);
+            // Where abs_oh < 32768, scalar uses oh directly (signed); the AVX-512
+            // path here blends abs_oh_epi32. AVX2 previously blended const_32768,
+            // producing small float-feature drift visible on 10-bit content.
+            __m256i kh_msb_epi32 = blend(abs_oh_epi32, tmp_kh_msb_epi32, mask_kh_msb_epi32);
+            kh_shift_epi32 = blend(_mm256_setzero_si256(), kh_shift_epi32, mask_kh_msb_epi32);
 
             tmp_kv_msb[0] = get_best15_from32(_mm256_extract_epi32(abs_ov_epi32, 0), &tmp_kv_shift[0]);
             tmp_kv_msb[1] = get_best15_from32(_mm256_extract_epi32(abs_ov_epi32, 1), &tmp_kv_shift[1]);
@@ -1521,7 +1525,8 @@ void adm_decouple_s123_avx2(AdmBuffer *buf, int w, int h, int stride,
             __m256i kv_shift_epi32 = _mm256_setr_epi32(tmp_kv_shift[0], tmp_kv_shift[1], tmp_kv_shift[2], tmp_kv_shift[3], tmp_kv_shift[4], tmp_kv_shift[5], tmp_kv_shift[6], tmp_kv_shift[7]);
             __m256i tmp_kv_msb_epi32 = _mm256_setr_epi32(tmp_kv_msb[0], tmp_kv_msb[1], tmp_kv_msb[2], tmp_kv_msb[3], tmp_kv_msb[4], tmp_kv_msb[5], tmp_kv_msb[6], tmp_kv_msb[7]);
             __m256i mask_kv_msb_epi32 = _mm256_cmpgt_epi32(const_32768_epi32, abs_ov_epi32);
-            __m256i kv_msb_epi32 = blend(const_32768_epi32, tmp_kv_msb_epi32, mask_kv_msb_epi32);
+            __m256i kv_msb_epi32 = blend(abs_ov_epi32, tmp_kv_msb_epi32, mask_kv_msb_epi32);
+            kv_shift_epi32 = blend(_mm256_setzero_si256(), kv_shift_epi32, mask_kv_msb_epi32);
 
             tmp_kd_msb[0] = get_best15_from32(_mm256_extract_epi32(abs_od_epi32, 0), &tmp_kd_shift[0]);
             tmp_kd_msb[1] = get_best15_from32(_mm256_extract_epi32(abs_od_epi32, 1), &tmp_kd_shift[1]);
@@ -1535,7 +1540,8 @@ void adm_decouple_s123_avx2(AdmBuffer *buf, int w, int h, int stride,
             __m256i kd_shift_epi32 = _mm256_setr_epi32(tmp_kd_shift[0], tmp_kd_shift[1], tmp_kd_shift[2], tmp_kd_shift[3], tmp_kd_shift[4], tmp_kd_shift[5], tmp_kd_shift[6], tmp_kd_shift[7]);
             __m256i tmp_kd_msb_epi32 = _mm256_setr_epi32(tmp_kd_msb[0], tmp_kd_msb[1], tmp_kd_msb[2], tmp_kd_msb[3], tmp_kd_msb[4], tmp_kd_msb[5], tmp_kd_msb[6], tmp_kd_msb[7]);
             __m256i mask_kd_msb_epi32 = _mm256_cmpgt_epi32(const_32768_epi32, abs_od_epi32);
-            __m256i kd_msb_epi32 = blend(const_32768_epi32, tmp_kd_msb_epi32, mask_kd_msb_epi32);
+            __m256i kd_msb_epi32 = blend(abs_od_epi32, tmp_kd_msb_epi32, mask_kd_msb_epi32);
+            kd_shift_epi32 = blend(_mm256_setzero_si256(), kd_shift_epi32, mask_kd_msb_epi32);
 
              // tmp_kh as int64
              __m256i div_lookup_kh_epi32 = _mm256_i32gather_epi32(adm_div_lookup, _mm256_add_epi32(kh_msb_epi32, const_32768_epi32), 4);

--- a/libvmaf/src/feature/x86/adm_avx512.c
+++ b/libvmaf/src/feature/x86/adm_avx512.c
@@ -1267,6 +1267,7 @@ void adm_decouple_s123_avx512(AdmBuffer *buf, int w, int h, int stride,
                                                                                              _mm512_sub_epi32(kh_shift_epi32, const_1_epi32))), kh_shift_epi32);
             __mmask16 mask_kh_msb = _mm512_cmp_epi32_mask(abs_oh_epi32,const_32768_epi32,_MM_CMPINT_LT);
             __m512i kh_msb_epi32 = _mm512_mask_blend_epi32(mask_kh_msb, tmp_kh_msb_epi32, abs_oh_epi32);
+            kh_shift_epi32 = _mm512_mask_blend_epi32(mask_kh_msb, kh_shift_epi32, _mm512_setzero_si512());
 
             __m512i kv_shift_epi32 =  _mm512_sub_epi32(_mm512_set1_epi32(17), _mm512_lzcnt_epi32(abs_ov_epi32));
             __m512i tmp_kv_msb_epi32 = _mm512_srlv_epi32( _mm512_add_epi32(abs_ov_epi32,
@@ -1274,6 +1275,7 @@ void adm_decouple_s123_avx512(AdmBuffer *buf, int w, int h, int stride,
                                                                                              _mm512_sub_epi32(kv_shift_epi32, const_1_epi32))), kv_shift_epi32);
             __mmask16 mask_kv_msb = _mm512_cmp_epi32_mask(abs_ov_epi32,const_32768_epi32,_MM_CMPINT_LT);
             __m512i kv_msb_epi32 = _mm512_mask_blend_epi32(mask_kv_msb, tmp_kv_msb_epi32, abs_ov_epi32);
+            kv_shift_epi32 = _mm512_mask_blend_epi32(mask_kv_msb, kv_shift_epi32, _mm512_setzero_si512());
 
             __m512i kd_shift_epi32 =  _mm512_sub_epi32(_mm512_set1_epi32(17), _mm512_lzcnt_epi32(abs_od_epi32));
             __m512i tmp_kd_msb_epi32 = _mm512_srlv_epi32( _mm512_add_epi32(abs_od_epi32,
@@ -1281,6 +1283,7 @@ void adm_decouple_s123_avx512(AdmBuffer *buf, int w, int h, int stride,
                                                                                              _mm512_sub_epi32(kd_shift_epi32, const_1_epi32))), kd_shift_epi32);
             __mmask16 mask_kd_msb = _mm512_cmp_epi32_mask(abs_od_epi32,const_32768_epi32,_MM_CMPINT_LT);
             __m512i kd_msb_epi32 = _mm512_mask_blend_epi32(mask_kd_msb, tmp_kd_msb_epi32, abs_od_epi32);
+            kd_shift_epi32 = _mm512_mask_blend_epi32(mask_kd_msb, kd_shift_epi32, _mm512_setzero_si512());
 
              // tmp_kh as int64
              __m512i div_lookup_kh_epi32 = _mm512_i32gather_epi32(_mm512_add_epi32(kh_msb_epi32, const_32768_epi32),adm_div_lookup, 4);

--- a/libvmaf/src/feature/x86/speed_avx2.c
+++ b/libvmaf/src/feature/x86/speed_avx2.c
@@ -1,0 +1,73 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <immintrin.h>
+#include <stddef.h>
+
+// AVX2 4-wide-double accumulator with two parallel chains to hide FMA latency.
+// Per-element math (mul + add) is fused via vfmadd231pd; the per-row sub is
+// kept separate to mirror scalar's two-rounding sub more closely.
+// Loop processes 8 elements per iteration when possible, then 4, then scalar.
+double compute_cov_kernel_avx2(const float *data_x, const float *data_y,
+                               size_t stride_px, size_t height, size_t width,
+                               double mean_x, double mean_y)
+{
+    __m256d acc0 = _mm256_setzero_pd();
+    __m256d acc1 = _mm256_setzero_pd();
+    const __m256d mx = _mm256_set1_pd(mean_x);
+    const __m256d my = _mm256_set1_pd(mean_y);
+    double scalar_tail = 0.0;
+
+    for (size_t i = 0; i < height; i++) {
+        const float *row_x = data_x + i * stride_px;
+        const float *row_y = data_y + i * stride_px;
+        size_t j = 0;
+
+        for (; j + 7 < width; j += 8) {
+            __m128 fx0 = _mm_loadu_ps(row_x + j);
+            __m128 fx1 = _mm_loadu_ps(row_x + j + 4);
+            __m128 fy0 = _mm_loadu_ps(row_y + j);
+            __m128 fy1 = _mm_loadu_ps(row_y + j + 4);
+            __m256d cx0 = _mm256_sub_pd(_mm256_cvtps_pd(fx0), mx);
+            __m256d cx1 = _mm256_sub_pd(_mm256_cvtps_pd(fx1), mx);
+            __m256d cy0 = _mm256_sub_pd(_mm256_cvtps_pd(fy0), my);
+            __m256d cy1 = _mm256_sub_pd(_mm256_cvtps_pd(fy1), my);
+            acc0 = _mm256_fmadd_pd(cx0, cy0, acc0);
+            acc1 = _mm256_fmadd_pd(cx1, cy1, acc1);
+        }
+
+        for (; j + 3 < width; j += 4) {
+            __m128 fx = _mm_loadu_ps(row_x + j);
+            __m128 fy = _mm_loadu_ps(row_y + j);
+            __m256d cx = _mm256_sub_pd(_mm256_cvtps_pd(fx), mx);
+            __m256d cy = _mm256_sub_pd(_mm256_cvtps_pd(fy), my);
+            acc0 = _mm256_fmadd_pd(cx, cy, acc0);
+        }
+
+        for (; j < width; j++) {
+            double val_x = row_x[j];
+            double val_y = row_y[j];
+            scalar_tail += (val_x - mean_x) * (val_y - mean_y);
+        }
+    }
+
+    __m256d acc = _mm256_add_pd(acc0, acc1);
+    double tmp[4];
+    _mm256_storeu_pd(tmp, acc);
+    return tmp[0] + tmp[1] + tmp[2] + tmp[3] + scalar_tail;
+}

--- a/libvmaf/src/feature/x86/speed_avx2.h
+++ b/libvmaf/src/feature/x86/speed_avx2.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef X86_AVX2_SPEED_H_
+#define X86_AVX2_SPEED_H_
+
+#include <stddef.h>
+
+double compute_cov_kernel_avx2(const float *data_x, const float *data_y,
+                               size_t stride_px, size_t height, size_t width,
+                               double mean_x, double mean_y);
+
+#endif /* X86_AVX2_SPEED_H_ */

--- a/libvmaf/src/feature/x86/speed_avx512.c
+++ b/libvmaf/src/feature/x86/speed_avx512.c
@@ -1,0 +1,69 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <immintrin.h>
+#include <stddef.h>
+
+// AVX-512 8-wide-double accumulator with two parallel chains for FMA pipelining.
+// Loop processes 16 elements per iteration, then 8, then scalar tail.
+double compute_cov_kernel_avx512(const float *data_x, const float *data_y,
+                                 size_t stride_px, size_t height, size_t width,
+                                 double mean_x, double mean_y)
+{
+    __m512d acc0 = _mm512_setzero_pd();
+    __m512d acc1 = _mm512_setzero_pd();
+    const __m512d mx = _mm512_set1_pd(mean_x);
+    const __m512d my = _mm512_set1_pd(mean_y);
+    double scalar_tail = 0.0;
+
+    for (size_t i = 0; i < height; i++) {
+        const float *row_x = data_x + i * stride_px;
+        const float *row_y = data_y + i * stride_px;
+        size_t j = 0;
+
+        for (; j + 15 < width; j += 16) {
+            __m256 fx0 = _mm256_loadu_ps(row_x + j);
+            __m256 fx1 = _mm256_loadu_ps(row_x + j + 8);
+            __m256 fy0 = _mm256_loadu_ps(row_y + j);
+            __m256 fy1 = _mm256_loadu_ps(row_y + j + 8);
+            __m512d cx0 = _mm512_sub_pd(_mm512_cvtps_pd(fx0), mx);
+            __m512d cx1 = _mm512_sub_pd(_mm512_cvtps_pd(fx1), mx);
+            __m512d cy0 = _mm512_sub_pd(_mm512_cvtps_pd(fy0), my);
+            __m512d cy1 = _mm512_sub_pd(_mm512_cvtps_pd(fy1), my);
+            acc0 = _mm512_fmadd_pd(cx0, cy0, acc0);
+            acc1 = _mm512_fmadd_pd(cx1, cy1, acc1);
+        }
+
+        for (; j + 7 < width; j += 8) {
+            __m256 fx = _mm256_loadu_ps(row_x + j);
+            __m256 fy = _mm256_loadu_ps(row_y + j);
+            __m512d cx = _mm512_sub_pd(_mm512_cvtps_pd(fx), mx);
+            __m512d cy = _mm512_sub_pd(_mm512_cvtps_pd(fy), my);
+            acc0 = _mm512_fmadd_pd(cx, cy, acc0);
+        }
+
+        for (; j < width; j++) {
+            double val_x = row_x[j];
+            double val_y = row_y[j];
+            scalar_tail += (val_x - mean_x) * (val_y - mean_y);
+        }
+    }
+
+    __m512d acc = _mm512_add_pd(acc0, acc1);
+    return _mm512_reduce_add_pd(acc) + scalar_tail;
+}

--- a/libvmaf/src/feature/x86/speed_avx512.h
+++ b/libvmaf/src/feature/x86/speed_avx512.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *  Copyright 2016-2020 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef X86_AVX512_SPEED_H_
+#define X86_AVX512_SPEED_H_
+
+#include <stddef.h>
+
+double compute_cov_kernel_avx512(const float *data_x, const float *data_y,
+                                 size_t stride_px, size_t height, size_t width,
+                                 double mean_x, double mean_y);
+
+#endif /* X86_AVX512_SPEED_H_ */

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -242,13 +242,14 @@ if is_asm_enabled
           feature_src_dir + 'x86/vif_avx2.c',
           feature_src_dir + 'x86/adm_avx2.c',
           feature_src_dir + 'x86/cambi_avx2.c',
+          feature_src_dir + 'x86/speed_avx2.c',
       ]
 
       x86_avx2_static_lib = static_library(
           'x86_avx2',
           x86_avx2_sources,
           include_directories : vmaf_base_include,
-          c_args : ['-mavx', '-mavx2'] + vmaf_cflags_common,
+          c_args : ['-mavx', '-mavx2', '-mfma'] + vmaf_cflags_common,
       )
 
       platform_specific_cpu_objects += x86_avx2_static_lib.extract_all_objects(recursive: true)
@@ -258,6 +259,7 @@ if is_asm_enabled
             feature_src_dir + 'x86/motion_avx512.c',
             feature_src_dir + 'x86/vif_avx512.c',
             feature_src_dir + 'x86/adm_avx512.c',
+            feature_src_dir + 'x86/speed_avx512.c',
         ]
 
         x86_avx512_static_lib = static_library(


### PR DESCRIPTION
Speed_chroma: vectorize compute_covariance (AVX2 + AVX-512)
ADM: enable adm_decouple_s123 SIMD dispatch and fix AVX2 kh_msb blend