### PR TITLE
libvmaf/feature: enable speed_chroma/speed_temporal without enable_float

### DIFF
--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -38,9 +38,9 @@ extern VmafFeatureExtractor vmaf_fex_float_adm;
 extern VmafFeatureExtractor vmaf_fex_float_motion;
 extern VmafFeatureExtractor vmaf_fex_float_moment;
 extern VmafFeatureExtractor vmaf_fex_float_vif;
+#endif
 extern VmafFeatureExtractor vmaf_fex_speed_chroma;
 extern VmafFeatureExtractor vmaf_fex_speed_temporal;
-#endif
 extern VmafFeatureExtractor vmaf_fex_float_ssim;
 extern VmafFeatureExtractor vmaf_fex_float_ms_ssim;
 extern VmafFeatureExtractor vmaf_fex_ciede;
@@ -65,9 +65,9 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_float_vif,
     &vmaf_fex_float_motion,
     &vmaf_fex_float_moment,
+#endif
     &vmaf_fex_speed_chroma,
     &vmaf_fex_speed_temporal,
-#endif
     &vmaf_fex_float_ms_ssim,
     &vmaf_fex_float_ssim,
     &vmaf_fex_ciede,


### PR DESCRIPTION
Fixes: #1556, #1547.