### PR TITLE
Fix problems when compiling for/on various platforms and OSes

### DIFF
--- a/libvmaf/src/feature/barten_csf_tools.h
+++ b/libvmaf/src/feature/barten_csf_tools.h
@@ -20,6 +20,10 @@
 #include "common/macros.h"
 #include <errno.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 #pragma once
 
 #ifndef BARTEN_CSF_TOOLS_H_

--- a/libvmaf/src/feature/ciede.c
+++ b/libvmaf/src/feature/ciede.c
@@ -52,6 +52,10 @@ SOFTWARE.
 #include "mem.h"
 #include "opt.h"
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 typedef struct CiedeState {
     VmafPicture ref;
     VmafPicture dist;

--- a/libvmaf/src/feature/integer_adm.h
+++ b/libvmaf/src/feature/integer_adm.h
@@ -171,9 +171,9 @@ struct dwt_model_params {
 
 // 0 -> Y, 1 -> Cb, 2 -> Cr
 static const struct dwt_model_params dwt_7_9_YCbCr_threshold[3] = {
-    {.a = 0.495, .k = 0.466, .f0 = 0.401, .g = {1.501, 1.0, 0.534, 1.0}},
-    {.a = 1.633, .k = 0.353, .f0 = 0.209, .g = {1.520, 1.0, 0.502, 1.0}},
-    {.a = 0.944, .k = 0.521, .f0 = 0.404, .g = {1.868, 1.0, 0.516, 1.0}}};
+    {0.495, 0.466, 0.401, {1.501, 1.0, 0.534, 1.0}},
+    {1.633, 0.353, 0.209, {1.520, 1.0, 0.502, 1.0}},
+    {0.944, 0.521, 0.404, {1.868, 1.0, 0.516, 1.0}}};
 
 /*
  * The following dwt basis function amplitudes, A(lambda,theta), are taken from
@@ -193,4 +193,16 @@ static const float dwt_7_9_basis_function_amplitudes[6][4] = {
     {0.045943, 0.059758, 0.077727, 0.059758},
     {0.023013, 0.030018, 0.039156, 0.030018}};
 
+#if defined(_MSC_VER) && defined(_M_X64)
+static inline int __builtin_clz(unsigned x) {
+    if (x == 0) return 32;
+    unsigned n = 0;
+    if ((x & 0xFFFF0000) == 0) { n += 16; x <<= 16; }
+    if ((x & 0xFF000000) == 0) { n += 8;  x <<= 8; }
+    if ((x & 0xF0000000) == 0) { n += 4;  x <<= 4; }
+    if ((x & 0xC0000000) == 0) { n += 2;  x <<= 2; }
+    if ((x & 0x80000000) == 0) { n += 1; }
+    return n;
+}
+#endif
 #endif /* _FEATURE_ADM_H_ */

--- a/libvmaf/src/feature/integer_vif.c
+++ b/libvmaf/src/feature/integer_vif.c
@@ -641,22 +641,22 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
     if (!data) return -ENOMEM;
     memset(data, 0, data_sz);
 
-    s->public.buf.data = data; data += pad_size;
-    s->public.buf.ref = data; data += frame_size + pad_size + pad_size;
-    s->public.buf.dis = data; data += frame_size + pad_size;
-    s->public.buf.mu1 = data; data += h * s->public.buf.stride_16;
-    s->public.buf.mu2 = data; data += h * s->public.buf.stride_16;
-    s->public.buf.mu1_32 = data; data += s->public.buf.stride_32;
-    s->public.buf.mu2_32 = data; data += s->public.buf.stride_32;
-    s->public.buf.ref_sq = data; data += s->public.buf.stride_32;
-    s->public.buf.dis_sq = data; data += s->public.buf.stride_32;
-    s->public.buf.ref_dis = data; data += s->public.buf.stride_32;
-    s->public.buf.tmp.mu1 = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.mu2 = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.dis = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref_dis = data; data += s->public.buf.stride_tmp;
-    s->public.buf.tmp.ref_convol = data; data += s->public.buf.stride_tmp;
+    s->public.buf.data = data; data = (char *) data + pad_size;
+    s->public.buf.ref = data; data = (char *) data + frame_size + pad_size + pad_size;
+    s->public.buf.dis = data; data = (char *) data + frame_size + pad_size;
+    s->public.buf.mu1 = data; data = (char *) data + h * s->public.buf.stride_16;
+    s->public.buf.mu2 = data; data = (char *) data + h * s->public.buf.stride_16;
+    s->public.buf.mu1_32 = data; data = (char *) data + s->public.buf.stride_32;
+    s->public.buf.mu2_32 = data; data = (char *) data + s->public.buf.stride_32;
+    s->public.buf.ref_sq = data; data = (char *) data + s->public.buf.stride_32;
+    s->public.buf.dis_sq = data; data = (char *) data + s->public.buf.stride_32;
+    s->public.buf.ref_dis = data; data = (char *) data + s->public.buf.stride_32;
+    s->public.buf.tmp.mu1 = data; data = (char *) data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.mu2 = data; data = (char *) data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref = data; data = (char *) data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.dis = data; data = (char *) data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_dis = data; data = (char *) data + s->public.buf.stride_tmp;
+    s->public.buf.tmp.ref_convol = data; data = (char *) data + s->public.buf.stride_tmp;
     s->public.buf.tmp.dis_convol = data;
 
     s->feature_name_dict =

--- a/libvmaf/src/feature/integer_vif.h
+++ b/libvmaf/src/feature/integer_vif.h
@@ -128,15 +128,28 @@ VifResiduals vif_compute_line_residuals(VifPublicState *s, unsigned from,
                                         unsigned to, int scale);
 
 
-#ifdef _MSC_VER
-#include <intrin.h>
-
+#if defined(_MSC_VER) && defined(_M_X64)
 static inline int __builtin_clz(unsigned x) {
-    return (int)__lzcnt(x);
+    if (x == 0) return 32;
+    unsigned n = 0;
+    if ((x & 0xFFFF0000) == 0) { n += 16; x <<= 16; }
+    if ((x & 0xFF000000) == 0) { n += 8;  x <<= 8; }
+    if ((x & 0xF0000000) == 0) { n += 4;  x <<= 4; }
+    if ((x & 0xC0000000) == 0) { n += 2;  x <<= 2; }
+    if ((x & 0x80000000) == 0) { n += 1; }
+    return n;
 }
 
 static inline int __builtin_clzll(unsigned long long x) {
-    return (int)__lzcnt64(x);
+    if (x == 0) return 64;
+    unsigned n = 0;
+    if ((x & 0xFFFFFFFF00000000ULL) == 0) { n += 32; x <<= 32; }
+    if ((x & 0xFFFF000000000000ULL) == 0) { n += 16; x <<= 16; }
+    if ((x & 0xFF00000000000000ULL) == 0) { n += 8;  x <<= 8; }
+    if ((x & 0xF000000000000000ULL) == 0) { n += 4;  x <<= 4; }
+    if ((x & 0xC000000000000000ULL) == 0) { n += 2;  x <<= 2; }
+    if ((x & 0x8000000000000000ULL) == 0) { n += 1; }
+    return n;
 }
 
 #endif

--- a/libvmaf/src/feature/speed.c
+++ b/libvmaf/src/feature/speed.c
@@ -43,6 +43,14 @@
 #endif
 #endif
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef M_E
+#define M_E 2.71828182845904523536
+#endif
+
 typedef double (*compute_cov_kernel_fn)(const float *data_x, const float *data_y,
                                         size_t stride_px, size_t height,
                                         size_t width, double mean_x,

--- a/libvmaf/src/feature/x86/adm_avx2.c
+++ b/libvmaf/src/feature/x86/adm_avx2.c
@@ -822,12 +822,12 @@ void adm_decouple_avx2(AdmBuffer *buf, int w, int h, int stride,
             __m256 od_inv_64 = _mm256_mul_ps(inv_64, _mm256_cvtepi32_ps(od));
             __m256 rst_d_f = _mm256_mul_ps(kd_inv_32768, od_inv_64);
 
-            __m256i gt0_rst_h_f = (__m256i)(_mm256_cmp_ps(rst_h_f, _mm256_setzero_ps(), 14));
-            __m256i lt0_rst_h_f = (__m256i)(_mm256_cmp_ps(rst_h_f, _mm256_setzero_ps(), 1));
-            __m256i gt0_rst_v_f = (__m256i)(_mm256_cmp_ps(rst_v_f, _mm256_setzero_ps(), 14));
-            __m256i lt0_rst_v_f = (__m256i)(_mm256_cmp_ps(rst_v_f, _mm256_setzero_ps(), 1));
-            __m256i gt0_rst_d_f = (__m256i)(_mm256_cmp_ps(rst_d_f, _mm256_setzero_ps(), 14));
-            __m256i lt0_rst_d_f = (__m256i)(_mm256_cmp_ps(rst_d_f, _mm256_setzero_ps(), 1));
+            __m256i gt0_rst_h_f = _mm256_castps_si256(_mm256_cmp_ps(rst_h_f, _mm256_setzero_ps(), 14));
+            __m256i lt0_rst_h_f = _mm256_castps_si256(_mm256_cmp_ps(rst_h_f, _mm256_setzero_ps(), 1));
+            __m256i gt0_rst_v_f = _mm256_castps_si256(_mm256_cmp_ps(rst_v_f, _mm256_setzero_ps(), 14));
+            __m256i lt0_rst_v_f = _mm256_castps_si256(_mm256_cmp_ps(rst_v_f, _mm256_setzero_ps(), 1));
+            __m256i gt0_rst_d_f = _mm256_castps_si256(_mm256_cmp_ps(rst_d_f, _mm256_setzero_ps(), 14));
+            __m256i lt0_rst_d_f = _mm256_castps_si256(_mm256_cmp_ps(rst_d_f, _mm256_setzero_ps(), 1));
 
             __m256i mask_min_max_h = _mm256_or_si256(gt0_rst_h_f, lt0_rst_h_f);
             __m256i mask_min_max_v = _mm256_or_si256(gt0_rst_v_f, lt0_rst_v_f);
@@ -2152,15 +2152,15 @@ float adm_cm_avx2(AdmBuffer *buf, int w, int h, int src_stride, int csf_a_stride
             }
             accum_inner_h_lo_256 = _mm256_add_epi64(accum_inner_h_lo_256, accum_inner_h_hi_256);
             __m128i r2_h = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_h_lo_256), _mm256_extracti128_si256(accum_inner_h_lo_256, 1));
-            int64_t res_h = r2_h[0] + r2_h[1];
+            int64_t res_h = _mm_extract_epi64(r2_h, 0) + _mm_extract_epi64(r2_h, 1);
 
             accum_inner_v_lo_256 = _mm256_add_epi64(accum_inner_v_lo_256, accum_inner_v_hi_256);
             __m128i r2_v = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_v_lo_256), _mm256_extracti128_si256(accum_inner_v_lo_256, 1));
