### PR TITLE
Add ARM NEON implementation for 8-bit integer motion feature

### DIFF
--- a/libvmaf/src/feature/arm64/motion_neon.c
+++ b/libvmaf/src/feature/arm64/motion_neon.c
@@ -1,0 +1,15 @@
+#include <arm_neon.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "feature/integer_motion.h"
+
+uint64_t motion_score_pipeline_8_neon(const uint8_t *prev, ptrdiff_t prev_stride,
+                                      const uint8_t *cur, ptrdiff_t cur_stride,
+                                      int32_t *y_row, unsigned w, unsigned h,
+                                      unsigned bpc)
+{
+    (void)prev; (void)prev_stride; (void)cur; (void)cur_stride;
+    (void)y_row; (void)w; (void)h; (void)bpc;
+    return 0;
+}

--- a/libvmaf/src/feature/arm64/motion_neon.c
+++ b/libvmaf/src/feature/arm64/motion_neon.c
@@ -105,16 +105,16 @@ uint64_t motion_score_pipeline_8_neon(const uint8_t *prev, ptrdiff_t prev_stride
             uint8x16_t p3 = vld1q_u8(p[3] + j), c3 = vld1q_u8(c[3] + j);
             uint8x16_t p4 = vld1q_u8(p[4] + j), c4 = vld1q_u8(c[4] + j);
 
-            int16x8_t d0_lo = vsubl_u8(vget_low_u8(p0), vget_low_u8(c0));
-            int16x8_t d0_hi = vsubl_u8(vget_high_u8(p0), vget_high_u8(c0));
-            int16x8_t d1_lo = vsubl_u8(vget_low_u8(p1), vget_low_u8(c1));
-            int16x8_t d1_hi = vsubl_u8(vget_high_u8(p1), vget_high_u8(c1));
-            int16x8_t d2_lo = vsubl_u8(vget_low_u8(p2), vget_low_u8(c2));
-            int16x8_t d2_hi = vsubl_u8(vget_high_u8(p2), vget_high_u8(c2));
-            int16x8_t d3_lo = vsubl_u8(vget_low_u8(p3), vget_low_u8(c3));
-            int16x8_t d3_hi = vsubl_u8(vget_high_u8(p3), vget_high_u8(c3));
-            int16x8_t d4_lo = vsubl_u8(vget_low_u8(p4), vget_low_u8(c4));
-            int16x8_t d4_hi = vsubl_u8(vget_high_u8(p4), vget_high_u8(c4));
+            int16x8_t d0_lo = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(p0), vget_low_u8(c0)));
+            int16x8_t d0_hi = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(p0), vget_high_u8(c0)));
+            int16x8_t d1_lo = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(p1), vget_low_u8(c1)));
+            int16x8_t d1_hi = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(p1), vget_high_u8(c1)));
+            int16x8_t d2_lo = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(p2), vget_low_u8(c2)));
+            int16x8_t d2_hi = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(p2), vget_high_u8(c2)));
+            int16x8_t d3_lo = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(p3), vget_low_u8(c3)));
+            int16x8_t d3_hi = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(p3), vget_high_u8(c3)));
+            int16x8_t d4_lo = vreinterpretq_s16_u16(vsubl_u8(vget_low_u8(p4), vget_low_u8(c4)));
+            int16x8_t d4_hi = vreinterpretq_s16_u16(vsubl_u8(vget_high_u8(p4), vget_high_u8(c4)));
 
             int32x4_t acc0 = vdupq_n_s32(0); // columns j+0..j+3
             int32x4_t acc1 = vdupq_n_s32(0); // columns j+4..j+7

--- a/libvmaf/src/feature/arm64/motion_neon.c
+++ b/libvmaf/src/feature/arm64/motion_neon.c
@@ -1,15 +1,182 @@
 #include <arm_neon.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "feature/integer_motion.h"
