### PR TITLE
cuda: add psnr_cuda, ssim_cuda and ciede_cuda feature extractors

### DIFF
--- a/libvmaf/src/feature/cuda/ciede/ciede.cu
+++ b/libvmaf/src/feature/cuda/ciede/ciede.cu
@@ -1,0 +1,331 @@
+/**
+ *
+ *  Copyright 2026 Bardie Høgh Joensen
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+// CUDA port of feature/ciede.c, which is in large part a port of the
+// ciede2000 implementation from av-metrics
+// (https://github.com/rust-av/av-metrics) with the following license:
+
+/*
+The MIT License (MIT)
+Copyright (c) 2019 Joshua Holmer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+ * Unlike the psnr_cuda/ssim_cuda kernels, this port is NOT bit-exact with the
+ * CPU extractor: ciede is dominated by libm transcendentals (pow/atan2/sin/
+ * cos/exp), which differ between glibc and CUDA in the low bits regardless of
+ * precision, and double-precision throughput is 1/64 rate on consumer GPUs.
+ * The device math therefore runs in float32 — the CPU reference truncates
+ * every intermediate to float anyway — and parity with the CPU extractor is
+ * validated to a per-frame score tolerance (|delta| <= 1e-3) instead of
+ * bit-exactness. The per-block partial sums and the final pooling stay in
+ * double, summed in a deterministic order.
+ */
+
+#include "cuda_helper.cuh"
+
+#include "common.h"
+
+#define M_PI_F 3.14159265358979323846f
+
+typedef struct LABColorf {
+    float l;
+    float a;
+    float b;
+} LABColorf;
+
+__device__ __forceinline__ float get_h_prime(const float x, const float y)
+{
+    if ((x == 0.0f) && (y == 0.0f))
+        return 0.0f;
+    float hue_angle = atan2f(x, y);
+    if (hue_angle < 0.0f)
+        hue_angle += 2.f * M_PI_F;
+    return hue_angle;
+}
+
+__device__ __forceinline__ float get_delta_h_prime(const float c1,
+        const float c2, const float h_prime_1, const float h_prime_2)
+{
+    if ((c1 == 0.0f) || (c2 == 0.0f))
+        return 0.0f;
+    if (fabsf(h_prime_1 - h_prime_2) <= M_PI_F)
+        return h_prime_2 - h_prime_1;
+    if (h_prime_2 <= h_prime_1)
+        return h_prime_2 - h_prime_1 + 2.f * M_PI_F;
+    else
+        return h_prime_2 - h_prime_1 - 2.f * M_PI_F;
+}
+
+__device__ __forceinline__ float get_upcase_h_bar_prime(const float h_prime_1,
+        const float h_prime_2)
+{
+    return fabsf(h_prime_1 - h_prime_2) > M_PI_F ?
+        (h_prime_1 + h_prime_2 + 2.0f * M_PI_F) / 2.0f :
+        (h_prime_1 + h_prime_2) / 2.0f;
+}
+
+__device__ __forceinline__ float get_upcase_t(const float upcase_h_bar_prime)
+{
+    return 1.0f -
+           0.17f * cosf(upcase_h_bar_prime - M_PI_F / 6.0f) +
+           0.24f * cosf(2.0f * upcase_h_bar_prime) +
+           0.32f * cosf(3.0f * upcase_h_bar_prime + M_PI_F / 30.0f) -
+           0.20f * cosf(4.0f * upcase_h_bar_prime - 7.0f * M_PI_F / 20.0f);
+}
+
+__device__ __forceinline__ float get_r_sub_t(const float c_bar_prime,
+        const float upcase_h_bar_prime)
+{
+    const float degrees =
+        (upcase_h_bar_prime * (180.0f / M_PI_F) - 275.0f) * (1.0f / 25.0f);
+    const float c7 = powf(c_bar_prime, 7);
+
+    return -2.0f *
+          sqrtf(c7 / (c7 + powf(25.f, 7))) *
+          sinf((60.0f * expf(-(degrees * degrees))) * (M_PI_F / 180.0f));
+}
+
+__device__ float ciede2000(LABColorf color_1, LABColorf color_2)
+{
+    // default ksub from feature/ciede.c: l = 0.65, c = 1.0, h = 4.0
+    const float ksub_l = 0.65f, ksub_c = 1.0f, ksub_h = 4.0f;
+
+    const float delta_l_prime = color_2.l - color_1.l;
+    const float l_bar = (color_1.l + color_2.l) / 2;
+    const float c1 = sqrtf(color_1.a * color_1.a + color_1.b * color_1.b);
+    const float c2 = sqrtf(color_2.a * color_2.a + color_2.b * color_2.b);
+    const float c_bar = (c1 + c2) / 2;
+    const float c_bar7 = powf(c_bar, 7);
+    const float chroma_shift = 1 - sqrtf(c_bar7 / (c_bar7 + powf(25.f, 7)));
+    const float a_prime_1 = color_1.a + (color_1.a / 2) * chroma_shift;
+    const float a_prime_2 = color_2.a + (color_2.a / 2) * chroma_shift;
+    const float c_prime_1 =
+        sqrtf(a_prime_1 * a_prime_1 + color_1.b * color_1.b);
+    const float c_prime_2 =
+        sqrtf(a_prime_2 * a_prime_2 + color_2.b * color_2.b);
+    const float c_bar_prime = (c_prime_1 + c_prime_2) / 2;
+    const float delta_c_prime = c_prime_2 - c_prime_1;
+    const float s_sub_l = 1.f + ((0.015f * ((l_bar - 50) * (l_bar - 50))) /
+                          sqrtf(20 + ((l_bar - 50) * (l_bar - 50))));
+    const float s_sub_c = 1.f + 0.045f * c_bar_prime;
+    const float h_prime_1 = get_h_prime(color_1.b, a_prime_1);
+    const float h_prime_2 = get_h_prime(color_2.b, a_prime_2);
+    const float delta_h_prime = get_delta_h_prime(c1, c2, h_prime_1, h_prime_2);
+    const float delta_upcase_h_prime =
+            2.0f * sqrtf(c_prime_1 * c_prime_2) * sinf(delta_h_prime / 2.0f);
+    const float upcase_h_bar_prime =
+        get_upcase_h_bar_prime(h_prime_1, h_prime_2);
+    const float upcase_t = get_upcase_t(upcase_h_bar_prime);
+    const float s_sub_upcase_h = 1.0f + 0.015f * c_bar_prime * upcase_t;
+    const float r_sub_t = get_r_sub_t(c_bar_prime, upcase_h_bar_prime);
+    const float lightness = delta_l_prime / (ksub_l * s_sub_l);
+    const float chroma  = delta_c_prime / (ksub_c * s_sub_c);
+    const float hue = delta_upcase_h_prime / (ksub_h * s_sub_upcase_h);
+
+    return sqrtf(lightness * lightness + chroma * chroma +
+                 hue * hue + r_sub_t * chroma * hue);
+}
+
+__device__ __forceinline__ float rgb_to_xyz_map(float c)
+{
+    if (c > 10.f / 255.f) {
+        const float A = 0.055f;
+        const float D = 1.0f / 1.055f;
+        return powf((c + A) * D, 2.4f);
+    } else {
+        const float D = 1.0f / 12.92f;
+        return (c * D);
+    }
+}
+
+__device__ __forceinline__ float xyz_to_lab_map(float c)
+{
+    const float KAPPA = 24389.0f / 27.0f;
+    const float EPSILON = 216.0f / 24389.0f;
+
+    if (c > EPSILON) {
+        return powf(c, 1.0f / 3.0f);
+    } else {
+        return (KAPPA * c + 16.0f) * (1.0f / 116.0f);
+    }
+}
+
+__device__ LABColorf get_lab_color(float y, float u, float v, unsigned bpc)
+{
+    const float scale = 1 << (bpc - 8);
+
+    y = (y - 16.f  * scale) * (1.f / (219.f * scale));
+    u = (u - 128.f * scale) * (1.f / (224.f * scale));
+    v = (v - 128.f * scale) * (1.f / (224.f * scale));
+
+    // Assumes BT.709
+    float r = y + 1.28033f * v;
+    float g = y - 0.21482f * u - 0.38059f * v;
+    float b = y + 2.12798f * u;
+
+    r = rgb_to_xyz_map(r);
+    g = rgb_to_xyz_map(g);
+    b = rgb_to_xyz_map(b);
+
+    float x = r * 0.4124564390896921f + g * 0.357576077643909f +
+              b * 0.18043748326639894f;
+          y = r * 0.21267285140562248f + g * 0.715152155287818f +
+              b * 0.07217499330655958f;
+    float z = r * 0.019333895582329317f + g * 0.119192025881303f +
+              b * 0.9503040785363677f;
+
+    x = xyz_to_lab_map(x * (1.0f / 0.95047f));
+    y = xyz_to_lab_map(y);
+    z = xyz_to_lab_map(z * (1.0f / 1.08883f));
+
+    LABColorf lab_color = {
+        (116.0f * y) - 16.0f,
+        500.0f * (x - y),
+        200.0f * (y - z),
+    };
+
+    return lab_color;
+}
+
+// Block-reduce per-thread ΔE (double partials) and write one partial per
+// block; the host sums the partials sequentially so pooling is deterministic
+__device__ __forceinline__ void block_reduce_de(double de,
+        VmafCudaBuffer partials)
+{
+    __shared__ double sh[256];
+
+    const int t = threadIdx.y * blockDim.x + threadIdx.x;
+    sh[t] = de;
+    __syncthreads();
+    for (int stride = 128; stride > 0; stride >>= 1) {
+        if (t < stride)
+            sh[t] += sh[t + stride];
+        __syncthreads();
+    }
+    if (t == 0)
+        reinterpret_cast<double*>(partials.data)[
+            blockIdx.y * gridDim.x + blockIdx.x] = sh[0];
+}
+
+// scale_chroma_planes in feature/ciede.c halves the column index when the
+// format is vertically subsampled and advances the source row every second
+// output row when horizontally subsampled — replicated as-is for parity
+__device__ __forceinline__ int chroma_col(int j, int ss_ver)
+{
+    return ss_ver ? j / 2 : j;
+}
+
+__device__ __forceinline__ int chroma_row(int i, int ss_hor)
+{
+    return ss_hor ? i / 2 : i;
+}
+
+extern "C" {
+
+__global__ void ciede_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
+        VmafCudaBuffer partials, unsigned width, unsigned height,
+        int ss_hor, int ss_ver)
+{
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    const int i = blockIdx.y * blockDim.y + threadIdx.y;
+
+    double de00 = 0.0;
+    if (j < width && i < height) {
+        const int cj = chroma_col(j, ss_ver);
+        const int ci = chroma_row(i, ss_hor);
+
+        const float r_y = (reinterpret_cast<const uint8_t*>(ref.data[0]) +
+                (size_t)i * ref.stride[0])[j];
+        const float r_u = (reinterpret_cast<const uint8_t*>(ref.data[1]) +
+                (size_t)ci * ref.stride[1])[cj];
+        const float r_v = (reinterpret_cast<const uint8_t*>(ref.data[2]) +
+                (size_t)ci * ref.stride[2])[cj];
+        const float d_y = (reinterpret_cast<const uint8_t*>(dis.data[0]) +
+                (size_t)i * dis.stride[0])[j];
+        const float d_u = (reinterpret_cast<const uint8_t*>(dis.data[1]) +
+                (size_t)ci * dis.stride[1])[cj];
+        const float d_v = (reinterpret_cast<const uint8_t*>(dis.data[2]) +
+                (size_t)ci * dis.stride[2])[cj];
+
+        const LABColorf color_1 = get_lab_color(r_y, r_u, r_v, 8);
+        const LABColorf color_2 = get_lab_color(d_y, d_u, d_v, 8);
+        de00 = ciede2000(color_1, color_2);
+    }
+
+    block_reduce_de(de00, partials);
+}
+
+__global__ void ciede_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
+        VmafCudaBuffer partials, unsigned width, unsigned height,
+        int ss_hor, int ss_ver)
+{
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    const int i = blockIdx.y * blockDim.y + threadIdx.y;
+
+    double de00 = 0.0;
+    if (j < width && i < height) {
+        const int cj = chroma_col(j, ss_ver);
+        const int ci = chroma_row(i, ss_hor);
+
+        const float r_y = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(ref.data[0]) +
+                (size_t)i * ref.stride[0])[j];
+        const float r_u = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(ref.data[1]) +
+                (size_t)ci * ref.stride[1])[cj];
+        const float r_v = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(ref.data[2]) +
+                (size_t)ci * ref.stride[2])[cj];
+        const float d_y = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(dis.data[0]) +
+                (size_t)i * dis.stride[0])[j];
+        const float d_u = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(dis.data[1]) +
+                (size_t)ci * dis.stride[1])[cj];
+        const float d_v = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(dis.data[2]) +
+                (size_t)ci * dis.stride[2])[cj];
+
+        const LABColorf color_1 = get_lab_color(r_y, r_u, r_v, ref.bpc);
+        const LABColorf color_2 = get_lab_color(d_y, d_u, d_v, dis.bpc);
+        de00 = ciede2000(color_1, color_2);
+    }
+
+    block_reduce_de(de00, partials);
+}
+
+}