-            int64_t res_v = r2_v[0] + r2_v[1];
+            int64_t res_v = _mm_extract_epi64(r2_v, 0) + _mm_extract_epi64(r2_v, 1);
 
             accum_inner_d_lo_256 = _mm256_add_epi64(accum_inner_d_lo_256, accum_inner_d_hi_256);
             __m128i r2_d = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_d_lo_256), _mm256_extracti128_si256(accum_inner_d_lo_256, 1));
-            int64_t res_d = r2_d[0] + r2_d[1];
+            int64_t res_d = _mm_extract_epi64(r2_d, 0) + _mm_extract_epi64(r2_d, 1);
 
             for (j = end_col_mod6; j < end_col; ++j) {
                 xh = src->band_h[i * src_stride + j] * i_rfactor[0];
@@ -2610,13 +2610,13 @@ float i4_adm_cm_avx2(AdmBuffer *buf, int w, int h, int src_stride, int csf_a_str
             }
 
             __m128i r2_h = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_h_256), _mm256_extracti128_si256(accum_inner_h_256, 1));
-            int64_t res_h = r2_h[0] + r2_h[1];
+            int64_t res_h = _mm_extract_epi64(r2_h, 0) + _mm_extract_epi64(r2_h, 1);
 
             __m128i r2_v = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_v_256), _mm256_extracti128_si256(accum_inner_v_256, 1));