+
+static inline int mirror(int idx, int size)
+{
+    if (idx < 0) return -idx;
+    if (idx >= size) return 2 * size - idx - 2;
+    return idx;
+}
+
+// Phase 2: x_conv + abs + SAD for one row of int32 y_row.
+// Processes 4 int32 columns at a time via widening s32->s64 multiply-accumulate.
+static inline uint32_t
+x_conv_row_sad_neon(const int32_t *y_row, unsigned w)
+{
+    uint32_t row_sad = 0;
+
+    // Scalar left edge (columns 0, 1) — mirror boundary
+    unsigned j;
+    for (j = 0; j < 2 && j < w; j++) {
+        int64_t accum = 0;
+        for (int k = 0; k < 5; k++) {
+            int col = mirror((int)j - 2 + k, (int)w);
+            accum += (int64_t)filter[k] * y_row[col];
+        }
+        int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
+        row_sad += (uint32_t)abs(val);
+    }
+
+    // SIMD middle: need y_row[j-2]..y_row[j+5], so j+6 <= w
+    int32x4_t sad_acc = vdupq_n_s32(0);
+    const int64x2_t round64 = vdupq_n_s64(1 << 15);
+    for (; j + 6 <= w; j += 4) {
+        int32x4_t y0 = vld1q_s32(y_row + j - 2);
+        int32x4_t y1 = vld1q_s32(y_row + j - 1);
+        int32x4_t y2 = vld1q_s32(y_row + j);
+        int32x4_t y3 = vld1q_s32(y_row + j + 1);
+        int32x4_t y4 = vld1q_s32(y_row + j + 2);
+
+        int64x2_t acc_lo = vmull_n_s32(vget_low_s32(y0), (int32_t)filter[0]);
+        acc_lo = vmlal_n_s32(acc_lo, vget_low_s32(y1), (int32_t)filter[1]);
+        acc_lo = vmlal_n_s32(acc_lo, vget_low_s32(y2), (int32_t)filter[2]);
+        acc_lo = vmlal_n_s32(acc_lo, vget_low_s32(y3), (int32_t)filter[3]);
+        acc_lo = vmlal_n_s32(acc_lo, vget_low_s32(y4), (int32_t)filter[4]);
+
+        int64x2_t acc_hi = vmull_n_s32(vget_high_s32(y0), (int32_t)filter[0]);
+        acc_hi = vmlal_n_s32(acc_hi, vget_high_s32(y1), (int32_t)filter[1]);
+        acc_hi = vmlal_n_s32(acc_hi, vget_high_s32(y2), (int32_t)filter[2]);
+        acc_hi = vmlal_n_s32(acc_hi, vget_high_s32(y3), (int32_t)filter[3]);
+        acc_hi = vmlal_n_s32(acc_hi, vget_high_s32(y4), (int32_t)filter[4]);
+
+        acc_lo = vshrq_n_s64(vaddq_s64(acc_lo, round64), 16);
+        acc_hi = vshrq_n_s64(vaddq_s64(acc_hi, round64), 16);
+
+        int32x2_t res_lo = vmovn_s64(acc_lo);
+        int32x2_t res_hi = vmovn_s64(acc_hi);
+        int32x4_t result = vcombine_s32(res_lo, res_hi);
+
+        sad_acc = vaddq_s32(sad_acc, vabsq_s32(result));
+    }
+    row_sad += vaddvq_s32(sad_acc);
+
+    // Scalar right edge + tail
+    for (; j < w; j++) {
+        int64_t accum = 0;
+        for (int k = 0; k < 5; k++) {
+            int col = mirror((int)j - 2 + k, (int)w);
+            accum += (int64_t)filter[k] * y_row[col];
+        }
+        int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
+        row_sad += (uint32_t)abs(val);
+    }
+
+    return row_sad;
+}
 
 uint64_t motion_score_pipeline_8_neon(const uint8_t *prev, ptrdiff_t prev_stride,
                                       const uint8_t *cur, ptrdiff_t cur_stride,
                                       int32_t *y_row, unsigned w, unsigned h,
                                       unsigned bpc)
 {
-    (void)prev; (void)prev_stride; (void)cur; (void)cur_stride;
-    (void)y_row; (void)w; (void)h; (void)bpc;
-    return 0;
+    (void)bpc;
+    uint64_t sad = 0;
+
+    for (unsigned i = 0; i < h; i++) {
+        const uint8_t *p[5], *c[5];
+        for (int k = 0; k < 5; k++) {
+            int r = mirror((int)i - 2 + k, (int)h);
+            p[k] = prev + r * prev_stride;
+            c[k] = cur + r * cur_stride;
+        }
+
+        // Phase 1: diff + y_conv -> y_row (16 columns at a time, shift >>8)
+        unsigned j;
+        int32x4_t nz_acc = vdupq_n_s32(0);
+        const int32x4_t round8 = vdupq_n_s32(1 << 7);
+        for (j = 0; j + 16 <= w; j += 16) {
+            uint8x16_t p0 = vld1q_u8(p[0] + j), c0 = vld1q_u8(c[0] + j);
+            uint8x16_t p1 = vld1q_u8(p[1] + j), c1 = vld1q_u8(c[1] + j);
+            uint8x16_t p2 = vld1q_u8(p[2] + j), c2 = vld1q_u8(c[2] + j);
+            uint8x16_t p3 = vld1q_u8(p[3] + j), c3 = vld1q_u8(c[3] + j);
+            uint8x16_t p4 = vld1q_u8(p[4] + j), c4 = vld1q_u8(c[4] + j);
+
+            int16x8_t d0_lo = vsubl_u8(vget_low_u8(p0), vget_low_u8(c0));
+            int16x8_t d0_hi = vsubl_u8(vget_high_u8(p0), vget_high_u8(c0));
+            int16x8_t d1_lo = vsubl_u8(vget_low_u8(p1), vget_low_u8(c1));
+            int16x8_t d1_hi = vsubl_u8(vget_high_u8(p1), vget_high_u8(c1));
+            int16x8_t d2_lo = vsubl_u8(vget_low_u8(p2), vget_low_u8(c2));
+            int16x8_t d2_hi = vsubl_u8(vget_high_u8(p2), vget_high_u8(c2));
+            int16x8_t d3_lo = vsubl_u8(vget_low_u8(p3), vget_low_u8(c3));
+            int16x8_t d3_hi = vsubl_u8(vget_high_u8(p3), vget_high_u8(c3));
+            int16x8_t d4_lo = vsubl_u8(vget_low_u8(p4), vget_low_u8(c4));
+            int16x8_t d4_hi = vsubl_u8(vget_high_u8(p4), vget_high_u8(c4));
+
+            int32x4_t acc0 = vdupq_n_s32(0); // columns j+0..j+3
+            int32x4_t acc1 = vdupq_n_s32(0); // columns j+4..j+7
+            int32x4_t acc2 = vdupq_n_s32(0); // columns j+8..j+11
+            int32x4_t acc3 = vdupq_n_s32(0); // columns j+12..j+15
+
+            acc0 = vmlal_n_s16(acc0, vget_low_s16(d0_lo), (int16_t)filter[0]);
+            acc1 = vmlal_n_s16(acc1, vget_high_s16(d0_lo), (int16_t)filter[0]);
+            acc2 = vmlal_n_s16(acc2, vget_low_s16(d0_hi), (int16_t)filter[0]);
+            acc3 = vmlal_n_s16(acc3, vget_high_s16(d0_hi), (int16_t)filter[0]);
+
+            acc0 = vmlal_n_s16(acc0, vget_low_s16(d1_lo), (int16_t)filter[1]);
+            acc1 = vmlal_n_s16(acc1, vget_high_s16(d1_lo), (int16_t)filter[1]);
+            acc2 = vmlal_n_s16(acc2, vget_low_s16(d1_hi), (int16_t)filter[1]);
+            acc3 = vmlal_n_s16(acc3, vget_high_s16(d1_hi), (int16_t)filter[1]);
+
+            acc0 = vmlal_n_s16(acc0, vget_low_s16(d2_lo), (int16_t)filter[2]);
+            acc1 = vmlal_n_s16(acc1, vget_high_s16(d2_lo), (int16_t)filter[2]);
+            acc2 = vmlal_n_s16(acc2, vget_low_s16(d2_hi), (int16_t)filter[2]);
+            acc3 = vmlal_n_s16(acc3, vget_high_s16(d2_hi), (int16_t)filter[2]);
+
+            acc0 = vmlal_n_s16(acc0, vget_low_s16(d3_lo), (int16_t)filter[3]);
+            acc1 = vmlal_n_s16(acc1, vget_high_s16(d3_lo), (int16_t)filter[3]);
+            acc2 = vmlal_n_s16(acc2, vget_low_s16(d3_hi), (int16_t)filter[3]);
+            acc3 = vmlal_n_s16(acc3, vget_high_s16(d3_hi), (int16_t)filter[3]);
+
+            acc0 = vmlal_n_s16(acc0, vget_low_s16(d4_lo), (int16_t)filter[4]);
+            acc1 = vmlal_n_s16(acc1, vget_high_s16(d4_lo), (int16_t)filter[4]);
+            acc2 = vmlal_n_s16(acc2, vget_low_s16(d4_hi), (int16_t)filter[4]);
+            acc3 = vmlal_n_s16(acc3, vget_high_s16(d4_hi), (int16_t)filter[4]);
+
+            acc0 = vshrq_n_s32(vaddq_s32(acc0, round8), 8);
+            acc1 = vshrq_n_s32(vaddq_s32(acc1, round8), 8);
+            acc2 = vshrq_n_s32(vaddq_s32(acc2, round8), 8);
+            acc3 = vshrq_n_s32(vaddq_s32(acc3, round8), 8);
+
+            vst1q_s32(y_row + j, acc0);
+            vst1q_s32(y_row + j + 4, acc1);
+            vst1q_s32(y_row + j + 8, acc2);
+            vst1q_s32(y_row + j + 12, acc3);
+
+            nz_acc = vorrq_s32(nz_acc, vorrq_s32(vorrq_s32(acc0, acc1), vorrq_s32(acc2, acc3)));
+        }
+
+        // Scalar tail for phase 1
+        int32_t nz_tail = 0;
+        for (; j < w; j++) {
+            int32_t accum = 0;
+            for (int k = 0; k < 5; k++) {
+                int32_t diff = p[k][j] - c[k][j];
+                accum += (int32_t)filter[k] * diff;
+            }
+            y_row[j] = (accum + (1 << 7)) >> 8;
+            nz_tail |= y_row[j];
+        }
+
+        uint32_t nz_scalar = vmaxvq_u32(vreinterpretq_u32_s32(nz_acc));
+        if (!nz_scalar && !nz_tail) continue;
+
+        // Phase 2: SIMD x_conv + abs + accumulate
+        sad += x_conv_row_sad_neon(y_row, w);
+    }
+
+    return sad;
 }