--- a/libvmaf/src/feature/cuda/ciede_cuda.c
+++ b/libvmaf/src/feature/cuda/ciede_cuda.c
@@ -1,0 +1,257 @@
+/**
+ *
+ *  Copyright 2026 Bardie Høgh Joensen
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <errno.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "feature_collector.h"
+#include "feature_extractor.h"
+#include "cuda/ciede_cuda.h"
+#include "picture.h"
+#include "picture_cuda.h"
+#include "cuda_helper.cuh"
+
+typedef struct CiedeStateCuda {
+    CUevent finished, consumed;
+    CUevent slot_done[2];
+    CUfunction funcbpc8, funcbpc16;
+    CUstream str, host_stream;
+    VmafCudaBuffer *partials;
+    double *partials_host;
+    void *write_score_parameters;
+    unsigned w, h;
+    unsigned bpc;
+    unsigned n_partials;
+    int ss_hor, ss_ver;
+} CiedeStateCuda;
+
+typedef struct write_score_parameters_ciede {
+    VmafFeatureCollector *feature_collector;
+    CiedeStateCuda *s;
+    const double *partials;
+    unsigned index;
+} write_score_parameters_ciede;
+
+static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                         unsigned bpc, unsigned w, unsigned h)
+{
+    CiedeStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    if (pix_fmt == VMAF_PIX_FMT_YUV400P)
+        return -EINVAL;
+    switch (bpc) {
+    case 8:
+    case 10:
+    case 12:
+    case 16:
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
+    // the work stream is deliberately legacy-blocking: producers like the
+    // ffmpeg libvmaf_cuda filter fill device pictures with synchronous-API
+    // copies that are queued on the legacy NULL stream (device-to-device
+    // memcpy does not block the host), and only blocking-flavor streams are
+    // implicitly ordered after NULL-stream work. Other extractors' created
+    // streams are unaffected, so kernel overlap with them is preserved.
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_DEFAULT, 0));
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->consumed, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[0], CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[1], CU_EVENT_DEFAULT));
+
+    CUmodule module;
+    CHECK_CUDA(cu_f, cuModuleLoadData(&module, ciede_ptx));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->funcbpc8, module, "ciede_kernel_8bpc"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->funcbpc16, module, "ciede_kernel_16bpc"));
+
+    CHECK_CUDA(cu_f, cuCtxPopCurrent(NULL));
+
+    s->w = w;
+    s->h = h;
+    s->bpc = bpc;
+    s->ss_hor = pix_fmt != VMAF_PIX_FMT_YUV444P;
+    s->ss_ver = pix_fmt == VMAF_PIX_FMT_YUV420P;
+    s->n_partials = DIV_ROUND_UP(w, 16) * DIV_ROUND_UP(h, 16);
+
+    int ret = 0;
+
+    // two write_score slots + two pinned readback slots so frame i+1 never
+    // has to wait for frame i's host callback (see slot_done in extract)
+    s->write_score_parameters = malloc(sizeof(write_score_parameters_ciede) * 2);
+    if (!s->write_score_parameters) return -ENOMEM;
+    for (unsigned i = 0; i < 2; i++)
+        ((write_score_parameters_ciede*)s->write_score_parameters)[i].s = s;
+
+    ret |= vmaf_cuda_buffer_alloc(fex->cu_state, &s->partials,
+                                  sizeof(double) * s->n_partials);
+    ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->partials_host,
+                                       sizeof(double) * s->n_partials * 2);
+    if (ret) return -ENOMEM;
+
+    return 0;
+}
+
+static int write_scores(write_score_parameters_ciede *params)
+{
+    CiedeStateCuda *s = params->s;
+    VmafFeatureCollector *feature_collector = params->feature_collector;
+
+    // sequential sum over block partials keeps the result deterministic
+    double de00_sum = 0.;
+    for (unsigned b = 0; b < s->n_partials; b++)
+        de00_sum += params->partials[b];
+
+    // identical frames give de00_sum == 0 and score +inf, like the CPU fex
+    const double score = 45. - 20. *
+                         log10(de00_sum / ((double)s->w * s->h));
+    return vmaf_feature_collector_append(feature_collector, "ciede2000", score,
+                                         params->index);
+}
+
+static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
+                            VmafPicture *ref_pic_90, VmafPicture *dist_pic,
+                            VmafPicture *dist_pic_90, unsigned index,
+                            VmafFeatureCollector *feature_collector)
+{
+    CiedeStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
+
+    // two slots: wait for frame index-2's host callback (effectively always
+    // complete) instead of stalling on the whole previous frame's work
+    const unsigned slot = index & 1;
+    CHECK_CUDA(cu_f, cuEventSynchronize(s->slot_done[slot]));
+
+    // kernels run on the extractor's own stream so they overlap with other
+    // extractors' work on the picture streams; wait for both uploads first
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
+                vmaf_cuda_picture_get_ready_event(ref_pic),
+                CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
+                vmaf_cuda_picture_get_ready_event(dist_pic),
+                CU_EVENT_WAIT_DEFAULT));
+
+    {
+        unsigned width = s->w, height = s->h;
+        int ss_hor = s->ss_hor, ss_ver = s->ss_ver;
+        void *kernel_params[] = {
+            (void*) ref_pic, (void*) dist_pic, (void*) s->partials,
+            &width, &height, &ss_hor, &ss_ver,
+        };
+        const CUfunction func =
+            (ref_pic->bpc == 8) ? s->funcbpc8 : s->funcbpc16;
+        CHECK_CUDA(cu_f, cuLaunchKernel(func,
+                    DIV_ROUND_UP(width, 16), DIV_ROUND_UP(height, 16), 1,
+                    16, 16, 1, 0, s->str, kernel_params, NULL));
+    }
+
+    // lifetime handshake: the pool recycles a picture once the `finished`
+    // event its own stream records (after the fex loop) has completed, so
+    // make both picture streams wait for our reads
+    CHECK_CUDA(cu_f, cuEventRecord(s->consumed, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(ref_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(dist_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
+
+    // Download block partials into this slot's readback segment
+    double *partials_host = s->partials_host + slot * s->n_partials;
+    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(partials_host, s->partials->data,
+                sizeof(double) * s->n_partials, s->str));
+    CHECK_CUDA(cu_f, cuEventRecord(s->finished, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->host_stream, s->finished,
+                CU_EVENT_WAIT_DEFAULT));
+
+    write_score_parameters_ciede *params =
+        &((write_score_parameters_ciede*)s->write_score_parameters)[slot];
+    params->feature_collector = feature_collector;
+    params->partials = partials_host;
+    params->index = index;
+    CHECK_CUDA(cu_f, cuLaunchHostFunc(s->host_stream, (CUhostFn*)write_scores,
+                params));
+    CHECK_CUDA(cu_f, cuEventRecord(s->slot_done[slot], s->host_stream));
+
+    return 0;
+}
+
+static int flush_fex_cuda(VmafFeatureExtractor *fex,
+                          VmafFeatureCollector *feature_collector)
+{
+    (void)feature_collector;
+    CiedeStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    // drain the pending write_scores host callback so the final frame's
+    // score is in the collector before anything reads it
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    return 1;
+}
+
+static int close_fex_cuda(VmafFeatureExtractor *fex)
+{
+    CiedeStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->finished));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->consumed));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[0]));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[1]));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->str));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->host_stream));
+
+    int ret = 0;
+    if (s->partials) {
+        ret |= vmaf_cuda_buffer_free(fex->cu_state, s->partials);
+        free(s->partials);
+    }
+    if (s->partials_host)
+        ret |= vmaf_cuda_buffer_host_free(fex->cu_state, s->partials_host);
+    if (s->write_score_parameters)
+        free(s->write_score_parameters);
+
+    return ret;
+}
+
+static const char *provided_features[] = {
+    "ciede2000",
+    NULL
+};
+
+VmafFeatureExtractor vmaf_fex_ciede_cuda = {
+    .name = "ciede_cuda",
+    .init = init_fex_cuda,
+    .extract = extract_fex_cuda,
+    .flush = flush_fex_cuda,
+    .close = close_fex_cuda,
+    .priv_size = sizeof(CiedeStateCuda),
+    .provided_features = provided_features,
+    .flags = VMAF_FEATURE_EXTRACTOR_CUDA | VMAF_FEATURE_EXTRACTOR_CUDA_CHROMA,
+};

--- a/libvmaf/src/feature/cuda/ciede_cuda.h
+++ b/libvmaf/src/feature/cuda/ciede_cuda.h
@@ -1,0 +1,26 @@
+/**
+ *
+ *  Copyright 2026 Bardie Høgh Joensen
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef FEATURE_CIEDE_CUDA_H_
+#define FEATURE_CIEDE_CUDA_H_
+
+#include <stdint.h>
+#include "common.h"
+
+extern const unsigned char ciede_ptx[];
+#endif /* _FEATURE_CIEDE_CUDA_H_ */

--- a/libvmaf/src/feature/cuda/float_ssim/ssim.cu
+++ b/libvmaf/src/feature/cuda/float_ssim/ssim.cu
@@ -1,0 +1,241 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/*
+ * GPU port of the float_ssim feature extractor (feature/ssim.c + feature/iqa).
+ *
+ * The kernels below replicate the iqa reference operation-for-operation so
+ * per-pixel intermediates match the CPU extractor to float precision:
+ *   - decimation samples at (x*factor, y*factor) with a box kernel and
+ *     symmetric boundary mirroring (iqa/decimate.c, _iqa_filter_pixel)
+ *   - the 11-tap separable Gaussian runs in valid mode (output shrinks by
+ *     kernel-1) with double accumulation per 1-D pass and a float round
+ *     in between, exactly like _iqa_convolve with IQA_CONVOLVE_1D
+ *   - per-pixel l/c/s uses the same float/double mixing as _iqa_ssim;
+ *     float-typed reference operations use explicit __f*_rn intrinsics so
+ *     nvcc cannot contract them into fma with different rounding
+ * The frame mean is a per-block tree reduction; the block partials are
+ * summed sequentially on the host, so results are deterministic run-to-run.
+ */
+
+#include "cuda_helper.cuh"
+
+#include "common.h"
+
+__constant__ float gaussian_k[11] = {
+    0.001028f, 0.007599f, 0.036001f, 0.109361f, 0.213006f, 0.266012f,
+    0.213006f, 0.109361f, 0.036001f, 0.007599f, 0.001028f,
+};
+
+// Mirrors an idx along its valid [0, sup) range like iqa's KBND_SYMMETRIC
+__device__ __forceinline__ int mirror_sym(int idx, const int sup)
+{
+    if (idx < 0) idx = -1 - idx;
+    else if (idx >= sup) idx = (sup - (idx - sup)) - 1;
+    return idx;
+}
+
+extern "C" {
+
+__global__ void ssim_normalize_8bpc(const VmafPicture pic, VmafCudaBuffer out,
+        unsigned w, unsigned h)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= w || y >= h) return;
+
+    const uint8_t v = (reinterpret_cast<const uint8_t*>(pic.data[0]) +
+            y * pic.stride[0])[x];
+    reinterpret_cast<float*>(out.data)[y * w + x] = static_cast<float>(v);
+}
+
+__global__ void ssim_normalize_16bpc(const VmafPicture pic, VmafCudaBuffer out,
+        unsigned w, unsigned h, float scaler)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= w || y >= h) return;
+
+    const uint16_t v = reinterpret_cast<const uint16_t*>(
+            reinterpret_cast<const uint8_t*>(pic.data[0]) +
+            y * pic.stride[0])[x];
+    // picture_copy: (float)data / scaler; scaler is a power of two, exact
+    reinterpret_cast<float*>(out.data)[y * w + x] =
+        __fdiv_rn(static_cast<float>(v), scaler);
+}
+
+// iqa/decimate.c: out[y*sw+x] = box(in, x*factor, y*factor), symmetric bounds
+__global__ void ssim_decimate(const VmafCudaBuffer in, VmafCudaBuffer out,
+        int w, int h, int sw, int sh, int factor)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= sw || y >= sh) return;
+
+    const float *img = reinterpret_cast<const float*>(in.data);
+    const int cx = x * factor;
+    const int cy = y * factor;
+    const int uc = factor / 2;
+    const int k_even = (factor & 1) ? 0 : 1;
+    const float k_val = 1.0f / (factor * factor);
+
+    double sum = 0.0;
+    if (cx >= uc && cy >= uc && cx < w - uc && cy < h - uc) {
+        for (int v = -uc; v <= uc - k_even; v++) {
+            const float *row = img + (cy + v) * w + cx;
+            for (int u = -uc; u <= uc - k_even; u++)
+                sum += row[u] * k_val;
+        }
+    } else {
+        for (int v = -uc; v <= uc - k_even; v++) {
+            const int yy = mirror_sym(cy + v, h);
+            for (int u = -uc; u <= uc - k_even; u++)
+                sum += img[yy * w + mirror_sym(cx + u, w)] * k_val;
+        }
+    }
+    // _iqa_filter_pixel returns (float)(sum * kscale) with kscale == 1.0
+    reinterpret_cast<float*>(out.data)[y * sw + x] = static_cast<float>(sum);
+}
+
+__global__ void ssim_products(const VmafCudaBuffer ref, const VmafCudaBuffer cmp,
+        VmafCudaBuffer ref2, VmafCudaBuffer cmp2, VmafCudaBuffer both, int n)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+
+    const float r = reinterpret_cast<const float*>(ref.data)[i];
+    const float c = reinterpret_cast<const float*>(cmp.data)[i];
+    reinterpret_cast<float*>(ref2.data)[i] = __fmul_rn(r, r);
+    reinterpret_cast<float*>(cmp2.data)[i] = __fmul_rn(c, c);
+    reinterpret_cast<float*>(both.data)[i] = __fmul_rn(r, c);
+}
+
+// _iqa_convolve horizontal pass (valid in x): rows span the full height so
+// the vertical pass has its apron, exactly like the CPU img_cache
+__global__ void ssim_conv_h(const VmafCudaBuffer in, VmafCudaBuffer cache,
+        int w, int h, int dst_w)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int ky = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || ky >= h) return;
+
+    const float *img = reinterpret_cast<const float*>(in.data);
+    const int kx = x + 5;
+    const int img_offset = ky * w + kx;
+
+    double sum = 0.0;
+#pragma unroll
+    for (int u = -5; u <= 5; u++)
+        sum += img[img_offset + u] * gaussian_k[u + 5];
+    reinterpret_cast<float*>(cache.data)[img_offset] = static_cast<float>(sum);
+}
+
+__global__ void ssim_conv_v(const VmafCudaBuffer cache, VmafCudaBuffer out,
+        int w, int dst_w, int dst_h)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    const float *c = reinterpret_cast<const float*>(cache.data);
+    const int img_offset = (y + 5) * w + x + 5;
+
+    double sum = 0.0;
+#pragma unroll
+    for (int v = -5; v <= 5; v++)
+        sum += c[img_offset + v * w] * gaussian_k[v + 5];
+    reinterpret_cast<float*>(out.data)[y * dst_w + x] = static_cast<float>(sum);
+}
+
+// _iqa_ssim per-pixel l/c/s and frame sums; one partial per block, laid out
+// as partials[block][4] = {ssim, l, c, s}
+__global__ void ssim_map_reduce(const VmafCudaBuffer mu1_buf,
+        const VmafCudaBuffer mu2_buf, const VmafCudaBuffer cref2_buf,
+        const VmafCudaBuffer ccmp2_buf, const VmafCudaBuffer cboth_buf,
+        VmafCudaBuffer partials, int n, float c1, float c2, float c3)
+{
+    __shared__ double sh[256][4];
+
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    const int t = threadIdx.x;
+
+    double lcs = 0.0, l = 0.0, c = 0.0, s = 0.0;
+    if (i < n) {
+        const float mu1 = reinterpret_cast<const float*>(mu1_buf.data)[i];
+        const float mu2 = reinterpret_cast<const float*>(mu2_buf.data)[i];
+
+        // sigma buffers are float and computed as conv(x^2) - mu^2 in float
+        float ref_sigma_sqd = __fsub_rn(
+                reinterpret_cast<const float*>(cref2_buf.data)[i],
+                __fmul_rn(mu1, mu1));
+        float cmp_sigma_sqd = __fsub_rn(
+                reinterpret_cast<const float*>(ccmp2_buf.data)[i],
+                __fmul_rn(mu2, mu2));
+        ref_sigma_sqd = MAX(0.0f, ref_sigma_sqd);
+        cmp_sigma_sqd = MAX(0.0f, cmp_sigma_sqd);
+        const float sigma_both = __fsub_rn(
+                reinterpret_cast<const float*>(cboth_buf.data)[i],
+                __fmul_rn(mu1, mu2));
+
+        // float sqrt over a double-promoted float product, as in _iqa_ssim
+        const float sigma_ref_sigma_cmp = static_cast<float>(sqrt(
+                    static_cast<double>(__fmul_rn(ref_sigma_sqd, cmp_sigma_sqd))));
+
+        // l and c divide a double numerator by a float-summed denominator
+        l = (2.0 * mu1 * mu2 + c1) /
+            static_cast<double>(__fadd_rn(__fadd_rn(__fmul_rn(mu1, mu1),
+                        __fmul_rn(mu2, mu2)), c1));
+        c = (2.0 * sigma_ref_sigma_cmp + c2) /
+            static_cast<double>(__fadd_rn(__fadd_rn(ref_sigma_sqd,
+                        cmp_sigma_sqd), c2));
+
+        const float clamped_sigma_both =
+            (sigma_both < 0.0f && sigma_ref_sigma_cmp <= 0.0f) ?
+            0.0f : sigma_both;
+        // s is a float division in the reference, promoted on assignment
+        s = static_cast<double>(__fdiv_rn(__fadd_rn(clamped_sigma_both, c3),
+                    __fadd_rn(sigma_ref_sigma_cmp, c3)));
+
+        lcs = l * c * s;
+    }
+
+    sh[t][0] = lcs;
+    sh[t][1] = l;
+    sh[t][2] = c;
+    sh[t][3] = s;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (t < stride) {
+#pragma unroll
+            for (int j = 0; j < 4; j++)
+                sh[t][j] += sh[t + stride][j];
+        }
+        __syncthreads();
+    }
+
+    if (t == 0) {
+#pragma unroll
+        for (int j = 0; j < 4; j++)
+            reinterpret_cast<double*>(partials.data)[blockIdx.x * 4 + j] =
+                sh[0][j];
+    }
+}
+
+}

--- a/libvmaf/src/feature/cuda/float_ssim/ssim.cu
+++ b/libvmaf/src/feature/cuda/float_ssim/ssim.cu
@@ -80,15 +80,18 @@ __global__ void ssim_normalize_16bpc(const VmafPicture pic, VmafCudaBuffer out,
         __fdiv_rn(static_cast<float>(v), scaler);
 }
 
-// iqa/decimate.c: out[y*sw+x] = box(in, x*factor, y*factor), symmetric bounds
-__global__ void ssim_decimate(const VmafCudaBuffer in, VmafCudaBuffer out,
+// iqa/decimate.c: out[y*sw+x] = box(in, x*factor, y*factor), symmetric
+// bounds — fused with the float conversion of picture_copy so the full-res
+// float image is never materialized. The conversion is exact per sample
+// (power-of-two divide), so the box filter sees bit-identical floats.
+__global__ void ssim_decimate_8bpc(const VmafPicture pic, VmafCudaBuffer out,
         int w, int h, int sw, int sh, int factor)
 {
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= sw || y >= sh) return;
 
-    const float *img = reinterpret_cast<const float*>(in.data);
+    const uint8_t *base = reinterpret_cast<const uint8_t*>(pic.data[0]);
     const int cx = x * factor;
     const int cy = y * factor;
     const int uc = factor / 2;
@@ -98,18 +101,62 @@ __global__ void ssim_decimate(const VmafCudaBuffer in, VmafCudaBuffer out,
     double sum = 0.0;
     if (cx >= uc && cy >= uc && cx < w - uc && cy < h - uc) {
         for (int v = -uc; v <= uc - k_even; v++) {
-            const float *row = img + (cy + v) * w + cx;
-            for (int u = -uc; u <= uc - k_even; u++)
-                sum += row[u] * k_val;
+            const uint8_t *row = base + (cy + v) * pic.stride[0] + cx;
+            for (int u = -uc; u <= uc - k_even; u++) {
+                const float px = static_cast<float>(row[u]);
+                sum += px * k_val;
+            }
         }
     } else {
         for (int v = -uc; v <= uc - k_even; v++) {
             const int yy = mirror_sym(cy + v, h);
-            for (int u = -uc; u <= uc - k_even; u++)
-                sum += img[yy * w + mirror_sym(cx + u, w)] * k_val;
+            const uint8_t *row = base + yy * pic.stride[0];
+            for (int u = -uc; u <= uc - k_even; u++) {
+                const float px = static_cast<float>(row[mirror_sym(cx + u, w)]);
+                sum += px * k_val;
+            }
         }
     }
     // _iqa_filter_pixel returns (float)(sum * kscale) with kscale == 1.0
+    reinterpret_cast<float*>(out.data)[y * sw + x] = static_cast<float>(sum);
+}
+
+__global__ void ssim_decimate_16bpc(const VmafPicture pic, VmafCudaBuffer out,
+        int w, int h, int sw, int sh, int factor, float scaler)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= sw || y >= sh) return;
+
+    const uint8_t *base = reinterpret_cast<const uint8_t*>(pic.data[0]);
+    const int cx = x * factor;
+    const int cy = y * factor;
+    const int uc = factor / 2;
+    const int k_even = (factor & 1) ? 0 : 1;
+    const float k_val = 1.0f / (factor * factor);
+
+    double sum = 0.0;
+    if (cx >= uc && cy >= uc && cx < w - uc && cy < h - uc) {
+        for (int v = -uc; v <= uc - k_even; v++) {
+            const uint16_t *row = reinterpret_cast<const uint16_t*>(
+                    base + (cy + v) * pic.stride[0]) + cx;
+            for (int u = -uc; u <= uc - k_even; u++) {
+                const float px = __fdiv_rn(static_cast<float>(row[u]), scaler);
+                sum += px * k_val;
+            }
+        }
+    } else {
+        for (int v = -uc; v <= uc - k_even; v++) {
+            const int yy = mirror_sym(cy + v, h);
+            const uint16_t *row = reinterpret_cast<const uint16_t*>(
+                    base + yy * pic.stride[0]);
+            for (int u = -uc; u <= uc - k_even; u++) {
+                const float px = __fdiv_rn(static_cast<float>(
+                            row[mirror_sym(cx + u, w)]), scaler);
+                sum += px * k_val;
+            }
+        }
+    }
     reinterpret_cast<float*>(out.data)[y * sw + x] = static_cast<float>(sum);
 }
 