-            int64_t res_v = r2_v[0] + r2_v[1];
+            int64_t res_v = _mm_extract_epi64(r2_v, 0) + _mm_extract_epi64(r2_v, 1);
 
             __m128i r2_d = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_d_256), _mm256_extracti128_si256(accum_inner_d_256, 1));
-            int64_t res_d = r2_d[0] + r2_d[1];
+            int64_t res_d = _mm_extract_epi64(r2_d, 0) + _mm_extract_epi64(r2_d, 1);
 
             for (j = end_col_mod2; j < end_col; ++j)
             {
@@ -3689,15 +3689,15 @@ float adm_csf_den_scale_avx2(const adm_dwt_band_t *src, int w, int h,
 
         accum_inner_h_lo = _mm256_add_epi64(accum_inner_h_lo, accum_inner_h_hi);
         __m128i h_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_h_lo), _mm256_extracti128_si256(accum_inner_h_lo, 1));
-        uint64_t h_r1 = h_r2[0] + h_r2[1];
+        uint64_t h_r1 = _mm_extract_epi64(h_r2, 0) + _mm_extract_epi64(h_r2, 1);
 
         accum_inner_v_lo = _mm256_add_epi64(accum_inner_v_lo, accum_inner_v_hi);
         __m128i v_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_v_lo), _mm256_extracti128_si256(accum_inner_v_lo, 1));
