### PR TITLE
CUDA: Fix compile, SIGSEGV and tests

### DIFF
--- a/libvmaf/src/cuda/picture_cuda.c
+++ b/libvmaf/src/cuda/picture_cuda.c
@@ -145,6 +145,7 @@ int vmaf_cuda_picture_alloc_pinned(VmafPicture *pic, enum VmafPixelFormat pix_fm
     err |= vmaf_picture_priv_init(pic);
     VmafPicturePrivate* priv = pic->priv;
     priv->cuda.ctx = cuda_state->ctx;
+    priv->cuda.state = cuda_state;
     err |= vmaf_picture_set_release_callback(pic, NULL, default_release_pinned_picture);
     if (err) goto free_data;
     priv->buf_type = VMAF_PICTURE_BUFFER_TYPE_CUDA_HOST_PINNED;

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -421,15 +421,16 @@ if is_cuda_enabled
             build_by_default: true,
             output : ['@0@.fatbin'.format(name)],
             input : _cu,
-            command : [nvcc_exe,
+            command : [
+                nvcc_exe,
                 gencode,
                 '@INPUT@',
-                '-o', '@OUTPUT@' ,
-                '-I', './src',
-                '-I', '../src',
-                '-I', '../include',
-                '-I', '../src/feature',
-                '-I', '../src/' + cuda_dir,
+                '-o', '@OUTPUT@',
+                '-I', meson.current_source_dir(),
+                '-I', meson.current_source_dir() / 'feature',
+                '-I', meson.current_source_dir() / 'cuda',
+                '-I', meson.current_source_dir() / '../include',
+                '-I', meson.current_build_dir(),
                 '-DDEVICE_CODE',
             ] + cuda_flags
         )

--- a/libvmaf/tools/test/meson.build
+++ b/libvmaf/tools/test/meson.build
@@ -1,4 +1,7 @@
 if get_option('enable_cuda')
     test_vmaf_cuda_gpumask = find_program('test_vmaf_cuda_gpumask.sh')
-    test('test_vmaf_cuda_gpumask', test_vmaf_cuda_gpumask)
+    test('test_vmaf_cuda_gpumask', test_vmaf_cuda_gpumask,
+        depends: [vmaf],
+        workdir: meson.project_build_root()
+    )
 endif


### PR DESCRIPTION
## Summary

This PR fixes several issues found while building and testing the CUDA support in libvmaf.

## Changes

- **Out-of-tree / relative includes:** CUDA custom targets used relative include paths (e.g. `-I ./src`, `-I ../src`). Those work when the build directory is under the source tree, but fail when the build dir is fully outside it. This often went unnoticed because the default workflow is an in-tree build (`libvmaf/build`). Includes are now based on absolute paths from the source/build layout so out-of-tree builds (as exercised by the CUDA CI in #1579) succeed.
- Fixed a crash in `vmaf_cuda_picture_alloc_pinned` caused by `priv->cuda.state` not being initialized (SIGSEGV in `default_release_pinned_picture` / picture release paths; not limited to the unit test).
- Ensured the CUDA gpumask test properly depends on the `vmaf` executable so it is built before the test runs.

These changes make the CUDA build and test suite more reliable for both in-tree and out-of-tree configurations.