--- a/libvmaf/src/feature/cuda/float_ssim/ssim.cu
+++ b/libvmaf/src/feature/cuda/float_ssim/ssim.cu
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -123,7 +123,13 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     (void) pix_fmt;
 
     CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
-    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
+    // the work stream is deliberately legacy-blocking: producers like the
+    // ffmpeg libvmaf_cuda filter fill device pictures with synchronous-API
+    // copies that are queued on the legacy NULL stream (device-to-device
+    // memcpy does not block the host), and only blocking-flavor streams are
+    // implicitly ordered after NULL-stream work. Other extractors' created
+    // streams are unaffected, so kernel overlap with them is preserved.
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_DEFAULT, 0));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
     CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
     CHECK_CUDA(cu_f, cuEventCreate(&s->consumed, CU_EVENT_DEFAULT));

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -371,6 +371,20 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
     return 0;
 }
 
+static int flush_fex_cuda(VmafFeatureExtractor *fex,
+                          VmafFeatureCollector *feature_collector)
+{
+    (void)feature_collector;
+    SsimStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    // drain the pending write_scores host callback so the final frame's
+    // score is in the collector before anything reads it
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    return 1;
+}
+
 static int free_buf(VmafFeatureExtractor *fex, VmafCudaBuffer *buf)
 {
     int ret = 0;
@@ -425,6 +439,7 @@ VmafFeatureExtractor vmaf_fex_float_ssim_cuda = {
     .options = options,
     .init = init_fex_cuda,
     .extract = extract_fex_cuda,
+    .flush = flush_fex_cuda,
     .close = close_fex_cuda,
     .priv_size = sizeof(SsimStateCuda),
     .provided_features = provided_features,

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -38,7 +38,7 @@
 typedef struct SsimStateCuda {
     CUevent finished, consumed;
     CUevent slot_done[2];
-    CUfunction f_norm8, f_norm16, f_decimate, f_products;
+    CUfunction f_norm8, f_norm16, f_dec8, f_dec16, f_products;
     CUfunction f_conv_h, f_conv_v, f_map_reduce;
     CUstream str, host_stream;
     VmafCudaBuffer *ref_f, *cmp_f;
@@ -134,7 +134,8 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     CHECK_CUDA(cu_f, cuModuleLoadData(&module, ssim_ptx));
     CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_norm8, module, "ssim_normalize_8bpc"));
     CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_norm16, module, "ssim_normalize_16bpc"));
-    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_decimate, module, "ssim_decimate"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_dec8, module, "ssim_decimate_8bpc"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_dec16, module, "ssim_decimate_16bpc"));
     CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_products, module, "ssim_products"));
     CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_conv_h, module, "ssim_conv_h"));
     CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_conv_v, module, "ssim_conv_v"));
@@ -187,11 +188,14 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     const size_t dec = sizeof(float) * s->sw * s->sh;
     const size_t conv = sizeof(float) * s->cw * s->ch;
 
-    ret |= alloc_buf(fex, &s->ref_f, full);
-    ret |= alloc_buf(fex, &s->cmp_f, full);
+    // factor>1 reads pictures directly in the fused decimate kernels, so
+    // the full-resolution float images are only needed at factor==1
     if (s->factor > 1) {
         ret |= alloc_buf(fex, &s->refd, dec);
         ret |= alloc_buf(fex, &s->cmpd, dec);
+    } else {
+        ret |= alloc_buf(fex, &s->ref_f, full);
+        ret |= alloc_buf(fex, &s->cmp_f, full);
     }
     ret |= alloc_buf(fex, &s->ref2, dec);
     ret |= alloc_buf(fex, &s->cmp2, dec);
@@ -303,46 +307,57 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
     if (s->bpc == 12) scaler = 16.0f;
     if (s->bpc == 16) scaler = 256.0f;
 
-    if (s->bpc == 8) {
-        void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h };
-        void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h };
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+    VmafCudaBuffer *ref_in, *cmp_in;
+    if (s->factor > 1) {
+        // fused normalize+decimate reads the pictures directly
+        int iw = w, ih = h, sw = s->sw, sh = s->sh, factor = s->factor;
+        if (s->bpc == 8) {
+            void *a1[] = { (void*)ref_pic, (void*)s->refd, &iw, &ih, &sw, &sh, &factor };
+            void *a2[] = { (void*)dist_pic, (void*)s->cmpd, &iw, &ih, &sw, &sh, &factor };
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_dec8, DIV_ROUND_UP(sw, 16),
+                        DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_dec8, DIV_ROUND_UP(sw, 16),
+                        DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+        } else {
+            void *a1[] = { (void*)ref_pic, (void*)s->refd, &iw, &ih, &sw, &sh, &factor, &scaler };
+            void *a2[] = { (void*)dist_pic, (void*)s->cmpd, &iw, &ih, &sw, &sh, &factor, &scaler };
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_dec16, DIV_ROUND_UP(sw, 16),
+                        DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_dec16, DIV_ROUND_UP(sw, 16),
+                        DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+        }
+        ref_in = s->refd;
+        cmp_in = s->cmpd;
     } else {
-        void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h, &scaler };
-        void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h, &scaler };
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+        if (s->bpc == 8) {
+            void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h };
+            void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h };
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
+                        DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
+                        DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+        } else {
+            void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h, &scaler };
+            void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h, &scaler };
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
+                        DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
+            CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
+                        DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
+        }
+        ref_in = s->ref_f;
+        cmp_in = s->cmp_f;
     }
 
     // lifetime handshake right after the only kernels that read picture
     // memory: the pool recycles a picture once the `finished` event its own
     // stream records (after the fex loop) has completed, so make both
-    // picture streams wait for the normalize reads — everything below works
-    // on our own buffers and can outlive the pictures
+    // picture streams wait for those reads — everything below works on our
+    // own buffers and can outlive the pictures
     CHECK_CUDA(cu_f, cuEventRecord(s->consumed, s->str));
     CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(ref_pic),
                 s->consumed, CU_EVENT_WAIT_DEFAULT));
     CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(dist_pic),
                 s->consumed, CU_EVENT_WAIT_DEFAULT));
-
-    VmafCudaBuffer *ref_in = s->ref_f;
-    VmafCudaBuffer *cmp_in = s->cmp_f;
-    if (s->factor > 1) {
-        int iw = w, ih = h, sw = s->sw, sh = s->sh, factor = s->factor;
-        void *a1[] = { (void*)s->ref_f, (void*)s->refd, &iw, &ih, &sw, &sh, &factor };
-        void *a2[] = { (void*)s->cmp_f, (void*)s->cmpd, &iw, &ih, &sw, &sh, &factor };
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
-                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
-        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
-                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
-        ref_in = s->refd;
-        cmp_in = s->cmpd;
-    }
 
     {
         int n = s->sw * s->sh;

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -1,0 +1,432 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <errno.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "feature_collector.h"
+#include "feature_extractor.h"
+#include "cuda/float_ssim_cuda.h"
+#include "opt.h"
+#include "picture.h"
+#include "picture_cuda.h"
+#include "cuda_helper.cuh"
+
+#define GAUSSIAN_LEN 11
+#define REDUCE_BLOCK 256
+
+typedef struct SsimStateCuda {
+    CUevent event, finished;
+    CUfunction f_norm8, f_norm16, f_decimate, f_products;
+    CUfunction f_conv_h, f_conv_v, f_map_reduce;
+    CUstream str, host_stream;
+    VmafCudaBuffer *ref_f, *cmp_f;
+    VmafCudaBuffer *refd, *cmpd;
+    VmafCudaBuffer *ref2, *cmp2, *both;
+    VmafCudaBuffer *cache;
+    VmafCudaBuffer *mu1, *mu2, *cref2, *ccmp2, *cboth;
+    VmafCudaBuffer *partials;
+    double *partials_host;
+    void *write_score_parameters;
+    unsigned w, h, sw, sh, cw, ch;
+    unsigned n_blocks;
+    unsigned bpc;
+    int factor;
+    bool enable_lcs;
+    bool enable_db;
+    bool clip_db;
+    double max_db;
+    int scale;
+} SsimStateCuda;
+
+static const VmafOption options[] = {
+    {
+        .name = "enable_lcs",
+        .help = "enable luminance, contrast and structure intermediate output",
+        .offset = offsetof(SsimStateCuda, enable_lcs),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "enable_db",
+        .help = "write SSIM values as dB",
+        .offset = offsetof(SsimStateCuda, enable_db),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "clip_db",
+        .help = "clip dB scores",
+        .offset = offsetof(SsimStateCuda, clip_db),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "scale",
+        .help = "decimation scale factor (0=auto, 1=no downscaling, 2-10=explicit)",
+        .offset = offsetof(SsimStateCuda, scale),
+        .type = VMAF_OPT_TYPE_INT,
+        .default_val.i = 0,
+        .min = 0,
+        .max = 10,
+    },
+    { 0 }
+};
+
+typedef struct write_score_parameters_ssim {
+    VmafFeatureCollector *feature_collector;
+    SsimStateCuda *s;
+    unsigned index;
+} write_score_parameters_ssim;
+
+// iqa/math_utils.c _round: round half away from zero
+static int iqa_round(float a)
+{
+    int sign_a = a > 0.0f ? 1 : -1;
+    return a - (int)a >= 0.5 ? (int)a + sign_a : (int)a;
+}
+
+static int alloc_buf(VmafFeatureExtractor *fex, VmafCudaBuffer **buf,
+                     size_t size)
+{
+    return vmaf_cuda_buffer_alloc(fex->cu_state, buf, size);
+}
+
+static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                         unsigned bpc, unsigned w, unsigned h)
+{
+    SsimStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    (void) pix_fmt;
+
+    CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->event, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
+
+    CUmodule module;
+    CHECK_CUDA(cu_f, cuModuleLoadData(&module, ssim_ptx));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_norm8, module, "ssim_normalize_8bpc"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_norm16, module, "ssim_normalize_16bpc"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_decimate, module, "ssim_decimate"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_products, module, "ssim_products"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_conv_h, module, "ssim_conv_h"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_conv_v, module, "ssim_conv_v"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->f_map_reduce, module, "ssim_map_reduce"));
+
+    CHECK_CUDA(cu_f, cuCtxPopCurrent(NULL));
+
+    s->w = w;
+    s->h = h;
+    s->bpc = bpc;
+
+    // compute_ssim: scale = max(1, round(min(w,h) / 256.0)), or the override
+    const unsigned min_wh = w < h ? w : h;
+    s->factor = s->scale > 0 ?
+        s->scale : (iqa_round((float)min_wh / 256.0f) < 1 ?
+                    1 : iqa_round((float)min_wh / 256.0f));
+
+    if (s->factor > 1) {
+        // _iqa_decimate: sw = w/factor + (w&1)
+        s->sw = w / s->factor + (w & 1);
+        s->sh = h / s->factor + (h & 1);
+    } else {
+        s->sw = w;
+        s->sh = h;
+    }
+    if (s->sw < GAUSSIAN_LEN || s->sh < GAUSSIAN_LEN)
+        return -EINVAL;
+    s->cw = s->sw - GAUSSIAN_LEN + 1;
+    s->ch = s->sh - GAUSSIAN_LEN + 1;
+    s->n_blocks = DIV_ROUND_UP(s->cw * s->ch, REDUCE_BLOCK);
+
+    const unsigned peak = (1 << bpc) - 1;
+    if (s->clip_db) {
+        const double mse = 0.5 / (w * h);
+        s->max_db = ceil(10. * log10(peak * peak / mse));
+    } else {
+        s->max_db = INFINITY;
+    }
+
+    int ret = 0;
+
+    s->write_score_parameters = malloc(sizeof(write_score_parameters_ssim));
+    if (!s->write_score_parameters) return -ENOMEM;
+    ((write_score_parameters_ssim*)s->write_score_parameters)->s = s;
+
+    const size_t full = sizeof(float) * w * h;
+    const size_t dec = sizeof(float) * s->sw * s->sh;
+    const size_t conv = sizeof(float) * s->cw * s->ch;
+
+    ret |= alloc_buf(fex, &s->ref_f, full);
+    ret |= alloc_buf(fex, &s->cmp_f, full);
+    if (s->factor > 1) {
+        ret |= alloc_buf(fex, &s->refd, dec);
+        ret |= alloc_buf(fex, &s->cmpd, dec);
+    }
+    ret |= alloc_buf(fex, &s->ref2, dec);
+    ret |= alloc_buf(fex, &s->cmp2, dec);
+    ret |= alloc_buf(fex, &s->both, dec);
+    ret |= alloc_buf(fex, &s->cache, dec);
+    ret |= alloc_buf(fex, &s->mu1, conv);
+    ret |= alloc_buf(fex, &s->mu2, conv);
+    ret |= alloc_buf(fex, &s->cref2, conv);
+    ret |= alloc_buf(fex, &s->ccmp2, conv);
+    ret |= alloc_buf(fex, &s->cboth, conv);
+    ret |= alloc_buf(fex, &s->partials, sizeof(double) * 4 * s->n_blocks);
+    ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->partials_host,
+                                       sizeof(double) * 4 * s->n_blocks);
+    if (ret) return -ENOMEM;
+
+    return 0;
+}
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+static double convert_to_db(double score, double max_db)
+{
+    return MIN(-10. * log10(1 - score), max_db);
+}
+
+static int write_scores(write_score_parameters_ssim *params)
+{
+    SsimStateCuda *s = params->s;
+    VmafFeatureCollector *feature_collector = params->feature_collector;
+
+    // sequential sum over block partials keeps the result deterministic
+    double ssim_sum = 0., l_sum = 0., c_sum = 0., s_sum = 0.;
+    for (unsigned b = 0; b < s->n_blocks; b++) {
+        ssim_sum += s->partials_host[b * 4 + 0];
+        l_sum += s->partials_host[b * 4 + 1];
+        c_sum += s->partials_host[b * 4 + 2];
+        s_sum += s->partials_host[b * 4 + 3];
+    }
+
+    // _iqa_ssim returns float means; compute_ssim widens them to double
+    const double n = (double)(s->cw * s->ch);
+    double score = (double)(float)(ssim_sum / n);
+    const double l_score = (double)(float)(l_sum / n);
+    const double c_score = (double)(float)(c_sum / n);
+    const double s_score = (double)(float)(s_sum / n);
+
+    if (s->enable_db)
+        score = convert_to_db(score, s->max_db);
+
+    int err = vmaf_feature_collector_append(feature_collector, "float_ssim",
+                                            score, params->index);
+    if (s->enable_lcs) {
+        err |= vmaf_feature_collector_append(feature_collector, "float_ssim_l",
+                                             l_score, params->index);
+        err |= vmaf_feature_collector_append(feature_collector, "float_ssim_c",
+                                             c_score, params->index);
+        err |= vmaf_feature_collector_append(feature_collector, "float_ssim_s",
+                                             s_score, params->index);
+    }
+
+    return err;
+}
+
+static void launch_conv(SsimStateCuda *s, CudaFunctions *cu_f, CUstream stream,
+                        VmafCudaBuffer *in, VmafCudaBuffer *out)
+{
+    int w = s->sw, h = s->sh, dst_w = s->cw, dst_h = s->ch;
+    {
+        void *args[] = { (void*)in, (void*)s->cache, &w, &h, &dst_w };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_conv_h,
+                    DIV_ROUND_UP(dst_w, 16), DIV_ROUND_UP(h, 16), 1,
+                    16, 16, 1, 0, stream, args, NULL));
+    }
+    {
+        void *args[] = { (void*)s->cache, (void*)out, &w, &dst_w, &dst_h };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_conv_v,
+                    DIV_ROUND_UP(dst_w, 16), DIV_ROUND_UP(dst_h, 16), 1,
+                    16, 16, 1, 0, stream, args, NULL));
+    }
+}
+
+static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
+                            VmafPicture *ref_pic_90, VmafPicture *dist_pic,
+                            VmafPicture *dist_pic_90, unsigned index,
+                            VmafFeatureCollector *feature_collector)
+{
+    SsimStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
+
+    // this is done to ensure that the CPU does not overwrite the buffer
+    // params for write_scores
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+
+    const CUstream pic_stream = vmaf_cuda_picture_get_stream(ref_pic);
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(pic_stream,
+                vmaf_cuda_picture_get_ready_event(dist_pic),
+                CU_EVENT_WAIT_DEFAULT));
+
+    unsigned w = s->w, h = s->h;
+    float scaler = 4.0f;
+    if (s->bpc == 12) scaler = 16.0f;
+    if (s->bpc == 16) scaler = 256.0f;
+
+    if (s->bpc == 8) {
+        void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h };
+        void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+    } else {
+        void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h, &scaler };
+        void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h, &scaler };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+    }
+
+    VmafCudaBuffer *ref_in = s->ref_f;
+    VmafCudaBuffer *cmp_in = s->cmp_f;
+    if (s->factor > 1) {
+        int iw = w, ih = h, sw = s->sw, sh = s->sh, factor = s->factor;
+        void *a1[] = { (void*)s->ref_f, (void*)s->refd, &iw, &ih, &sw, &sh, &factor };
+        void *a2[] = { (void*)s->cmp_f, (void*)s->cmpd, &iw, &ih, &sw, &sh, &factor };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
+                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
+                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+        ref_in = s->refd;
+        cmp_in = s->cmpd;
+    }
+
+    {
+        int n = s->sw * s->sh;
+        void *args[] = { (void*)ref_in, (void*)cmp_in, (void*)s->ref2,
+                         (void*)s->cmp2, (void*)s->both, &n };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_products,
+                    DIV_ROUND_UP(n, REDUCE_BLOCK), 1, 1,
+                    REDUCE_BLOCK, 1, 1, 0, pic_stream, args, NULL));
+    }
+
+    launch_conv(s, cu_f, pic_stream, ref_in, s->mu1);
+    launch_conv(s, cu_f, pic_stream, cmp_in, s->mu2);
+    launch_conv(s, cu_f, pic_stream, s->ref2, s->cref2);
+    launch_conv(s, cu_f, pic_stream, s->cmp2, s->ccmp2);
+    launch_conv(s, cu_f, pic_stream, s->both, s->cboth);
+
+    {
+        // _iqa_ssim: C1 = (K1*L)^2, C2 = (K2*L)^2, C3 = C2/2, L = 255
+        float c1 = (0.01f * 255) * (0.01f * 255);
+        float c2 = (0.03f * 255) * (0.03f * 255);
+        float c3 = c2 / 2.0f;
+        int n = s->cw * s->ch;
+        void *args[] = { (void*)s->mu1, (void*)s->mu2, (void*)s->cref2,
+                         (void*)s->ccmp2, (void*)s->cboth, (void*)s->partials,
+                         &n, &c1, &c2, &c3 };
+        CHECK_CUDA(cu_f, cuLaunchKernel(s->f_map_reduce,
+                    s->n_blocks, 1, 1, REDUCE_BLOCK, 1, 1, 0,
+                    pic_stream, args, NULL));
+    }
+
+    CHECK_CUDA(cu_f, cuEventRecord(s->event, pic_stream));
+    // This event ensures the input buffer is consumed
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str, s->event, CU_EVENT_WAIT_DEFAULT));
+
+    // Download block partials
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(s->partials_host, s->partials->data,
+                sizeof(double) * 4 * s->n_blocks, s->str));
+    CHECK_CUDA(cu_f, cuEventRecord(s->finished, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->host_stream, s->finished,
+                CU_EVENT_WAIT_DEFAULT));
+
+    write_score_parameters_ssim *params = s->write_score_parameters;
+    params->feature_collector = feature_collector;
+    params->index = index;
+    CHECK_CUDA(cu_f, cuLaunchHostFunc(s->host_stream, (CUhostFn*)write_scores,
+                s->write_score_parameters));
+
+    return 0;
+}
+
+static int free_buf(VmafFeatureExtractor *fex, VmafCudaBuffer *buf)
+{
+    int ret = 0;
+    if (buf) {
+        ret = vmaf_cuda_buffer_free(fex->cu_state, buf);
+        free(buf);
+    }
+    return ret;
+}
+
+static int close_fex_cuda(VmafFeatureExtractor *fex)
+{
+    SsimStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->event));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->finished));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->str));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->host_stream));
+
+    int ret = 0;
+    ret |= free_buf(fex, s->ref_f);
+    ret |= free_buf(fex, s->cmp_f);
+    ret |= free_buf(fex, s->refd);
+    ret |= free_buf(fex, s->cmpd);
+    ret |= free_buf(fex, s->ref2);
+    ret |= free_buf(fex, s->cmp2);
+    ret |= free_buf(fex, s->both);
+    ret |= free_buf(fex, s->cache);
+    ret |= free_buf(fex, s->mu1);
+    ret |= free_buf(fex, s->mu2);
+    ret |= free_buf(fex, s->cref2);
+    ret |= free_buf(fex, s->ccmp2);
+    ret |= free_buf(fex, s->cboth);
+    ret |= free_buf(fex, s->partials);
+    if (s->partials_host)
+        ret |= vmaf_cuda_buffer_host_free(fex->cu_state, s->partials_host);
+    if (s->write_score_parameters)
+        free(s->write_score_parameters);
+
+    return ret;
+}
+
+static const char *provided_features[] = {
+    "float_ssim",
+    NULL
+};
+
+VmafFeatureExtractor vmaf_fex_float_ssim_cuda = {
+    .name = "ssim_cuda",
+    .options = options,
+    .init = init_fex_cuda,
+    .extract = extract_fex_cuda,
+    .close = close_fex_cuda,
+    .priv_size = sizeof(SsimStateCuda),
+    .provided_features = provided_features,
+    .flags = VMAF_FEATURE_EXTRACTOR_CUDA,
+};

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.c
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.c
@@ -36,7 +36,8 @@
 #define REDUCE_BLOCK 256
 
 typedef struct SsimStateCuda {
-    CUevent event, finished;
+    CUevent finished, consumed;
+    CUevent slot_done[2];
     CUfunction f_norm8, f_norm16, f_decimate, f_products;
     CUfunction f_conv_h, f_conv_v, f_map_reduce;
     CUstream str, host_stream;
@@ -96,6 +97,7 @@ static const VmafOption options[] = {
 typedef struct write_score_parameters_ssim {
     VmafFeatureCollector *feature_collector;
     SsimStateCuda *s;
+    const double *partials;
     unsigned index;
 } write_score_parameters_ssim;
 
@@ -123,8 +125,10 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
-    CHECK_CUDA(cu_f, cuEventCreate(&s->event, CU_EVENT_DEFAULT));
     CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->consumed, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[0], CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[1], CU_EVENT_DEFAULT));
 
     CUmodule module;
     CHECK_CUDA(cu_f, cuModuleLoadData(&module, ssim_ptx));