-        uint64_t v_r1 = v_r2[0] + v_r2[1];
+        uint64_t v_r1 = _mm_extract_epi64(v_r2, 0) + _mm_extract_epi64(v_r2, 1);
 
         accum_inner_d_lo = _mm256_add_epi64(accum_inner_d_lo, accum_inner_d_hi);
         __m128i d_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_d_lo), _mm256_extracti128_si256(accum_inner_d_lo, 1));
-        uint64_t d_r1 = d_r2[0] + d_r2[1];
+        uint64_t d_r1 = _mm_extract_epi64(d_r2, 0) + _mm_extract_epi64(d_r2, 1);
 
         for (int j = right_mod_8; j < right; ++j) {
             uint16_t h = (uint16_t)abs(src_h[j]);
@@ -4157,13 +4157,13 @@ float adm_csf_den_s123_avx2(const i4_adm_dwt_band_t *src, int scale, int w, int 
             accum_inner_d_256 = _mm256_add_epi64(accum_inner_d_256, d_cu);
         }
         __m128i h_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_h_256), _mm256_extracti128_si256(accum_inner_h_256, 1));
-        uint64_t h_r1 = h_r2[0] + h_r2[1];
+        uint64_t h_r1 = _mm_extract_epi64(h_r2, 0) + _mm_extract_epi64(h_r2, 1);
 
         __m128i d_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_d_256), _mm256_extracti128_si256(accum_inner_d_256, 1));
-        uint64_t d_r1 = d_r2[0] + d_r2[1];
+        uint64_t d_r1 = _mm_extract_epi64(d_r2, 0) + _mm_extract_epi64(d_r2, 1);
 
         __m128i v_r2 = _mm_add_epi64(_mm256_castsi256_si128(accum_inner_v_256), _mm256_extracti128_si256(accum_inner_v_256, 1));
-        uint64_t v_r1 = v_r2[0] + v_r2[1];
+        uint64_t v_r1 = _mm_extract_epi64(v_r2, 0) + _mm_extract_epi64(v_r2, 1);
 
         for (int j = right_mod_4; j < right; ++j)
         {

--- a/libvmaf/src/feature/x86/adm_avx512.c
+++ b/libvmaf/src/feature/x86/adm_avx512.c
@@ -1807,17 +1807,17 @@ float adm_cm_avx512(AdmBuffer *buf, int w, int h, int src_stride, int csf_a_stri
             accum_inner_h_lo_512 = _mm512_add_epi64(accum_inner_h_lo_512, accum_inner_h_hi_512);
             __m256i r4_h = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_h_lo_512), _mm512_extracti64x4_epi64(accum_inner_h_lo_512, 1));
             __m128i r2_h = _mm_add_epi64(_mm256_castsi256_si128(r4_h), _mm256_extracti128_si256(r4_h, 1));