--- a/libvmaf/src/feature/arm64/motion_neon.h
+++ b/libvmaf/src/feature/arm64/motion_neon.h
@@ -1,0 +1,12 @@
+#ifndef ARM64_MOTION_NEON_H_
+#define ARM64_MOTION_NEON_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+uint64_t motion_score_pipeline_8_neon(const uint8_t *prev, ptrdiff_t prev_stride,
+                                      const uint8_t *cur, ptrdiff_t cur_stride,
+                                      int32_t *y_row, unsigned w, unsigned h,
+                                      unsigned bpc);
+
+#endif /* ARM64_MOTION_NEON_H_ */

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -40,6 +40,8 @@
 #if HAVE_AVX512
 #include "x86/motion_avx512.h"
 #endif
+#elif ARCH_AARCH64
+#include "arm64/motion_neon.h"
 #endif
 
 typedef uint64_t (*motion_pipeline_fn)(const uint8_t *, ptrdiff_t,
@@ -287,6 +289,11 @@ static int init(VmafFeatureExtractor *fex, enum VmafPixelFormat pix_fmt,
             s->pipeline = motion_score_pipeline_16_avx512;
     }
 #endif
+#elif ARCH_AARCH64
+    if (vmaf_get_cpu_flags() & VMAF_ARM_CPU_FLAG_NEON) {
+        if (bpc == 8)
+            s->pipeline = motion_score_pipeline_8_neon;
+    }
 #endif
 
     return 0;

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -273,6 +273,7 @@ if is_asm_enabled
         arm64_sources = [
           feature_src_dir + 'arm64/vif_neon.c',
           feature_src_dir + 'arm64/adm_neon.c',
+          feature_src_dir + 'arm64/motion_neon.c',
         ]
 
           arm64_static_lib = static_library(

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -226,3 +226,22 @@ test('test_propagate_metadata', test_propagate_metadata)
 test('test_adm_csf', test_adm_csf)
 test('test_barten_csf', test_barten_csf)
 test('test_motion_blend', test_motion_blend)
+
+if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64')
+    test_motion_neon = executable('test_motion_neon',
+        ['test.c', 'test_motion_neon.c', '../src/mem.c', '../src/picture.c', '../src/ref.c',
+         '../src/dict.c', '../src/opt.c', '../src/log.c', '../src/predict.c',
+         '../src/metadata_handler.c'],
+        include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+        dependencies : [math_lib, stdatomic_dependency, thread_lib, cuda_dependency],
+        objects : [
+          common_cuda_objects,
+          platform_specific_cpu_objects,
+          libvmaf_feature_static_lib.extract_all_objects(recursive: true),
+          libvmaf_cpu_static_lib.extract_all_objects(recursive: true),
+          libsvm_static_lib.extract_all_objects(recursive: true),
+        ]
+    )
+
+    test('test_motion_neon', test_motion_neon)
+endif

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -227,7 +227,7 @@ test('test_adm_csf', test_adm_csf)
 test('test_barten_csf', test_barten_csf)
 test('test_motion_blend', test_motion_blend)
 
-if host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64')
+if is_asm_enabled and (host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64'))
     test_motion_neon = executable('test_motion_neon',
         ['test.c', 'test_motion_neon.c', '../src/mem.c', '../src/picture.c', '../src/ref.c',
          '../src/dict.c', '../src/opt.c', '../src/log.c', '../src/predict.c',

--- a/libvmaf/test/test_motion_neon.c
+++ b/libvmaf/test/test_motion_neon.c
@@ -74,8 +74,13 @@ static int compute_motion_sad(unsigned w, unsigned h,
 
 static char *test_motion_neon_matches_scalar()
 {
+    // Sizes below 3 are excluded: integer_motion.c's mirror() helper (radius-2 5-tap
+    // filter) reads out-of-bounds indices for width/height < 3. This is a pre-existing
+    // property shared by the scalar reference and AVX2 alike (not specific to NEON), so
+    // testing those sizes here would compare undefined-behavior reads against each other
+    // rather than verify real NEON-vs-scalar parity.
     static const struct { unsigned w, h; } sizes[] = {
-        {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
+        {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
         {15, 15}, {16, 16}, {17, 17}, {20, 4}, {33, 9}, {64, 48}, {65, 63},
     };
     const unsigned n_sizes = sizeof(sizes) / sizeof(sizes[0]);

--- a/libvmaf/test/test_motion_neon.c
+++ b/libvmaf/test/test_motion_neon.c
@@ -74,11 +74,8 @@ static int compute_motion_sad(unsigned w, unsigned h,
 
 static char *test_motion_neon_matches_scalar()
 {
-    // Sizes below 3 are excluded: integer_motion.c's mirror() helper (radius-2 5-tap
-    // filter) reads out-of-bounds indices for width/height < 3. This is a pre-existing
-    // property shared by the scalar reference and AVX2 alike (not specific to NEON), so
-    // testing those sizes here would compare undefined-behavior reads against each other
-    // rather than verify real NEON-vs-scalar parity.
+    // w/h < 3 excluded: mirror()'s radius-2 reflection goes out of bounds there
+    // (same bug in scalar/AVX2), so those sizes compare garbage against garbage.
     static const struct { unsigned w, h; } sizes[] = {
         {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
         {15, 15}, {16, 16}, {17, 17}, {20, 4}, {33, 9}, {64, 48}, {65, 63},

--- a/libvmaf/test/test_motion_neon.c
+++ b/libvmaf/test/test_motion_neon.c
@@ -1,0 +1,113 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "cpu.h"
+#include "test.h"
+#include "libvmaf/picture.h"
+#include "feature/feature_extractor.h"
+#include "feature/feature_collector.h"
+
+static void fill_random_luma(VmafPicture *pic, unsigned seed)
+{
+    srand(seed);
+    uint8_t *data = pic->data[0];
+    for (unsigned i = 0; i < pic->h[0]; i++) {
+        for (unsigned j = 0; j < pic->w[0]; j++) {
+            data[i * pic->stride[0] + j] = (uint8_t)(rand() % 256);
+        }
+    }
+}
+
+static int compute_motion_sad(unsigned w, unsigned h,
+                              unsigned seed_prev, unsigned seed_cur,
+                              unsigned cpu_mask, double *score)
+{
+    int err;
+    vmaf_set_cpu_flags_mask(cpu_mask);
+
+    VmafFeatureExtractor *fex = vmaf_get_feature_extractor_by_name("motion");
+    if (!fex) return -1;
+
+    VmafFeatureExtractorContext *fex_ctx;
+    err = vmaf_feature_extractor_context_create(&fex_ctx, fex, NULL);
+    if (err) return err;
+
+    VmafPicture prev_pic, cur_pic;
+    err = vmaf_picture_alloc(&prev_pic, VMAF_PIX_FMT_YUV420P, 8, w, h);
+    if (err) return err;
+    err = vmaf_picture_alloc(&cur_pic, VMAF_PIX_FMT_YUV420P, 8, w, h);
+    if (err) return err;
+
+    fill_random_luma(&prev_pic, seed_prev);
+    fill_random_luma(&cur_pic, seed_cur);
+
+    VmafFeatureCollector *vfc;
+    err = vmaf_feature_collector_init(&vfc);
+    if (err) return err;
+
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &prev_pic, NULL,
+                                                 &prev_pic, NULL, 0, vfc);
+    if (err) return err;
+
+    if (fex_ctx->fex->flags & VMAF_FEATURE_EXTRACTOR_PREV_REF)
+        fex_ctx->fex->prev_ref = prev_pic;
+
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &cur_pic, NULL,
+                                                 &cur_pic, NULL, 1, vfc);
+    if (err) return err;
+
+    err = vmaf_feature_collector_get_score(vfc,
+            "VMAF_integer_feature_motion_sad_score", score, 1);
+    if (err) return err;
+
+    err = vmaf_feature_extractor_context_close(fex_ctx);
+    if (err) return err;
+    err = vmaf_feature_extractor_context_destroy(fex_ctx);
+    if (err) return err;
+
+    vmaf_feature_collector_destroy(vfc);
+    vmaf_picture_unref(&prev_pic);
+    vmaf_picture_unref(&cur_pic);
+
+    return 0;
+}
+
+static char *test_motion_neon_matches_scalar()
+{
+    static const struct { unsigned w, h; } sizes[] = {
+        {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
+        {15, 15}, {16, 16}, {17, 17}, {20, 4}, {33, 9}, {64, 48}, {65, 63},
+    };
+    const unsigned n_sizes = sizeof(sizes) / sizeof(sizes[0]);
+
+    vmaf_init_cpu();
+
+    for (unsigned s = 0; s < n_sizes; s++) {
+        for (unsigned seed = 0; seed < 3; seed++) {
+            double scalar_score = -1.0, neon_score = -1.0;
+            int err;
+
+            err = compute_motion_sad(sizes[s].w, sizes[s].h,
+                                     100 + seed, 200 + seed,
+                                     0, &scalar_score);
+            mu_assert("scalar motion extraction failed", !err);
+
+            err = compute_motion_sad(sizes[s].w, sizes[s].h,
+                                     100 + seed, 200 + seed,
+                                     ~0u, &neon_score);
+            mu_assert("neon motion extraction failed", !err);
+
+            mu_assert("NEON motion SAD score must bit-exactly match scalar",
+                      scalar_score == neon_score);
+        }
+    }
+
+    vmaf_set_cpu_flags_mask(~0u);
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_motion_neon_matches_scalar);
+    return NULL;
+}


### PR DESCRIPTION
## Summary

- Adds an ARM NEON implementation of the 8-bit integer motion feature (`motion_score_pipeline_8_neon`), mirroring the existing x86 AVX2 implementation's two-phase structure (vertical diff + 5-tap convolution, then horizontal 5-tap convolution + abs + SAD)
- Wired into the existing per-architecture dispatch pattern (`#elif ARCH_AARCH64` + `VMAF_ARM_CPU_FLAG_NEON`), following the same convention already used by the ADM and VIF NEON implementations
- Scope is intentionally limited to 8-bit; 16-bit stays on the scalar path for now, same precedent as VIF's NEON dispatch
- Output is bit-exact with the scalar reference (same round-then-shift order at every step, explicit signed arithmetic shifts only)

## Testing

- New dedicated parity test (`test_motion_neon`) drives the public feature-extractor dispatch path via `vmaf_set_cpu_flags_mask()`, comparing the resulting motion SAD score between the forced-scalar and NEON-enabled paths across a matrix of widths/heights (including SIMD lane-boundary cases)
- Full `meson test` suite passes on two independent arm64 hosts/toolchains:
  - macOS (Apple Silicon, Apple Clang)
  - Ubuntu 22.04 (GCC 11.4.0)
- `test_motion_neon` additionally verified with 50 repeated direct runs (0 failures) on both hosts, since an earlier draft of the parity test itself had an intermittent failure traced to a pre-existing out-of-bounds read in the shared `mirror()` helper for width/height < 3 (present in the scalar and AVX2 paths too, not NEON-specific) — the test's size matrix now excludes those two unsafe sizes
- Python golden-score regression suite (`quality_runner_test.py`) also passes (67/67) on the Ubuntu host

## Benchmark

Motion feature only, `foreman_cif.y4m` (352x288, 300 frames, Xiph derf's test set), average of 20 runs each:

| Path   | fps     |
|--------|---------|
| NEON   | ~8961   |
| Scalar | ~2534   |

~3.5x speedup.