@@ -172,9 +176,12 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
 
     int ret = 0;
 
-    s->write_score_parameters = malloc(sizeof(write_score_parameters_ssim));
+    // two write_score slots + two pinned readback slots so frame i+1 never
+    // has to wait for frame i's host callback (see slot_done in extract)
+    s->write_score_parameters = malloc(sizeof(write_score_parameters_ssim) * 2);
     if (!s->write_score_parameters) return -ENOMEM;
-    ((write_score_parameters_ssim*)s->write_score_parameters)->s = s;
+    for (unsigned i = 0; i < 2; i++)
+        ((write_score_parameters_ssim*)s->write_score_parameters)[i].s = s;
 
     const size_t full = sizeof(float) * w * h;
     const size_t dec = sizeof(float) * s->sw * s->sh;
@@ -197,7 +204,7 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     ret |= alloc_buf(fex, &s->cboth, conv);
     ret |= alloc_buf(fex, &s->partials, sizeof(double) * 4 * s->n_blocks);
     ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->partials_host,
-                                       sizeof(double) * 4 * s->n_blocks);
+                                       sizeof(double) * 4 * s->n_blocks * 2);
     if (ret) return -ENOMEM;
 
     return 0;
@@ -218,10 +225,10 @@ static int write_scores(write_score_parameters_ssim *params)
     // sequential sum over block partials keeps the result deterministic
     double ssim_sum = 0., l_sum = 0., c_sum = 0., s_sum = 0.;
     for (unsigned b = 0; b < s->n_blocks; b++) {
-        ssim_sum += s->partials_host[b * 4 + 0];
-        l_sum += s->partials_host[b * 4 + 1];
-        c_sum += s->partials_host[b * 4 + 2];
-        s_sum += s->partials_host[b * 4 + 3];
+        ssim_sum += params->partials[b * 4 + 0];
+        l_sum += params->partials[b * 4 + 1];
+        c_sum += params->partials[b * 4 + 2];
+        s_sum += params->partials[b * 4 + 3];
     }
 
     // _iqa_ssim returns float means; compute_ssim widens them to double
@@ -277,12 +284,17 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
     (void) ref_pic_90;
     (void) dist_pic_90;
 
-    // this is done to ensure that the CPU does not overwrite the buffer
-    // params for write_scores
-    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    // two slots: wait for frame index-2's host callback (effectively always
+    // complete) instead of stalling on the whole previous frame's work
+    const unsigned slot = index & 1;
+    CHECK_CUDA(cu_f, cuEventSynchronize(s->slot_done[slot]));
 
-    const CUstream pic_stream = vmaf_cuda_picture_get_stream(ref_pic);
-    CHECK_CUDA(cu_f, cuStreamWaitEvent(pic_stream,
+    // kernels run on the extractor's own stream so they overlap with other
+    // extractors' work on the picture streams; wait for both uploads first
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
+                vmaf_cuda_picture_get_ready_event(ref_pic),
+                CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
                 vmaf_cuda_picture_get_ready_event(dist_pic),
                 CU_EVENT_WAIT_DEFAULT));
 
@@ -295,17 +307,28 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
         void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h };
         void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h };
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm8, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
     } else {
         void *a1[] = { (void*)ref_pic, (void*)s->ref_f, &w, &h, &scaler };
         void *a2[] = { (void*)dist_pic, (void*)s->cmp_f, &w, &h, &scaler };
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_norm16, DIV_ROUND_UP(w, 16),
-                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+                    DIV_ROUND_UP(h, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
     }
+
+    // lifetime handshake right after the only kernels that read picture
+    // memory: the pool recycles a picture once the `finished` event its own
+    // stream records (after the fex loop) has completed, so make both
+    // picture streams wait for the normalize reads — everything below works
+    // on our own buffers and can outlive the pictures
+    CHECK_CUDA(cu_f, cuEventRecord(s->consumed, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(ref_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(dist_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
 
     VmafCudaBuffer *ref_in = s->ref_f;
     VmafCudaBuffer *cmp_in = s->cmp_f;
@@ -314,9 +337,9 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
         void *a1[] = { (void*)s->ref_f, (void*)s->refd, &iw, &ih, &sw, &sh, &factor };
         void *a2[] = { (void*)s->cmp_f, (void*)s->cmpd, &iw, &ih, &sw, &sh, &factor };
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
-                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, pic_stream, a1, NULL));
+                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a1, NULL));
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_decimate, DIV_ROUND_UP(sw, 16),
-                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, pic_stream, a2, NULL));
+                    DIV_ROUND_UP(sh, 16), 1, 16, 16, 1, 0, s->str, a2, NULL));
         ref_in = s->refd;
         cmp_in = s->cmpd;
     }
@@ -327,14 +350,14 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
                          (void*)s->cmp2, (void*)s->both, &n };
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_products,
                     DIV_ROUND_UP(n, REDUCE_BLOCK), 1, 1,
-                    REDUCE_BLOCK, 1, 1, 0, pic_stream, args, NULL));
+                    REDUCE_BLOCK, 1, 1, 0, s->str, args, NULL));
     }
 
-    launch_conv(s, cu_f, pic_stream, ref_in, s->mu1);
-    launch_conv(s, cu_f, pic_stream, cmp_in, s->mu2);
-    launch_conv(s, cu_f, pic_stream, s->ref2, s->cref2);
-    launch_conv(s, cu_f, pic_stream, s->cmp2, s->ccmp2);
-    launch_conv(s, cu_f, pic_stream, s->both, s->cboth);
+    launch_conv(s, cu_f, s->str, ref_in, s->mu1);
+    launch_conv(s, cu_f, s->str, cmp_in, s->mu2);
+    launch_conv(s, cu_f, s->str, s->ref2, s->cref2);
+    launch_conv(s, cu_f, s->str, s->cmp2, s->ccmp2);
+    launch_conv(s, cu_f, s->str, s->both, s->cboth);
 
     {
         // _iqa_ssim: C1 = (K1*L)^2, C2 = (K2*L)^2, C3 = C2/2, L = 255
@@ -347,26 +370,25 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
                          &n, &c1, &c2, &c3 };
         CHECK_CUDA(cu_f, cuLaunchKernel(s->f_map_reduce,
                     s->n_blocks, 1, 1, REDUCE_BLOCK, 1, 1, 0,
-                    pic_stream, args, NULL));
+                    s->str, args, NULL));
     }
 
-    CHECK_CUDA(cu_f, cuEventRecord(s->event, pic_stream));
-    // This event ensures the input buffer is consumed
-    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str, s->event, CU_EVENT_WAIT_DEFAULT));
-
-    // Download block partials
-    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
-    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(s->partials_host, s->partials->data,
+    // Download block partials into this slot's readback segment
+    double *partials_host = s->partials_host + slot * 4 * s->n_blocks;
+    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(partials_host, s->partials->data,
                 sizeof(double) * 4 * s->n_blocks, s->str));
     CHECK_CUDA(cu_f, cuEventRecord(s->finished, s->str));
     CHECK_CUDA(cu_f, cuStreamWaitEvent(s->host_stream, s->finished,
                 CU_EVENT_WAIT_DEFAULT));
 
-    write_score_parameters_ssim *params = s->write_score_parameters;
+    write_score_parameters_ssim *params =
+        &((write_score_parameters_ssim*)s->write_score_parameters)[slot];
     params->feature_collector = feature_collector;
+    params->partials = partials_host;
     params->index = index;
     CHECK_CUDA(cu_f, cuLaunchHostFunc(s->host_stream, (CUhostFn*)write_scores,
-                s->write_score_parameters));
+                params));
+    CHECK_CUDA(cu_f, cuEventRecord(s->slot_done[slot], s->host_stream));
 
     return 0;
 }
@@ -401,8 +423,10 @@ static int close_fex_cuda(VmafFeatureExtractor *fex)
     CudaFunctions *cu_f = fex->cu_state->f;
     CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
     CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
-    CHECK_CUDA(cu_f, cuEventDestroy(s->event));
     CHECK_CUDA(cu_f, cuEventDestroy(s->finished));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->consumed));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[0]));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[1]));
     CHECK_CUDA(cu_f, cuStreamDestroy(s->str));
     CHECK_CUDA(cu_f, cuStreamDestroy(s->host_stream));
 

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.h
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.h
@@ -1,0 +1,27 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef FEATURE_SSIM_CUDA_H_
+#define FEATURE_SSIM_CUDA_H_
+
+#include <stdint.h>
+#include "common.h"
+
+extern const unsigned char ssim_ptx[];
+#endif /* _FEATURE_SSIM_CUDA_H_ */

--- a/libvmaf/src/feature/cuda/float_ssim_cuda.h
+++ b/libvmaf/src/feature/cuda/float_ssim_cuda.h
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/cuda/integer_motion/motion_score.cu
+++ b/libvmaf/src/feature/cuda/integer_motion/motion_score.cu
@@ -101,7 +101,7 @@ __global__ void calculate_motion_score_kernel_16bpc(const VmafPicture src, VmafC
             uint32_t blurred_y = 0u;
 #pragma unroll
             for (int yf=0; yf < filter_width_d; ++yf) {
-                blurred_y += filter_d[yf] * (reinterpret_cast<const uint16_t*>(src.data[0]) + mirror(y-radius+yf, height) * src.stride[0])[mirror(x-radius+xf, width)];
+                blurred_y += filter_d[yf] * reinterpret_cast<const uint16_t*>(reinterpret_cast<const uint8_t*>(src.data[0]) + mirror(y-radius+yf, height) * src.stride[0])[mirror(x-radius+xf, width)];
             }
             blurred += filter_d[xf]*((blurred_y + add_before_shift_y) >> shift_var_y);
         }