-            int64_t res_h = r2_h[0] + r2_h[1];
+            int64_t res_h = _mm_extract_epi64(r2_h, 0) + _mm_extract_epi64(r2_h, 1);
 
             accum_inner_v_lo_512 = _mm512_add_epi64(accum_inner_v_lo_512, accum_inner_v_hi_512);
             __m256i r4_v = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_v_lo_512), _mm512_extracti64x4_epi64(accum_inner_v_lo_512, 1));
             __m128i r2_v = _mm_add_epi64(_mm256_castsi256_si128(r4_v), _mm256_extracti128_si256(r4_v, 1));
-            int64_t res_v = r2_v[0] + r2_v[1];
+            int64_t res_v = _mm_extract_epi64(r2_v, 0) + _mm_extract_epi64(r2_v, 1);
 
             accum_inner_d_lo_512 = _mm512_add_epi64(accum_inner_d_lo_512, accum_inner_d_hi_512);
             __m256i r4_d = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_d_lo_512), _mm512_extracti64x4_epi64(accum_inner_d_lo_512, 1));
             __m128i r2_d = _mm_add_epi64(_mm256_castsi256_si128(r4_d), _mm256_extracti128_si256(r4_d, 1));
-            int64_t res_d = r2_d[0] + r2_d[1];
+            int64_t res_d = _mm_extract_epi64(r2_d, 0) + _mm_extract_epi64(r2_d, 1);
 
             for (j = end_col_mod14; j < end_col; ++j) {
                 xh = src->band_h[i * src_stride + j] * i_rfactor[0];
@@ -2254,15 +2254,15 @@ float i4_adm_cm_avx512(AdmBuffer *buf, int w, int h, int src_stride, int csf_a_s
 
             __m256i r4_h = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_h_512), _mm512_extracti64x4_epi64(accum_inner_h_512, 1));
             __m128i r2_h = _mm_add_epi64(_mm256_castsi256_si128(r4_h), _mm256_extracti128_si256(r4_h, 1));
-            int64_t res_h = r2_h[0] + r2_h[1];
+            int64_t res_h = _mm_extract_epi64(r2_h, 0) + _mm_extract_epi64(r2_h, 1);
 
             __m256i r4_v = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_v_512), _mm512_extracti64x4_epi64(accum_inner_v_512, 1));
             __m128i r2_v = _mm_add_epi64(_mm256_castsi256_si128(r4_v), _mm256_extracti128_si256(r4_v, 1));
-            int64_t res_v = r2_v[0] + r2_v[1];
+            int64_t res_v = _mm_extract_epi64(r2_v, 0) + _mm_extract_epi64(r2_v, 1);
 
             __m256i r4_d = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_d_512), _mm512_extracti64x4_epi64(accum_inner_d_512, 1));
             __m128i r2_d = _mm_add_epi64(_mm256_castsi256_si128(r4_d), _mm256_extracti128_si256(r4_d, 1));
-            int64_t res_d = r2_d[0] + r2_d[1];
+            int64_t res_d = _mm_extract_epi64(r2_d, 0) + _mm_extract_epi64(r2_d, 1);
 
             for (j = end_col_mod6; j < end_col; ++j)
             {
@@ -4006,17 +4006,17 @@ float adm_csf_den_scale_avx512(const adm_dwt_band_t *src, int w, int h,
         accum_inner_h_lo = _mm512_add_epi64(accum_inner_h_lo, accum_inner_h_hi);
         __m256i h_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_h_lo), _mm512_extracti64x4_epi64(accum_inner_h_lo, 1));
         __m128i h_r2 = _mm_add_epi64(_mm256_castsi256_si128(h_r4), _mm256_extracti64x2_epi64(h_r4, 1));
