### PR TITLE
Enable floating-point feature extractors by default

### DIFF
--- a/libvmaf/meson_options.txt
+++ b/libvmaf/meson_options.txt
@@ -30,7 +30,7 @@ option('built_in_models',
 
 option('enable_float',
     type: 'boolean',
-    value: false,
+    value: true,
     description: 'Compile floating-point feature extractors into the library')
 
 option('enable_cuda',


### PR DESCRIPTION
CAMBI and SpEED from the v1 model require float to function, so this should probably be on by default