--- a/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
+++ b/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
@@ -22,8 +22,8 @@
 #include "common.h"
 
 // Block-reduce a per-thread value and let thread 0 issue ONE atomicAdd per
-// block: one atomic per warp serializes on the single global accumulator
-// (~2.6 ms/frame on 4K yuv444p16), one per block is ~32x fewer
+// block: one atomic per warp serializes on the single global accumulator,
+// one per block is ~32x fewer
 __device__ __forceinline__ void block_reduce_add(uint64_t v,
         unsigned long long *accum)
 {
@@ -50,20 +50,44 @@ __device__ __forceinline__ void block_reduce_add(uint64_t v,
 
 extern "C" {
 
+// Grid-stride over uchar4 vectors so each warp reads full 128-byte segments
+// (cuMemAllocPitch aligns every row start); the <=3 tail pixels of each row
+// when the width isn't a multiple of 4 are covered by a scalar per-row loop.
+// Integer sums are order-independent, so the score is unchanged.
 __global__ void psnr_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
         VmafCudaBuffer sse, unsigned plane, unsigned width, unsigned height)
 {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    const uint8_t *rbase = reinterpret_cast<const uint8_t*>(ref.data[plane]);
+    const uint8_t *dbase = reinterpret_cast<const uint8_t*>(dis.data[plane]);
+    const long vecs = width / 4;
+    const long total = vecs * height;
+    const long tid = blockIdx.x * (long)blockDim.x + threadIdx.x;
+    const long step = (long)gridDim.x * blockDim.x;
 
-    uint32_t sq = 0u;
-    if (x < width && y < height) {
-        const int r = (reinterpret_cast<const uint8_t*>(ref.data[plane]) +
-                y * ref.stride[plane])[x];
-        const int d = (reinterpret_cast<const uint8_t*>(dis.data[plane]) +
-                y * dis.stride[plane])[x];
-        const int e = r - d;
-        sq = e * e;
+    uint64_t sq = 0;
+    for (long i = tid; i < total; i += step) {
+        const long y = i / vecs;
+        const long x = (i - y * vecs) * 4;
+        const uchar4 r = *reinterpret_cast<const uchar4*>(
+                rbase + y * ref.stride[plane] + x);
+        const uchar4 d = *reinterpret_cast<const uchar4*>(
+                dbase + y * dis.stride[plane] + x);
+        int e = r.x - d.x; sq += e * e;
+        e = r.y - d.y; sq += e * e;
+        e = r.z - d.z; sq += e * e;
+        e = r.w - d.w; sq += e * e;
+    }
+
+    const unsigned tail = width & 3;
+    if (tail) {
+        for (long y = tid; y < height; y += step) {
+            const uint8_t *r = rbase + y * ref.stride[plane];
+            const uint8_t *d = dbase + y * dis.stride[plane];
+            for (unsigned x = width - tail; x < width; x++) {
+                const int e = r[x] - d[x];
+                sq += e * e;
+            }
+        }
     }
 
     block_reduce_add(sq,
@@ -73,19 +97,36 @@ __global__ void psnr_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
 __global__ void psnr_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
         VmafCudaBuffer sse, unsigned plane, unsigned width, unsigned height)
 {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    const uint8_t *rbase = reinterpret_cast<const uint8_t*>(ref.data[plane]);
+    const uint8_t *dbase = reinterpret_cast<const uint8_t*>(dis.data[plane]);
+    const long vecs = width / 2;
+    const long total = vecs * height;
+    const long tid = blockIdx.x * (long)blockDim.x + threadIdx.x;
+    const long step = (long)gridDim.x * blockDim.x;
 
     uint64_t sq = 0;
-    if (x < width && y < height) {
-        const int r = reinterpret_cast<const uint16_t*>(
-                reinterpret_cast<const uint8_t*>(ref.data[plane]) +
-                y * ref.stride[plane])[x];
-        const int d = reinterpret_cast<const uint16_t*>(
-                reinterpret_cast<const uint8_t*>(dis.data[plane]) +
-                y * dis.stride[plane])[x];
-        const int e = r - d;
-        sq = static_cast<uint64_t>(static_cast<int64_t>(e) * e);
+    for (long i = tid; i < total; i += step) {
+        const long y = i / vecs;
+        const long x = (i - y * vecs) * 4; // byte offset of the ushort2
+        const ushort2 r = *reinterpret_cast<const ushort2*>(
+                rbase + y * ref.stride[plane] + x);
+        const ushort2 d = *reinterpret_cast<const ushort2*>(
+                dbase + y * dis.stride[plane] + x);
+        int e = r.x - d.x;
+        sq += static_cast<uint64_t>(static_cast<int64_t>(e) * e);
+        e = r.y - d.y;
+        sq += static_cast<uint64_t>(static_cast<int64_t>(e) * e);
+    }
+
+    if (width & 1) {
+        const unsigned x = width - 1;
+        for (long y = tid; y < height; y += step) {
+            const int e = reinterpret_cast<const uint16_t*>(
+                        rbase + y * ref.stride[plane])[x] -
+                    reinterpret_cast<const uint16_t*>(
+                        dbase + y * dis.stride[plane])[x];
+            sq += static_cast<uint64_t>(static_cast<int64_t>(e) * e);
+        }
     }
 
     block_reduce_add(sq,

--- a/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
+++ b/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
@@ -21,6 +21,33 @@
 
 #include "common.h"
 
+// Block-reduce a per-thread value and let thread 0 issue ONE atomicAdd per
+// block: one atomic per warp serializes on the single global accumulator
+// (~2.6 ms/frame on 4K yuv444p16), one per block is ~32x fewer
+__device__ __forceinline__ void block_reduce_add(uint64_t v,
+        unsigned long long *accum)
+{
+    __shared__ uint64_t warp_sums[8]; // 256 threads = 8 warps
+
+    const int t = threadIdx.y * blockDim.x + threadIdx.x;
+#pragma unroll
+    for (int i = 16; i > 0; i >>= 1) {
+        v += uint64_t(__shfl_down_sync(0xffffffff, uint32_t(v), i)) |
+             (uint64_t(__shfl_down_sync(0xffffffff, uint32_t(v >> 32), i)) << 32);
+    }
+    if ((t % 32) == 0)
+        warp_sums[t / 32] = v;
+    __syncthreads();
+    if (t == 0) {
+        uint64_t sum = 0;
+#pragma unroll
+        for (int i = 0; i < 8; i++)
+            sum += warp_sums[i];
+        if (sum)
+            atomicAdd(accum, static_cast<unsigned long long>(sum));
+    }
+}
+
 extern "C" {
 
 __global__ void psnr_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
@@ -39,17 +66,8 @@ __global__ void psnr_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
         sq = e * e;
     }
 
-    // Warp-reduce sq; max per-thread value is 255^2 so a full warp fits u32
-    sq += __shfl_down_sync(0xffffffff, sq, 16);
-    sq += __shfl_down_sync(0xffffffff, sq, 8);
-    sq += __shfl_down_sync(0xffffffff, sq, 4);
-    sq += __shfl_down_sync(0xffffffff, sq, 2);
-    sq += __shfl_down_sync(0xffffffff, sq, 1);
-    // Let threads in lane zero add warp-reduced sq atomically to global sse
-    const int lane = (threadIdx.y * blockDim.x + threadIdx.x) % 32;
-    if (lane == 0)
-        atomicAdd(reinterpret_cast<unsigned long long*>(sse.data) + plane,
-                static_cast<unsigned long long>(sq));
+    block_reduce_add(sq,
+            reinterpret_cast<unsigned long long*>(sse.data) + plane);
 }
 
 __global__ void psnr_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
@@ -58,7 +76,7 @@ __global__ void psnr_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
     const int y = blockIdx.y * blockDim.y + threadIdx.y;
 
-    int64_t sq = 0;
+    uint64_t sq = 0;
     if (x < width && y < height) {
         const int r = reinterpret_cast<const uint16_t*>(
                 reinterpret_cast<const uint8_t*>(ref.data[plane]) +
@@ -67,14 +85,11 @@ __global__ void psnr_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
                 reinterpret_cast<const uint8_t*>(dis.data[plane]) +
                 y * dis.stride[plane])[x];
         const int e = r - d;
-        sq = static_cast<int64_t>(e) * e;
+        sq = static_cast<uint64_t>(static_cast<int64_t>(e) * e);
     }
 
-    // 65535^2 overflows u32 once warp-accumulated, reduce in 64-bit
-    sq = warp_reduce(sq);
-    const int lane = (threadIdx.y * blockDim.x + threadIdx.x) % 32;
-    if (lane == 0)
-        atomicAdd_int64(reinterpret_cast<int64_t*>(sse.data) + plane, sq);
+    block_reduce_add(sq,
+            reinterpret_cast<unsigned long long*>(sse.data) + plane);
 }
 
 }

--- a/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
+++ b/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
+++ b/libvmaf/src/feature/cuda/integer_psnr/psnr.cu
@@ -1,0 +1,80 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "cuda_helper.cuh"
+
+#include "common.h"
+
+extern "C" {
+
+__global__ void psnr_kernel_8bpc(const VmafPicture ref, const VmafPicture dis,
+        VmafCudaBuffer sse, unsigned plane, unsigned width, unsigned height)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    uint32_t sq = 0u;
+    if (x < width && y < height) {
+        const int r = (reinterpret_cast<const uint8_t*>(ref.data[plane]) +
+                y * ref.stride[plane])[x];
+        const int d = (reinterpret_cast<const uint8_t*>(dis.data[plane]) +
+                y * dis.stride[plane])[x];
+        const int e = r - d;
+        sq = e * e;
+    }
+
+    // Warp-reduce sq; max per-thread value is 255^2 so a full warp fits u32
+    sq += __shfl_down_sync(0xffffffff, sq, 16);
+    sq += __shfl_down_sync(0xffffffff, sq, 8);
+    sq += __shfl_down_sync(0xffffffff, sq, 4);
+    sq += __shfl_down_sync(0xffffffff, sq, 2);
+    sq += __shfl_down_sync(0xffffffff, sq, 1);
+    // Let threads in lane zero add warp-reduced sq atomically to global sse
+    const int lane = (threadIdx.y * blockDim.x + threadIdx.x) % 32;
+    if (lane == 0)
+        atomicAdd(reinterpret_cast<unsigned long long*>(sse.data) + plane,
+                static_cast<unsigned long long>(sq));
+}
+
+__global__ void psnr_kernel_16bpc(const VmafPicture ref, const VmafPicture dis,
+        VmafCudaBuffer sse, unsigned plane, unsigned width, unsigned height)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    int64_t sq = 0;
+    if (x < width && y < height) {
+        const int r = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(ref.data[plane]) +
+                y * ref.stride[plane])[x];
+        const int d = reinterpret_cast<const uint16_t*>(
+                reinterpret_cast<const uint8_t*>(dis.data[plane]) +
+                y * dis.stride[plane])[x];
+        const int e = r - d;
+        sq = static_cast<int64_t>(e) * e;
+    }
+
+    // 65535^2 overflows u32 once warp-accumulated, reduce in 64-bit
+    sq = warp_reduce(sq);
+    const int lane = (threadIdx.y * blockDim.x + threadIdx.x) % 32;
+    if (lane == 0)
+        atomicAdd_int64(reinterpret_cast<int64_t*>(sse.data) + plane, sq);
+}
+
+}

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.c
@@ -111,7 +111,13 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     CudaFunctions *cu_f = fex->cu_state->f;
 
     CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
-    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
+    // the work stream is deliberately legacy-blocking: producers like the
+    // ffmpeg libvmaf_cuda filter fill device pictures with synchronous-API
+    // copies that are queued on the legacy NULL stream (device-to-device
+    // memcpy does not block the host), and only blocking-flavor streams are
+    // implicitly ordered after NULL-stream work. Other extractors' created
+    // streams are unaffected, so kernel overlap with them is preserved.
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_DEFAULT, 0));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
     CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
     CHECK_CUDA(cu_f, cuEventCreate(&s->consumed, CU_EVENT_DEFAULT));

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.c
@@ -1,0 +1,350 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include <errno.h>
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "feature_collector.h"
+#include "feature_extractor.h"
+#include "cuda/integer_psnr_cuda.h"
+#include "opt.h"
+#include "picture.h"
+#include "picture_cuda.h"
+#include "cuda_helper.cuh"
+
+typedef struct PsnrStateCuda {
+    CUevent event, finished;
+    CUfunction funcbpc8, funcbpc16;
+    CUstream str, host_stream;
+    VmafCudaBuffer *sse;
+    uint64_t *sse_host;
+    void *write_score_parameters;
+    unsigned bpc;
+    bool enable_chroma;
+    bool enable_mse;
+    bool enable_apsnr;
+    bool reduced_hbd_peak;
+    uint32_t peak;
+    double psnr_max[3];
+    double min_sse;
+    struct {
+        uint64_t sse[3];
+        uint64_t n_pixels[3];
+    } apsnr;
+} PsnrStateCuda;
+
+static const VmafOption options[] = {
+    {
+        .name = "enable_chroma",
+        .help = "enable calculation for chroma channels",
+        .offset = offsetof(PsnrStateCuda, enable_chroma),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = true,
+    },
+    {
+        .name = "enable_mse",
+        .help = "enable MSE calculation",
+        .offset = offsetof(PsnrStateCuda, enable_mse),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "enable_apsnr",
+        .help = "enable APSNR calculation",
+        .offset = offsetof(PsnrStateCuda, enable_apsnr),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "reduced_hbd_peak",
+        .help = "reduce hbd peak value to align with scaled 8-bit content",
+        .offset = offsetof(PsnrStateCuda, reduced_hbd_peak),
+        .type = VMAF_OPT_TYPE_BOOL,
+        .default_val.b = false,
+    },
+    {
+        .name = "min_sse",
+        .help = "constrain the minimum possible sse",
+        .offset = offsetof(PsnrStateCuda, min_sse),
+        .type = VMAF_OPT_TYPE_DOUBLE,
+        .default_val.d = 0.0,
+        .min = 0.0,
+        .max = DBL_MAX,
+    },
+    { 0 }
+};
+
+typedef struct write_score_parameters_psnr {
+    VmafFeatureCollector *feature_collector;
+    PsnrStateCuda *s;
+    unsigned w[3], h[3];
+    unsigned index;
+} write_score_parameters_psnr;
+
+static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
+                         unsigned bpc, unsigned w, unsigned h)
+{
+    PsnrStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
+    CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->event, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
+
+    CUmodule module;
+    CHECK_CUDA(cu_f, cuModuleLoadData(&module, psnr_ptx));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->funcbpc8, module, "psnr_kernel_8bpc"));
+    CHECK_CUDA(cu_f, cuModuleGetFunction(&s->funcbpc16, module, "psnr_kernel_16bpc"));
+
+    CHECK_CUDA(cu_f, cuCtxPopCurrent(NULL));
+
+    s->bpc = bpc;
+    s->peak = s->reduced_hbd_peak ? 255 * 1 << (bpc - 8) : (1 << bpc) - 1;
+
+    if (pix_fmt == VMAF_PIX_FMT_YUV400P)
+        s->enable_chroma = false;
+
+    for (unsigned i = 0; i < 3; i++) {
+        if (s->min_sse != 0.0) {
+            const int ss_hor = pix_fmt != VMAF_PIX_FMT_YUV444P;
+            const int ss_ver = pix_fmt == VMAF_PIX_FMT_YUV420P;
+            const double mse = s->min_sse /
+                (((i && ss_hor) ? w / 2 : w) * ((i && ss_ver) ? h / 2 : h));
+            s->psnr_max[i] = ceil(10. * log10(s->peak * s->peak / mse));
+        } else {
+            s->psnr_max[i] = (6 * bpc) + 12;
+        }
+    }
+
+    int ret = 0;
+
+    s->write_score_parameters = malloc(sizeof(write_score_parameters_psnr));
+    if (!s->write_score_parameters) goto free_buf;
+    ((write_score_parameters_psnr*)s->write_score_parameters)->s = s;
+
+    ret |= vmaf_cuda_buffer_alloc(fex->cu_state, &s->sse, sizeof(uint64_t) * 3);
+    if (ret) goto free_buf;
+    ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->sse_host,
+                                       sizeof(uint64_t) * 3);
+    if (ret) goto free_buf;
+
+    return 0;
+
+free_buf:
+    if (s->sse) {
+        ret |= vmaf_cuda_buffer_free(fex->cu_state, s->sse);
+        free(s->sse);
+    }
+    if (s->write_score_parameters)
+        free(s->write_score_parameters);
+
+    return -ENOMEM;
+}
+
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+static char *mse_name[3] = { "mse_y", "mse_cb", "mse_cr" };
+static char *psnr_name[3] = { "psnr_y", "psnr_cb", "psnr_cr" };
+
+static int write_scores(write_score_parameters_psnr *params)
+{
+    PsnrStateCuda *s = params->s;
+    VmafFeatureCollector *feature_collector = params->feature_collector;
+
+    const double peak = (s->bpc == 8) ? 255. : (double) s->peak;
+    const unsigned n = s->enable_chroma ? 3 : 1;
+
+    int err = 0;
+    for (unsigned p = 0; p < n; p++) {
+        const uint64_t sse = s->sse_host[p];
+
+        if (s->enable_apsnr) {
+            s->apsnr.sse[p] += sse;
+            s->apsnr.n_pixels[p] += (uint64_t)params->w[p] * params->h[p];
+        }
+
+        const double mse =
+            ((double) sse) / ((double)params->w[p] * params->h[p]);
+        const double psnr =
+            MIN(10. * log10(peak * peak / MAX(mse, 1e-16)), s->psnr_max[p]);
+
+        err |= vmaf_feature_collector_append(feature_collector, psnr_name[p],
+                                             psnr, params->index);
+        if (s->enable_mse) {
+            err |= vmaf_feature_collector_append(feature_collector, mse_name[p],
+                                                 mse, params->index);
+        }
+    }
+
+    return err;
+}
+
+static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
+                            VmafPicture *ref_pic_90, VmafPicture *dist_pic,
+                            VmafPicture *dist_pic_90, unsigned index,
+                            VmafFeatureCollector *feature_collector)
+{
+    PsnrStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+
+    (void) ref_pic_90;
+    (void) dist_pic_90;
+
+    // this is done to ensure that the CPU does not overwrite the buffer
+    // params for write_scores
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+
+    const CUstream pic_stream = vmaf_cuda_picture_get_stream(ref_pic);
+    const unsigned n = s->enable_chroma ? 3 : 1;
+
+    // Reset device SSE on the picture stream so the reset is stream-ordered
+    // with the kernels below (unlike a reset on s->str, which would race)
+    CHECK_CUDA(cu_f, cuMemsetD8Async(s->sse->data, 0, sizeof(uint64_t) * 3,
+                pic_stream));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(pic_stream,
+                vmaf_cuda_picture_get_ready_event(dist_pic),
+                CU_EVENT_WAIT_DEFAULT));
+
+    const CUfunction func = (ref_pic->bpc == 8) ? s->funcbpc8 : s->funcbpc16;
+    const int block_dim_x = 16;
+    const int block_dim_y = 16;
+    for (unsigned p = 0; p < n; p++) {
+        unsigned plane = p;
+        unsigned width = ref_pic->w[p];
+        unsigned height = ref_pic->h[p];
+        void *kernel_params[] = {
+            (void*) ref_pic, (void*) dist_pic, (void*) s->sse,
+            &plane, &width, &height,
+        };
+        CHECK_CUDA(cu_f, cuLaunchKernel(func,
+                    DIV_ROUND_UP(width, block_dim_x),
+                    DIV_ROUND_UP(height, block_dim_y), 1,
+                    block_dim_x, block_dim_y, 1, 0,
+                    pic_stream, kernel_params, NULL));
+    }
+    CHECK_CUDA(cu_f, cuEventRecord(s->event, pic_stream));
+    // This event ensures the input buffer is consumed
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str, s->event, CU_EVENT_WAIT_DEFAULT));
+
+    // Download sse
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(s->sse_host, s->sse->data,
+                sizeof(uint64_t) * 3, s->str));
+    CHECK_CUDA(cu_f, cuEventRecord(s->finished, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->host_stream, s->finished,
+                CU_EVENT_WAIT_DEFAULT));
+
+    write_score_parameters_psnr *params = s->write_score_parameters;
+    params->feature_collector = feature_collector;
+    for (unsigned p = 0; p < n; p++) {
+        params->w[p] = ref_pic->w[p];
+        params->h[p] = ref_pic->h[p];
+    }
+    params->index = index;
+    CHECK_CUDA(cu_f, cuLaunchHostFunc(s->host_stream, (CUhostFn*)write_scores,
+                s->write_score_parameters));
+
+    return 0;
+}
+
+static int flush_fex_cuda(VmafFeatureExtractor *fex,
+                          VmafFeatureCollector *feature_collector)
+{
+    PsnrStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+    const char *apsnr_name[3] = { "apsnr_y", "apsnr_cb", "apsnr_cr" };
+
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+
+    // aggregates only: set_aggregate is idempotent, so a second flush from
+    // the threaded + CUDA flush paths cannot double-append
+    int err = 0;
+    if (s->enable_apsnr) {
+        for (unsigned i = 0; i < 3; i++) {
+
+            double apsnr = 10 * (log10(s->peak * s->peak) +
+                                 log10(s->apsnr.n_pixels[i]) -
+                                 log10(s->apsnr.sse[i]));
+
+            double max_apsnr =
+                ceil(10 * log10(s->peak * s->peak *
+                                s->apsnr.n_pixels[i] *
+                                2));
+
+            err |=
+                vmaf_feature_collector_set_aggregate(feature_collector,
+                                                     apsnr_name[i],
+                                                     MIN(apsnr, max_apsnr));
+        }
+    }
+
+    return (err < 0) ? err : !err;
+}
+
+static int close_fex_cuda(VmafFeatureExtractor *fex)
+{
+    PsnrStateCuda *s = fex->priv;
+    CudaFunctions *cu_f = fex->cu_state->f;
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->event));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->finished));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->str));
+    CHECK_CUDA(cu_f, cuStreamDestroy(s->host_stream));
+
+    int ret = 0;
+
+    if (s->sse) {
+        ret |= vmaf_cuda_buffer_free(fex->cu_state, s->sse);
+        free(s->sse);
+    }
+    if (s->sse_host)
+        ret |= vmaf_cuda_buffer_host_free(fex->cu_state, s->sse_host);
+
+    if (s->write_score_parameters)
+        free(s->write_score_parameters);
+
+    return ret;
+}
+
+static const char *provided_features[] = {
+    "psnr_y", "psnr_cb", "psnr_cr",
+    NULL
+};
+
+VmafFeatureExtractor vmaf_fex_integer_psnr_cuda = {
+    .name = "psnr_cuda",
+    .options = options,
+    .init = init_fex_cuda,
+    .extract = extract_fex_cuda,
+    .flush = flush_fex_cuda,
+    .close = close_fex_cuda,
+    .priv_size = sizeof(PsnrStateCuda),
+    .provided_features = provided_features,
+    .flags = VMAF_FEATURE_EXTRACTOR_TEMPORAL | VMAF_FEATURE_EXTRACTOR_CUDA |
+             VMAF_FEATURE_EXTRACTOR_CUDA_CHROMA,
+};

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.c
@@ -239,20 +239,22 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
                 s->str));
 
     const CUfunction func = (ref_pic->bpc == 8) ? s->funcbpc8 : s->funcbpc16;