-        uint64_t h_r1 = h_r2[0] + h_r2[1];
+        uint64_t h_r1 = _mm_extract_epi64(h_r2, 0) + _mm_extract_epi64(h_r2, 1);
 
         accum_inner_v_lo = _mm512_add_epi64(accum_inner_v_lo, accum_inner_v_hi);
         __m256i v_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_v_lo), _mm512_extracti64x4_epi64(accum_inner_v_lo, 1));
         __m128i v_r2 = _mm_add_epi64(_mm256_castsi256_si128(v_r4), _mm256_extracti64x2_epi64(v_r4, 1));
-        uint64_t v_r1 = v_r2[0] + v_r2[1];
+        uint64_t v_r1 = _mm_extract_epi64(v_r2, 0) + _mm_extract_epi64(v_r2, 1);
 
         accum_inner_d_lo = _mm512_add_epi64(accum_inner_d_lo, accum_inner_d_hi);
         __m256i d_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_d_lo), _mm512_extracti64x4_epi64(accum_inner_d_lo, 1));
         __m128i d_r2 = _mm_add_epi64(_mm256_castsi256_si128(d_r4), _mm256_extracti64x2_epi64(d_r4, 1));
-        uint64_t d_r1 = d_r2[0] + d_r2[1];
+        uint64_t d_r1 = _mm_extract_epi64(d_r2, 0) + _mm_extract_epi64(d_r2, 1);
 
         for (int j = right_mod_16; j < right; ++j) {
             uint16_t h = (uint16_t)abs(src_h[j]);
@@ -4147,15 +4147,15 @@ float adm_csf_den_s123_avx512(const i4_adm_dwt_band_t *src, int scale, int w, in
         }
         __m256i h_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_h_512), _mm512_extracti64x4_epi64(accum_inner_h_512, 1));
         __m128i h_r2 = _mm_add_epi64(_mm256_castsi256_si128(h_r4), _mm256_extracti64x2_epi64(h_r4, 1));
-        uint64_t h_r1 = h_r2[0] + h_r2[1];
+        uint64_t h_r1 = _mm_extract_epi64(h_r2, 0) + _mm_extract_epi64(h_r2, 1);
 
         __m256i d_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_d_512), _mm512_extracti64x4_epi64(accum_inner_d_512, 1));
         __m128i d_r2 = _mm_add_epi64(_mm256_castsi256_si128(d_r4), _mm256_extracti64x2_epi64(d_r4, 1));
-        uint64_t d_r1 = d_r2[0] + d_r2[1];
+        uint64_t d_r1 = _mm_extract_epi64(d_r2, 0) + _mm_extract_epi64(d_r2, 1);
 
         __m256i v_r4 = _mm256_add_epi64(_mm512_castsi512_si256(accum_inner_v_512), _mm512_extracti64x4_epi64(accum_inner_v_512, 1));
         __m128i v_r2 = _mm_add_epi64(_mm256_castsi256_si128(v_r4), _mm256_extracti64x2_epi64(v_r4, 1));
-        uint64_t v_r1 = v_r2[0] + v_r2[1];
+        uint64_t v_r1 = _mm_extract_epi64(v_r2, 0) + _mm_extract_epi64(v_r2, 1);
 
         for (int j = right_mod_8; j < right; ++j)
         {

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -1093,7 +1093,7 @@ int vmaf_score_pooled_model_collection(VmafContext *vmaf,
     const char *suffix_stddev = "_stddev";
     const size_t name_sz =
         strlen(model_collection->name) + strlen(suffix_lo) + 1;
-    char name[name_sz];
+    char *name = (char *)malloc(name_sz * sizeof(char));
     memset(name, 0, name_sz);
 
     snprintf(name, name_sz, "%s%s", model_collection->name, suffix_bagging);
@@ -1115,7 +1115,7 @@ int vmaf_score_pooled_model_collection(VmafContext *vmaf,
     err |= vmaf_feature_score_pooled(vmaf, name, pool_method,
                                      &score->bootstrap.ci.p95.hi,
                                      index_low, index_high);
-
+    free(name);
     return err;
 }
 

--- a/libvmaf/src/predict.c
+++ b/libvmaf/src/predict.c
@@ -444,7 +444,7 @@ static int vmaf_bootstrap_predict_score_at_index(
                                         VmafModelCollectionScore *score)
 {
     int err = 0;
-    double scores[model_collection->cnt];
+    double *scores = (double *)malloc(model_collection->cnt * sizeof(double));
 
     for (unsigned i = 0; i < model_collection->cnt; i++) {
         // mean, stddev, etc. are calculated on untransformed/unclipped scores
@@ -456,7 +456,10 @@ static int vmaf_bootstrap_predict_score_at_index(
                                           feature_collector, index,
                                           &scores[i], false,
                                           false, flags);
-        if (err) return err;
+        if (err) {
+            free(scores);
+            return err;
+        }
 
         // do not override the model's transform/clip behavior
         // write the scores to the feature collector
@@ -464,7 +467,10 @@ static int vmaf_bootstrap_predict_score_at_index(
         err = vmaf_predict_score_at_index(model_collection->model[i],
                                           feature_collector, index,
                                           &score, true, false, 0);
-        if (err) return err;
+        if (err) {
+            free(scores);
+            return err;
+        }
     }
 
     score->type = VMAF_MODEL_COLLECTION_SCORE_BOOTSTRAP;
@@ -510,7 +516,7 @@ static int vmaf_bootstrap_predict_score_at_index(
     const char *suffix_stddev = "_stddev";
     const size_t name_sz =
         strlen(model_collection->name) + strlen(suffix_lo) + 1;
-    char name[name_sz];
+    char *name = (char *)malloc(name_sz * sizeof(char));
     memset(name, 0, name_sz);
 
     snprintf(name, name_sz, "%s%s", model_collection->name, suffix_bagging);
@@ -529,6 +535,8 @@ static int vmaf_bootstrap_predict_score_at_index(
     err |= vmaf_feature_collector_append(feature_collector, name,
                                          score->bootstrap.ci.p95.hi,
                                          index);
+    free(name);
+    free(scores);
     return err;
 }
 

--- a/libvmaf/src/read_json_model.c
+++ b/libvmaf/src/read_json_model.c
@@ -501,10 +501,10 @@ static int model_collection_parse(json_stream *s, VmafModel **model,
     if (!c.name) return -ENOMEM;
 
     const size_t cfg_name_sz = strlen(name) + 5 + 1;
-    char cfg_name[cfg_name_sz];
+    char *cfg_name = (char *)malloc(cfg_name_sz);
 
     const size_t generated_key_sz = 4 + 1;
-    char generated_key[generated_key_sz];
+    char *generated_key = (char *)malloc(generated_key_sz);
 
     unsigned i = 0;
     while (json_peek(s) != JSON_OBJECT_END && !json_get_error(s)) {
@@ -535,6 +535,8 @@ static int model_collection_parse(json_stream *s, VmafModel **model,
     }
 
     free((char*)name);
+    free(cfg_name);
+    free(generated_key);
     if (!(*model_collection)) return -EINVAL;
     return err;
 }

--- a/libvmaf/tools/vmaf.c
+++ b/libvmaf/tools/vmaf.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
     model_collection = malloc(model_sz);
     memset(model_collection, 0, model_collection_sz);
 
-    const char *model_collection_label[c.model_cnt];
+    const char **model_collection_label = malloc(c.model_cnt * sizeof(char *));
     unsigned model_collection_cnt = 0;
 
     for (unsigned i = 0; i < c.model_cnt; i++) {
@@ -448,6 +448,7 @@ int main(int argc, char *argv[])
     for (unsigned i = 0; i < model_collection_cnt; i++)
         vmaf_model_collection_destroy(model_collection[i]);
     free(model_collection);
+    free(model_collection_label);
 
     video_input_close(&vid_ref);
     video_input_close(&vid_dist);


### PR DESCRIPTION
Hey there, 

I just collected a few changes required when you want to compile for/on various platforms and OSes. 
E.g. MSVC would not compile the avx accelerated code with plain casts and `[]` access in ` __m128i`s. 

The changes do not change the behavior of the code itself, but make life simpler when (cross) compiling libvmaf. 