-    const int block_dim_x = 16;
-    const int block_dim_y = 16;
+    const unsigned vec = (ref_pic->bpc == 8) ? 4 : 2;
     for (unsigned p = 0; p < n; p++) {
         unsigned plane = p;
         unsigned width = ref_pic->w[p];
         unsigned height = ref_pic->h[p];
+        // 1-D grid-stride kernel over vectorized loads; cap the grid so
+        // tail-of-wave blocks stay busy
+        unsigned n_blocks = DIV_ROUND_UP(width / vec * height, 256);
+        if (n_blocks > 2048) n_blocks = 2048;
+        if (!n_blocks) n_blocks = 1;
         void *kernel_params[] = {
             (void*) ref_pic, (void*) dist_pic, (void*) s->sse,
             &plane, &width, &height,
         };
         CHECK_CUDA(cu_f, cuLaunchKernel(func,
-                    DIV_ROUND_UP(width, block_dim_x),
-                    DIV_ROUND_UP(height, block_dim_y), 1,
-                    block_dim_x, block_dim_y, 1, 0,
+                    n_blocks, 1, 1, 256, 1, 1, 0,
                     s->str, kernel_params, NULL));
     }
 

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.c
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.c
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.c
@@ -34,7 +34,8 @@
 #include "cuda_helper.cuh"
 
 typedef struct PsnrStateCuda {
-    CUevent event, finished;
+    CUevent finished, consumed;
+    CUevent slot_done[2];
     CUfunction funcbpc8, funcbpc16;
     CUstream str, host_stream;
     VmafCudaBuffer *sse;
@@ -98,6 +99,7 @@ static const VmafOption options[] = {
 typedef struct write_score_parameters_psnr {
     VmafFeatureCollector *feature_collector;
     PsnrStateCuda *s;
+    const uint64_t *sse;
     unsigned w[3], h[3];
     unsigned index;
 } write_score_parameters_psnr;
@@ -111,8 +113,10 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
     CHECK_CUDA(cu_f, cuCtxPushCurrent(fex->cu_state->ctx));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->str, CU_STREAM_NON_BLOCKING, 0));
     CHECK_CUDA(cu_f, cuStreamCreateWithPriority(&s->host_stream, CU_STREAM_NON_BLOCKING, 0));
-    CHECK_CUDA(cu_f, cuEventCreate(&s->event, CU_EVENT_DEFAULT));
     CHECK_CUDA(cu_f, cuEventCreate(&s->finished, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->consumed, CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[0], CU_EVENT_DEFAULT));
+    CHECK_CUDA(cu_f, cuEventCreate(&s->slot_done[1], CU_EVENT_DEFAULT));
 
     CUmodule module;
     CHECK_CUDA(cu_f, cuModuleLoadData(&module, psnr_ptx));
@@ -141,14 +145,17 @@ static int init_fex_cuda(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt
 
     int ret = 0;
 
-    s->write_score_parameters = malloc(sizeof(write_score_parameters_psnr));
+    // two write_score slots + two pinned readback slots so frame i+1 never
+    // has to wait for frame i's host callback (see slot_done in extract)
+    s->write_score_parameters = malloc(sizeof(write_score_parameters_psnr) * 2);
     if (!s->write_score_parameters) goto free_buf;
-    ((write_score_parameters_psnr*)s->write_score_parameters)->s = s;
+    for (unsigned i = 0; i < 2; i++)
+        ((write_score_parameters_psnr*)s->write_score_parameters)[i].s = s;
 
     ret |= vmaf_cuda_buffer_alloc(fex->cu_state, &s->sse, sizeof(uint64_t) * 3);
     if (ret) goto free_buf;
     ret |= vmaf_cuda_buffer_host_alloc(fex->cu_state, (void**)&s->sse_host,
-                                       sizeof(uint64_t) * 3);
+                                       sizeof(uint64_t) * 3 * 2);
     if (ret) goto free_buf;
 
     return 0;
@@ -179,7 +186,7 @@ static int write_scores(write_score_parameters_psnr *params)
 
     int err = 0;
     for (unsigned p = 0; p < n; p++) {
-        const uint64_t sse = s->sse_host[p];
+        const uint64_t sse = params->sse[p];
 
         if (s->enable_apsnr) {
             s->apsnr.sse[p] += sse;
@@ -213,20 +220,23 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
     (void) ref_pic_90;
     (void) dist_pic_90;
 
-    // this is done to ensure that the CPU does not overwrite the buffer
-    // params for write_scores
-    CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
+    // two slots: wait for frame index-2's host callback (effectively always
+    // complete) instead of stalling on the whole previous frame's work
+    const unsigned slot = index & 1;
+    CHECK_CUDA(cu_f, cuEventSynchronize(s->slot_done[slot]));
 
-    const CUstream pic_stream = vmaf_cuda_picture_get_stream(ref_pic);
     const unsigned n = s->enable_chroma ? 3 : 1;
 
-    // Reset device SSE on the picture stream so the reset is stream-ordered
-    // with the kernels below (unlike a reset on s->str, which would race)
-    CHECK_CUDA(cu_f, cuMemsetD8Async(s->sse->data, 0, sizeof(uint64_t) * 3,
-                pic_stream));
-    CHECK_CUDA(cu_f, cuStreamWaitEvent(pic_stream,
+    // kernels run on the extractor's own stream so they overlap with other
+    // extractors' work on the picture streams; wait for both uploads first
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
+                vmaf_cuda_picture_get_ready_event(ref_pic),
+                CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str,
                 vmaf_cuda_picture_get_ready_event(dist_pic),
                 CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuMemsetD8Async(s->sse->data, 0, sizeof(uint64_t) * 3,
+                s->str));
 
     const CUfunction func = (ref_pic->bpc == 8) ? s->funcbpc8 : s->funcbpc16;
     const int block_dim_x = 16;
@@ -243,29 +253,38 @@ static int extract_fex_cuda(VmafFeatureExtractor *fex, VmafPicture *ref_pic,
                     DIV_ROUND_UP(width, block_dim_x),
                     DIV_ROUND_UP(height, block_dim_y), 1,
                     block_dim_x, block_dim_y, 1, 0,
-                    pic_stream, kernel_params, NULL));
+                    s->str, kernel_params, NULL));
     }
-    CHECK_CUDA(cu_f, cuEventRecord(s->event, pic_stream));
-    // This event ensures the input buffer is consumed
-    CHECK_CUDA(cu_f, cuStreamWaitEvent(s->str, s->event, CU_EVENT_WAIT_DEFAULT));
 
-    // Download sse
-    CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
-    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(s->sse_host, s->sse->data,
+    // lifetime handshake: the pool recycles a picture once the `finished`
+    // event its own stream records (after the fex loop) has completed, so
+    // make both picture streams wait for our reads
+    CHECK_CUDA(cu_f, cuEventRecord(s->consumed, s->str));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(ref_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
+    CHECK_CUDA(cu_f, cuStreamWaitEvent(vmaf_cuda_picture_get_stream(dist_pic),
+                s->consumed, CU_EVENT_WAIT_DEFAULT));
+
+    // Download sse into this slot's readback segment
+    uint64_t *sse_host = s->sse_host + slot * 3;
+    CHECK_CUDA(cu_f, cuMemcpyDtoHAsync(sse_host, s->sse->data,
                 sizeof(uint64_t) * 3, s->str));
     CHECK_CUDA(cu_f, cuEventRecord(s->finished, s->str));
     CHECK_CUDA(cu_f, cuStreamWaitEvent(s->host_stream, s->finished,
                 CU_EVENT_WAIT_DEFAULT));
 
-    write_score_parameters_psnr *params = s->write_score_parameters;
+    write_score_parameters_psnr *params =
+        &((write_score_parameters_psnr*)s->write_score_parameters)[slot];
     params->feature_collector = feature_collector;
+    params->sse = sse_host;
     for (unsigned p = 0; p < n; p++) {
         params->w[p] = ref_pic->w[p];
         params->h[p] = ref_pic->h[p];
     }
     params->index = index;
     CHECK_CUDA(cu_f, cuLaunchHostFunc(s->host_stream, (CUhostFn*)write_scores,
-                s->write_score_parameters));
+                params));
+    CHECK_CUDA(cu_f, cuEventRecord(s->slot_done[slot], s->host_stream));
 
     return 0;
 }
@@ -311,8 +330,10 @@ static int close_fex_cuda(VmafFeatureExtractor *fex)
     CudaFunctions *cu_f = fex->cu_state->f;
     CHECK_CUDA(cu_f, cuStreamSynchronize(s->str));
     CHECK_CUDA(cu_f, cuStreamSynchronize(s->host_stream));
-    CHECK_CUDA(cu_f, cuEventDestroy(s->event));
     CHECK_CUDA(cu_f, cuEventDestroy(s->finished));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->consumed));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[0]));
+    CHECK_CUDA(cu_f, cuEventDestroy(s->slot_done[1]));
     CHECK_CUDA(cu_f, cuStreamDestroy(s->str));
     CHECK_CUDA(cu_f, cuStreamDestroy(s->host_stream));
 

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.h
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.h
@@ -1,0 +1,27 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#ifndef FEATURE_PSNR_CUDA_H_
+#define FEATURE_PSNR_CUDA_H_
+
+#include <stdint.h>
+#include "common.h"
+
+extern const unsigned char psnr_ptx[];
+#endif /* _FEATURE_PSNR_CUDA_H_ */

--- a/libvmaf/src/feature/cuda/integer_psnr_cuda.h
+++ b/libvmaf/src/feature/cuda/integer_psnr_cuda.h
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -55,6 +55,7 @@ extern VmafFeatureExtractor vmaf_fex_integer_adm_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_vif_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_motion_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_psnr_cuda;
+extern VmafFeatureExtractor vmaf_fex_float_ssim_cuda;
 #endif
 extern VmafFeatureExtractor vmaf_fex_null;
 
@@ -83,6 +84,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_integer_vif_cuda,
     &vmaf_fex_integer_motion_cuda,
     &vmaf_fex_integer_psnr_cuda,
+    &vmaf_fex_float_ssim_cuda,
 #endif
     &vmaf_fex_null,
     NULL

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -54,6 +54,7 @@ extern VmafFeatureExtractor vmaf_fex_cambi;
 extern VmafFeatureExtractor vmaf_fex_integer_adm_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_vif_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_motion_cuda;
+extern VmafFeatureExtractor vmaf_fex_integer_psnr_cuda;
 #endif
 extern VmafFeatureExtractor vmaf_fex_null;
 
@@ -81,6 +82,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_integer_adm_cuda,
     &vmaf_fex_integer_vif_cuda,
     &vmaf_fex_integer_motion_cuda,
+    &vmaf_fex_integer_psnr_cuda,
 #endif
     &vmaf_fex_null,
     NULL

--- a/libvmaf/src/feature/feature_extractor.c
+++ b/libvmaf/src/feature/feature_extractor.c
@@ -56,6 +56,7 @@ extern VmafFeatureExtractor vmaf_fex_integer_vif_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_motion_cuda;
 extern VmafFeatureExtractor vmaf_fex_integer_psnr_cuda;
 extern VmafFeatureExtractor vmaf_fex_float_ssim_cuda;
+extern VmafFeatureExtractor vmaf_fex_ciede_cuda;
 #endif
 extern VmafFeatureExtractor vmaf_fex_null;
 
@@ -85,6 +86,7 @@ static VmafFeatureExtractor *feature_extractor_list[] = {
     &vmaf_fex_integer_motion_cuda,
     &vmaf_fex_integer_psnr_cuda,
     &vmaf_fex_float_ssim_cuda,
+    &vmaf_fex_ciede_cuda,
 #endif
     &vmaf_fex_null,
     NULL

--- a/libvmaf/src/feature/feature_extractor.h
+++ b/libvmaf/src/feature/feature_extractor.h
@@ -39,6 +39,7 @@ enum VmafFeatureExtractorFlags {
     VMAF_FEATURE_EXTRACTOR_CUDA = 1 << 1,
     VMAF_FEATURE_FRAME_SYNC = 1 << 2,
     VMAF_FEATURE_EXTRACTOR_PREV_REF = 1 << 3,
+    VMAF_FEATURE_EXTRACTOR_CUDA_CHROMA = 1 << 4,
 };
 
 typedef struct VmafFeatureExtractor {

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -800,7 +800,9 @@ static int translate_picture_device(VmafContext *vmaf, VmafPicture *pic,
         return err;
     }
 
-    err = vmaf_cuda_picture_download_async(pic, pic_host, 0x1);
+    // host pictures always carry every plane, so CPU feature extractors
+    // that read chroma (psnr, ciede, ...) expect all of them here
+    err = vmaf_cuda_picture_download_async(pic, pic_host, 0x7);
     if (err) {
         vmaf_log(VMAF_LOG_LEVEL_ERROR,
                  "problem moving cuda pic into host buffer\n");

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -740,6 +740,21 @@ enum  {
     HW_FLAG_DEVICE = 1 << 1,
 };
 
+static uint8_t rfe_cuda_plane_mask(RegisteredFeatureExtractors *rfe)
+{
+    // existing CUDA feature extractors are luma-only, so only upload the
+    // chroma planes when a registered extractor declares it reads them
+    uint8_t mask = 0x1;
+    for (unsigned i = 0; i < rfe->cnt; i++) {
+        const uint64_t flags = rfe->fex_ctx[i]->fex->flags;
+        if ((flags & VMAF_FEATURE_EXTRACTOR_CUDA) &&
+            (flags & VMAF_FEATURE_EXTRACTOR_CUDA_CHROMA))
+            mask |= 0x6;
+    }
+
+    return mask;
+}
+
 static int translate_picture_host(VmafContext *vmaf, VmafPicture *pic,
                                   VmafPicture *pic_device, unsigned hw_flags)
 {
@@ -754,7 +769,8 @@ static int translate_picture_host(VmafContext *vmaf, VmafPicture *pic,
         if (!vmaf->cuda.state.ctx)
             return -EINVAL;
         err |= vmaf_ring_buffer_fetch_next_picture(vmaf->cuda.ring_buffer, pic_device);
-        err |= vmaf_cuda_picture_upload_async(pic_device, pic, 0x1);
+        err |= vmaf_cuda_picture_upload_async(pic_device, pic,
+                rfe_cuda_plane_mask(&vmaf->registered_feature_extractors));
         if (err) {
             vmaf_log(VMAF_LOG_LEVEL_ERROR,
                     "problem moving host pic into cuda device buffer\n");

--- a/libvmaf/src/libvmaf.c
+++ b/libvmaf/src/libvmaf.c
@@ -649,6 +649,12 @@ static int flush_context_threaded(VmafContext *vmaf)
     for (unsigned i = 0; i < rfe.cnt; i++) {
         if (!(rfe.fex_ctx[i]->fex->flags & VMAF_FEATURE_EXTRACTOR_TEMPORAL))
             continue;
+        /* CUDA feature extractors are flushed by the HAVE_CUDA block in
+         * flush_context(); flushing them here as well double-appends their
+         * final scores. */
+        if (rfe.fex_ctx[i]->fex->flags & VMAF_FEATURE_EXTRACTOR_CUDA)
+            continue;
+
         err |= vmaf_feature_extractor_context_flush(rfe.fex_ctx[i],
                                                     vmaf->feature_collector);
     }

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -356,6 +356,7 @@ if is_cuda_enabled
         'motion_score' : [feature_src_dir + 'cuda/integer_motion/motion_score.cu'],
         'psnr' : [feature_src_dir + 'cuda/integer_psnr/psnr.cu'],
         'ssim' : [feature_src_dir + 'cuda/float_ssim/ssim.cu'],
+        'ciede' : [feature_src_dir + 'cuda/ciede/ciede.cu'],
     }
     message(cuda_cu_sources)
     cuda_sources = [
@@ -545,6 +546,7 @@ if is_cuda_enabled
         feature_src_dir + 'cuda/integer_motion_cuda.c',
         feature_src_dir + 'cuda/integer_psnr_cuda.c',
         feature_src_dir + 'cuda/float_ssim_cuda.c',
+        feature_src_dir + 'cuda/ciede_cuda.c',
     ]
 endif
 

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -354,6 +354,7 @@ if is_cuda_enabled
         'adm_decouple' : [feature_src_dir + 'cuda/integer_adm/adm_decouple.cu'],
         'filter1d' : [feature_src_dir + 'cuda/integer_vif/filter1d.cu'],
         'motion_score' : [feature_src_dir + 'cuda/integer_motion/motion_score.cu'],
+        'psnr' : [feature_src_dir + 'cuda/integer_psnr/psnr.cu'],
     }
     message(cuda_cu_sources)
     cuda_sources = [
@@ -541,6 +542,7 @@ if is_cuda_enabled
         feature_src_dir + 'cuda/integer_adm_cuda.c',
         feature_src_dir + 'cuda/integer_vif_cuda.c',
         feature_src_dir + 'cuda/integer_motion_cuda.c',
+        feature_src_dir + 'cuda/integer_psnr_cuda.c',
     ]
 endif
 

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -355,6 +355,7 @@ if is_cuda_enabled
         'filter1d' : [feature_src_dir + 'cuda/integer_vif/filter1d.cu'],
         'motion_score' : [feature_src_dir + 'cuda/integer_motion/motion_score.cu'],
         'psnr' : [feature_src_dir + 'cuda/integer_psnr/psnr.cu'],
+        'ssim' : [feature_src_dir + 'cuda/float_ssim/ssim.cu'],
     }
     message(cuda_cu_sources)
     cuda_sources = [
@@ -543,6 +544,7 @@ if is_cuda_enabled
         feature_src_dir + 'cuda/integer_vif_cuda.c',
         feature_src_dir + 'cuda/integer_motion_cuda.c',
         feature_src_dir + 'cuda/integer_psnr_cuda.c',
+        feature_src_dir + 'cuda/float_ssim_cuda.c',
     ]
 endif
 

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -203,9 +203,18 @@ test_cuda_psnr_ssim_parity = executable('test_cuda_psnr_ssim_parity',
     c_args: ['-DHAVE_CUDA=1']
 )
 
+test_cuda_ciede_parity = executable('test_cuda_ciede_parity',
+    ['test.c', 'test_cuda_ciede_parity.c'],
+    include_directories : [libvmaf_inc, test_inc],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+    dependencies: cuda_dependency,
+    c_args: ['-DHAVE_CUDA=1']
+)
+
 test('test_ring_buffer', test_ring_buffer)
 test('test_cuda_pic_preallocation', test_cuda_pic_preallocation)
 test('test_cuda_psnr_ssim_parity', test_cuda_psnr_ssim_parity)
+test('test_cuda_ciede_parity', test_cuda_ciede_parity)
 endif
 
 test_pic_preallocation = executable('test_pic_preallocation',

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -195,8 +195,17 @@ test_cuda_pic_preallocation = executable('test_cuda_pic_preallocation',
     c_args: ['-DHAVE_CUDA=1']
 )
 
+test_cuda_psnr_ssim_parity = executable('test_cuda_psnr_ssim_parity',
+    ['test.c', 'test_cuda_psnr_ssim_parity.c'],
+    include_directories : [libvmaf_inc, test_inc],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+    dependencies: cuda_dependency,
+    c_args: ['-DHAVE_CUDA=1']
+)
+
 test('test_ring_buffer', test_ring_buffer)
 test('test_cuda_pic_preallocation', test_cuda_pic_preallocation)
+test('test_cuda_psnr_ssim_parity', test_cuda_psnr_ssim_parity)
 endif
 
 test_pic_preallocation = executable('test_pic_preallocation',

--- a/libvmaf/test/test_cuda_ciede_parity.c
+++ b/libvmaf/test/test_cuda_ciede_parity.c
@@ -1,0 +1,190 @@
+/**
+ *
+ *  Copyright 2026 Bardie Høgh Joensen
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/*
+ * CPU vs CUDA parity test for the ciede_cuda feature extractor. Unlike the
+ * psnr_cuda/ssim_cuda parity test this asserts a small tolerance rather than
+ * bit-exactness: ciede is dominated by libm transcendentals, which differ
+ * between glibc and CUDA in the low bits, and the device math runs in
+ * float32 (the CPU reference truncates every intermediate to float anyway).
+ *
+ * Uses YUV420P input so the fused nearest-neighbor chroma upsampling in the
+ * kernel is exercised against the CPU's scale_chroma_planes. Also checks the
+ * identical-frame case, where both implementations must return +inf.
+ *
+ * Exits with meson's SKIP code (77) when no CUDA device is available so CI
+ * without a GPU reports the test as skipped.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test.h"
+
+#include "libvmaf/libvmaf.h"
+#include "libvmaf/libvmaf_cuda.h"
+#include "libvmaf/picture.h"
+
+#define N_FRAMES 4
+#define TEST_W 768
+#define TEST_H 432
+
+#define CIEDE_EPS 1e-3
+
+static uint32_t lcg_state;
+
+static uint32_t lcg_next(void)
+{
+    lcg_state = lcg_state * 1664525u + 1013904223u;
+    return lcg_state >> 16;
+}
+
+// frame N_FRAMES-1 is generated identical (ref == dist) to exercise the
+// de00_sum == 0 -> +inf path
+static void fill_pictures(VmafPicture *ref, VmafPicture *dist, unsigned bpc,
+                          unsigned index)
+{
+    const unsigned peak = (1 << bpc) - 1;
+    const int identical = index == N_FRAMES - 1;
+    lcg_state = 54321u + index * 7919u;
+
+    for (unsigned p = 0; p < 3; p++) {
+        for (unsigned i = 0; i < ref->h[p]; i++) {
+            for (unsigned j = 0; j < ref->w[p]; j++) {
+                const int v = (i + j + lcg_next()) % (peak + 1);
+                const int noise = identical ? 0 : (int)(lcg_next() % 31) - 15;
+                int vd = v + noise;
+                if (vd < 0) vd = 0;
+                if (vd > (int)peak) vd = peak;
+                if (bpc == 8) {
+                    ((uint8_t*)ref->data[p])[i * ref->stride[p] + j] = v;
+                    ((uint8_t*)dist->data[p])[i * dist->stride[p] + j] = vd;
+                } else {
+                    ((uint16_t*)ref->data[p])[i * (ref->stride[p] / 2) + j] = v;
+                    ((uint16_t*)dist->data[p])[i * (dist->stride[p] / 2) + j] = vd;
+                }
+            }
+        }
+    }
+}
+
+// returns 0 on success, 1 when CUDA is unavailable (caller should skip)
+static int run_pass(int use_cuda, unsigned bpc, double scores[N_FRAMES],
+                    char **fail)
+{
+    int err = 0;
+    *fail = NULL;
+
+    VmafConfiguration cfg = {
+        .log_level = VMAF_LOG_LEVEL_ERROR,
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, cfg);
+    if (err) { *fail = "problem during vmaf_init"; return 0; }
+
+    if (use_cuda) {
+        VmafCudaState *cu_state;
+        VmafCudaConfiguration cuda_cfg = { 0 };
+        err = vmaf_cuda_state_init(&cu_state, cuda_cfg);
+        if (err) {
+            vmaf_close(vmaf);
+            return 1; // no CUDA device, skip
+        }
+        err = vmaf_cuda_import_state(vmaf, cu_state);
+        if (err) { *fail = "problem during vmaf_cuda_import_state"; return 0; }
+    }
+
+    err = vmaf_use_feature(vmaf, use_cuda ? "ciede_cuda" : "ciede", NULL);
+    if (err) { *fail = "problem during vmaf_use_feature"; return 0; }
+
+    for (unsigned i = 0; i < N_FRAMES; i++) {
+        VmafPicture ref, dist;
+        err = vmaf_picture_alloc(&ref, VMAF_PIX_FMT_YUV420P, bpc,
+                                 TEST_W, TEST_H);
+        err |= vmaf_picture_alloc(&dist, VMAF_PIX_FMT_YUV420P, bpc,
+                                  TEST_W, TEST_H);
+        if (err) { *fail = "problem during vmaf_picture_alloc"; return 0; }
+        fill_pictures(&ref, &dist, bpc, i);
+        err = vmaf_read_pictures(vmaf, &ref, &dist, i);
+        if (err) { *fail = "problem during vmaf_read_pictures"; return 0; }
+    }
+
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    if (err) { *fail = "problem during vmaf_read_pictures flush"; return 0; }
+
+    for (unsigned i = 0; i < N_FRAMES; i++) {
+        err = vmaf_feature_score_at_index(vmaf, "ciede2000", &scores[i], i);
+        if (err) { *fail = "problem during vmaf_feature_score_at_index"; return 0; }
+    }
+
+    err = vmaf_close(vmaf);
+    if (err) { *fail = "problem during vmaf_close"; return 0; }
+
+    return 0;
+}
+
+static char *parity(unsigned bpc)
+{
+    double cpu[N_FRAMES], gpu[N_FRAMES];
+    char *fail = NULL;
+
+    run_pass(0, bpc, cpu, &fail);
+    if (fail) return fail;
+
+    if (run_pass(1, bpc, gpu, &fail)) {
+        fprintf(stderr, "no CUDA device available, skipping\n");
+        exit(77);
+    }
+    if (fail) return fail;
+
+    // the identical last frame must be +inf on both sides
+    mu_assert("cpu identical-frame score must be +inf",
+              isinf(cpu[N_FRAMES - 1]) && cpu[N_FRAMES - 1] > 0);
+    mu_assert("cuda identical-frame score must be +inf",
+              isinf(gpu[N_FRAMES - 1]) && gpu[N_FRAMES - 1] > 0);
+
+    for (unsigned i = 0; i < N_FRAMES - 1; i++) {
+        if (fabs(cpu[i] - gpu[i]) > CIEDE_EPS) {
+            fprintf(stderr, "mismatch %u bpc, frame %u: cpu=%.9f gpu=%.9f\n",
+                    bpc, i, cpu[i], gpu[i]);
+            return "cpu/cuda ciede2000 score mismatch";
+        }
+    }
+
+    return NULL;
+}
+
+static char *test_ciede_cuda_parity_8bpc(void)
+{
+    return parity(8);
+}
+
+static char *test_ciede_cuda_parity_10bpc(void)
+{
+    return parity(10);
+}
+
+char *run_tests()
+{
+    mu_run_test(test_ciede_cuda_parity_8bpc);
+    mu_run_test(test_ciede_cuda_parity_10bpc);
+    return NULL;
+}

--- a/libvmaf/test/test_cuda_psnr_ssim_parity.c
+++ b/libvmaf/test/test_cuda_psnr_ssim_parity.c
@@ -29,6 +29,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "test.h"
@@ -178,8 +179,10 @@ static char *parity(unsigned bpc)
     if (fail) return fail;
 
     if (run_pass(1, bpc, gpu, &fail)) {
+        // meson exitcode protocol: 77 = SKIP, so CI without a GPU reports
+        // this as skipped rather than silently passing
         fprintf(stderr, "no CUDA device available, skipping\n");
-        return NULL;
+        exit(77);
     }
     if (fail) return fail;
 

--- a/libvmaf/test/test_cuda_psnr_ssim_parity.c
+++ b/libvmaf/test/test_cuda_psnr_ssim_parity.c
@@ -1,0 +1,216 @@
+/**
+ *
+ *  Copyright 2016-2023 Netflix, Inc.
+ *  Copyright 2021 NVIDIA Corporation.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+/*
+ * CPU vs CUDA parity test for the psnr_cuda and ssim_cuda feature
+ * extractors. Runs the same deterministic synthetic frames through the CPU
+ * extractors (psnr, float_ssim) and the CUDA extractors (psnr_cuda,
+ * ssim_cuda) and asserts per-frame score equality within a small epsilon.
+ *
+ * Skips (passes with a notice) when no CUDA device is available so CI
+ * without a GPU stays green.
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test.h"
+
+#include "libvmaf/libvmaf.h"
+#include "libvmaf/libvmaf_cuda.h"
+#include "libvmaf/picture.h"
+
+#define N_FRAMES 5
+// 768x432 makes float_ssim pick decimation scale 2, so the full pipeline
+// (decimate + convolve) is exercised, not just the scale=1 path
+#define TEST_W 768
+#define TEST_H 432
+
+#define PSNR_EPS 1e-9
+#define SSIM_EPS 1e-7
+
+static const char *score_keys[] = { "psnr_y", "psnr_cb", "psnr_cr",
+                                    "float_ssim" };
+#define N_KEYS 4
+
+static uint32_t lcg_state;
+
+static uint32_t lcg_next(void)
+{
+    lcg_state = lcg_state * 1664525u + 1013904223u;
+    return lcg_state >> 16;
+}
+
+static void fill_pictures(VmafPicture *ref, VmafPicture *dist, unsigned bpc,
+                          unsigned index)
+{
+    const unsigned peak = (1 << bpc) - 1;
+    lcg_state = 12345u + index * 7919u;
+
+    for (unsigned p = 0; p < 3; p++) {
+        if (bpc == 8) {
+            uint8_t *r = ref->data[p];
+            uint8_t *d = dist->data[p];
+            for (unsigned i = 0; i < ref->h[p]; i++) {
+                for (unsigned j = 0; j < ref->w[p]; j++) {
+                    const int v = (i + j + lcg_next()) % (peak + 1);
+                    const int noise = (int)(lcg_next() % 15) - 7;
+                    int vd = v + noise;
+                    if (vd < 0) vd = 0;
+                    if (vd > (int)peak) vd = peak;
+                    r[j] = v;
+                    d[j] = vd;
+                }
+                r += ref->stride[p];
+                d += dist->stride[p];
+            }
+        } else {
+            uint16_t *r = ref->data[p];
+            uint16_t *d = dist->data[p];
+            for (unsigned i = 0; i < ref->h[p]; i++) {
+                for (unsigned j = 0; j < ref->w[p]; j++) {
+                    const int v = (i + j + lcg_next()) % (peak + 1);
+                    const int noise = (int)(lcg_next() % 61) - 30;
+                    int vd = v + noise;
+                    if (vd < 0) vd = 0;
+                    if (vd > (int)peak) vd = peak;
+                    r[j] = v;
+                    d[j] = vd;
+                }
+                r += ref->stride[p] / 2;
+                d += dist->stride[p] / 2;
+            }
+        }
+    }
+}
+
+// returns 0 on success, 1 when CUDA is unavailable (caller should skip)
+static int run_pass(int use_cuda, unsigned bpc,
+                    double scores[N_FRAMES][N_KEYS], char **fail)
+{
+    int err = 0;
+    *fail = NULL;
+
+    VmafConfiguration cfg = {
+        .log_level = VMAF_LOG_LEVEL_ERROR,
+        .n_threads = use_cuda ? 2 : 0, // threads + CUDA: the double-flush path
+    };
+
+    VmafContext *vmaf;
+    err = vmaf_init(&vmaf, cfg);
+    if (err) { *fail = "problem during vmaf_init"; return 0; }
+
+    if (use_cuda) {
+        VmafCudaState *cu_state;
+        VmafCudaConfiguration cuda_cfg = { 0 };
+        err = vmaf_cuda_state_init(&cu_state, cuda_cfg);
+        if (err) {
+            vmaf_close(vmaf);
+            return 1; // no CUDA device, skip
+        }
+        err = vmaf_cuda_import_state(vmaf, cu_state);
+        if (err) { *fail = "problem during vmaf_cuda_import_state"; return 0; }
+    }
+
+    // enable_apsnr makes the temporal flush emit aggregates; combined with
+    // n_threads it regression-tests flush idempotency under the double-flush
+    VmafFeatureDictionary *dict = NULL;
+    err = vmaf_feature_dictionary_set(&dict, "enable_apsnr", "true");
+    if (err) { *fail = "problem during vmaf_feature_dictionary_set"; return 0; }
+
+    err = vmaf_use_feature(vmaf, use_cuda ? "psnr_cuda" : "psnr", dict);
+    if (err) { *fail = "problem during vmaf_use_feature psnr"; return 0; }
+    err = vmaf_use_feature(vmaf, use_cuda ? "ssim_cuda" : "float_ssim", NULL);
+    if (err) { *fail = "problem during vmaf_use_feature ssim"; return 0; }
+
+    for (unsigned i = 0; i < N_FRAMES; i++) {
+        VmafPicture ref, dist;
+        err = vmaf_picture_alloc(&ref, VMAF_PIX_FMT_YUV420P, bpc,
+                                 TEST_W, TEST_H);
+        err |= vmaf_picture_alloc(&dist, VMAF_PIX_FMT_YUV420P, bpc,
+                                  TEST_W, TEST_H);
+        if (err) { *fail = "problem during vmaf_picture_alloc"; return 0; }
+        fill_pictures(&ref, &dist, bpc, i);
+        err = vmaf_read_pictures(vmaf, &ref, &dist, i);
+        if (err) { *fail = "problem during vmaf_read_pictures"; return 0; }
+    }
+
+    err = vmaf_read_pictures(vmaf, NULL, NULL, 0);
+    if (err) { *fail = "problem during vmaf_read_pictures flush"; return 0; }
+
+    for (unsigned i = 0; i < N_FRAMES; i++) {
+        for (unsigned k = 0; k < N_KEYS; k++) {
+            err = vmaf_feature_score_at_index(vmaf, score_keys[k],
+                                              &scores[i][k], i);
+            if (err) { *fail = "problem during vmaf_feature_score_at_index"; return 0; }
+        }
+    }
+
+    err = vmaf_close(vmaf);
+    if (err) { *fail = "problem during vmaf_close"; return 0; }
+
+    return 0;
+}
+
+static char *parity(unsigned bpc)
+{
+    double cpu[N_FRAMES][N_KEYS], gpu[N_FRAMES][N_KEYS];
+    char *fail = NULL;
+
+    run_pass(0, bpc, cpu, &fail);
+    if (fail) return fail;
+
+    if (run_pass(1, bpc, gpu, &fail)) {
+        fprintf(stderr, "no CUDA device available, skipping\n");
+        return NULL;
+    }
+    if (fail) return fail;
+
+    for (unsigned i = 0; i < N_FRAMES; i++) {
+        for (unsigned k = 0; k < N_KEYS; k++) {
+            const double eps = k < 3 ? PSNR_EPS : SSIM_EPS;
+            if (fabs(cpu[i][k] - gpu[i][k]) > eps) {
+                fprintf(stderr, "mismatch %u bpc, frame %u, %s: "
+                        "cpu=%.9f gpu=%.9f\n", bpc, i, score_keys[k],
+                        cpu[i][k], gpu[i][k]);
+                return "cpu/cuda score mismatch";
+            }
+        }
+    }
+
+    return NULL;
+}
+
+static char *test_psnr_ssim_cuda_parity_8bpc(void)
+{
+    return parity(8);
+}
+
+static char *test_psnr_ssim_cuda_parity_10bpc(void)
+{
+    return parity(10);
+}
+
+char *run_tests()
+{
+    mu_run_test(test_psnr_ssim_cuda_parity_8bpc);
+    mu_run_test(test_psnr_ssim_cuda_parity_10bpc);
+    return NULL;
+}

--- a/libvmaf/test/test_cuda_psnr_ssim_parity.c
+++ b/libvmaf/test/test_cuda_psnr_ssim_parity.c
@@ -1,7 +1,6 @@
 /**
  *
- *  Copyright 2016-2023 Netflix, Inc.
- *  Copyright 2021 NVIDIA Corporation.
+ *  Copyright 2026 Bardie Høgh Joensen
  *
  *     Licensed under the BSD+Patent License (the "License");
  *     you may not use this file except in compliance with the License.
@@ -23,8 +22,8 @@
  * extractors (psnr, float_ssim) and the CUDA extractors (psnr_cuda,
  * ssim_cuda) and asserts per-frame score equality within a small epsilon.
  *
- * Skips (passes with a notice) when no CUDA device is available so CI
- * without a GPU stays green.
+ * Exits with meson's SKIP code (77) when no CUDA device is available so CI
+ * without a GPU reports the test as skipped.
  */
 
 #include <math.h>

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -47,6 +47,14 @@ static char *test_get_feature_extractor_by_name_and_feature_name()
             "VMAF_integer_feature_adm2_score", flags);
     mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
               fex && !strcmp(fex->name, "adm_cuda"));
+
+    fex = vmaf_get_feature_extractor_by_feature_name("psnr_y", flags);
+    mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
+              fex && !strcmp(fex->name, "psnr_cuda"));
+
+    fex = vmaf_get_feature_extractor_by_feature_name("float_ssim", flags);
+    mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
+              fex && !strcmp(fex->name, "ssim_cuda"));
 #endif
 
     return NULL;

--- a/libvmaf/test/test_feature_extractor.c
+++ b/libvmaf/test/test_feature_extractor.c
@@ -55,6 +55,10 @@ static char *test_get_feature_extractor_by_name_and_feature_name()
     fex = vmaf_get_feature_extractor_by_feature_name("float_ssim", flags);
     mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
               fex && !strcmp(fex->name, "ssim_cuda"));
+
+    fex = vmaf_get_feature_extractor_by_feature_name("ciede2000", flags);
+    mu_assert("problem during vmaf_get_feature_extractor_by_feature_name",
+              fex && !strcmp(fex->name, "ciede_cuda"));
 #endif
 
     return NULL;


### PR DESCRIPTION
This PR adds three CUDA feature extractors so PSNR, SSIM and CIEDE2000 can run in the same GPU pass as the VMAF features, instead of forcing a separate CPU pass (and, with `libvmaf_cuda` in ffmpeg, a second decode of both inputs):

* **`psnr_cuda`** — GPU port of `psnr`. Integer SSE reduction on device (vectorized grid-stride loads, one atomic per block), scoring math unchanged on the host, so scores are **bit-exact** vs the CPU extractor — now asserted for PSNR and MSE at 8/10/12/16-bit across YUV420P/YUV422P/YUV444P, with APSNR aggregates compared as well. It is also verified on 500-frame real SDR/HDR clips, y/cb/cr. Supports the CPU extractor's options (`enable_chroma`, `enable_mse`, `enable_apsnr`, `reduced_hbd_peak`, `min_sse`). The APSNR flush emits only via `vmaf_feature_collector_set_aggregate`, so it is idempotent under the threaded+CUDA double flush (#1553).
* **`ssim_cuda`** — GPU port of `float_ssim`, replicating the iqa reference operation-for-operation: box decimation with symmetric borders (fused with the float conversion, so the full-resolution float image is never materialized), 11-tap separable valid-mode Gaussian with double accumulation and float rounding between passes, and the exact float/double mixing of `_iqa_ssim` (float-typed reference operations use explicit `__f*_rn` intrinsics so nvcc cannot contract them into fma). Also **bit-exact** vs the CPU extractor in all testing, and deterministic run-to-run (per-block tree reduction + sequential host sum over block partials). Supports `enable_lcs`, `enable_db`, `clip_db`, `scale`.
* **`ciede_cuda`** — GPU port of `ciede`. One fused kernel does the nearest-neighbor chroma upsample, YUV→Lab conversion and per-pixel ΔE, with per-block double partials pooled sequentially on the host into the `45 − 20·log10(mean ΔE)` score (identical frames yield +inf, matching the CPU extractor — note this also means the pooled `mean`/`max` serialize as `null` in JSON output whenever any frame is identical, for the CPU and CUDA extractors alike, while `harmonic_mean` stays finite). The shared chroma-upsample index math now correctly treats horizontal and vertical subsampling independently, with YUV420P and YUV422P regression coverage. Unlike the other two, this port is **tolerance-validated rather than bit-exact**: ciede is dominated by libm transcendentals, which round differently between glibc and CUDA regardless of precision, and FP64 throughput makes a faithful double port impractical on consumer GPUs (1/64 rate). Device math runs in float32 — the CPU reference truncates every intermediate to float anyway — and measured agreement is within **3e-5** on the per-frame score against the CPU extractor on real content (the included test asserts 1e-3). For reference, the CPU extractor measures ~4 fps at 4K with 16 threads (scalar libm, no SIMD variant); the CUDA extractor makes the metric usable full-file.

Performance (RTX 5060 Ti, two 4K HEVC inputs via the ffmpeg `libvmaf_cuda` filter, vmaf + vmaf_neg models): adding all three features costs ~8% vs models-only. The extractors launch on their **own CUDA stream** and overlap with the model extractors' work instead of extending the shared picture stream's critical path; picture lifetime is handled by recording a `consumed` event after the last picture-reading kernel and making both picture streams wait on it, so the pool's existing `finished`-event reuse protocol transitively covers the own-stream reads. compute-sanitizer racecheck reports 0 hazards (run with per-frame host synchronization in place of the two-slot pipelining — racecheck cannot retire its tracking state without host syncs and runs out of memory on the pipelined variant; the cross-stream handshake under test is identical). The pipelined variant is additionally verified deterministic across repeated runs and bit-identical to the serialized implementation. One subtlety worth reviewer attention: the work streams are deliberately created `CU_STREAM_DEFAULT` (legacy-blocking) — producers like the ffmpeg filter fill device pictures with synchronous-API D2D copies that queue on the legacy NULL stream without blocking the host, and only blocking-flavor streams are implicitly ordered after NULL-stream work. With a non-blocking stream, ~4% of frames scored nondeterministically through the ffmpeg path; blocking flavor restores the ordering while still overlapping with the other extractors' created streams.

Supporting changes:

* New `VMAF_FEATURE_EXTRACTOR_CUDA_CHROMA` flag: the host→device picture upload (`translate_picture_host`) copied only the luma plane because all existing CUDA extractors are luma-only. The upload plane mask now widens to all planes only when a registered CUDA extractor declares it reads chroma — existing configurations upload exactly what they did before. The device→host direction (`translate_picture_device`) now downloads all planes unconditionally, since host pictures always carry every plane and CPU extractors that read chroma (`psnr`, `ciede`) expect them.
* All three extractors provide a `flush` that drains their async score callback, so the final frame's score is in the collector before scores are read after flushing the context.
* Tests: `test_cuda_psnr_ssim_parity` drives deterministic 8/10/12/16-bit YUV420P/YUV422P/YUV444P frames through the CPU and CUDA extractors via the public API. It asserts bit-exact PSNR, MSE, SSIM and L/C/S scores, compares APSNR aggregates, covers odd dimensions and automatic/explicit scales, and exercises the remaining scoring options. `test_cuda_ciede_parity` covers YUV420P and YUV422P in both 8-bit and high-bit-depth paths, asserts the 1e-3 tolerance, and checks the identical-frame +inf case. Both **exit 77 (meson SKIP) when no CUDA device is available**, so CI without a GPU reports them as skipped rather than silently passing. Dispatch assertions in `test_feature_extractor.c` are extended to the new extractors.

Naming follows the existing convention (`vif_cuda`/`motion_cuda`/`adm_cuda`): unique `.name` for `--feature psnr_cuda` / ffmpeg `feature=name=psnr_cuda`, with `provided_features` matching the CPU extractors so model-driven flag-aware selection works. The option tables mirror the CPU extractors' tables, following the existing CUDA extractors' pattern (they embed `offsetof` into each extractor's own state struct) — happy to factor the scoring math into a shared header instead if you'd prefer.

Notes:

* Rebased onto `master` at `f85a8536`. #1552 has landed and its duplicate commit has been removed; this branch remains stacked on #1553 for correct CUDA operation with a thread pool.
* While validating through ffmpeg's `libvmaf_cuda` filter I found that `vf_libvmaf.c`'s `copy_picture_data_cuda` breaks out of its plane loop after plane 0, so chroma never reaches libvmaf and chroma-reading features report the psnr_max cap. That is an ffmpeg bug, not a libvmaf one (I patch it locally and plan to report it there), but it explains why chroma features through the filter need an ffmpeg fix to be useful.
* Possible follow-up (not in this PR): the model extractors (vif/adm/motion) still serialize on the shared picture streams; moving them to per-extractor streams with the same consumed-event handshake should overlap them the same way.

Tested on RTX 5060 Ti (sm_120), driver 595.71.05, CUDA 12.9/13.3.
