### PR TITLE
AVX512: Drop -mavx512vbmi from generic AVX-512 compile flags

### DIFF
--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -316,8 +316,7 @@ if is_asm_enabled
             'x86_avx512',
             x86_avx512_sources,
             include_directories : vmaf_base_include,
-            c_args : ['-mavx512f', '-mavx512dq', '-mavx512bw', '-mavx512cd', '-mavx512dq',
-                      '-mavx512vbmi', '-mavx512vl'] +
+            c_args : ['-mavx512f', '-mavx512dq', '-mavx512bw', '-mavx512cd', '-mavx512vl'] +
                      vmaf_cflags_common,
         )
 


### PR DESCRIPTION
## Summary

Closes #1555.

The issue is correct: the generic AVX-512 objects were compiled with `-mavx512vbmi` while runtime dispatch can select that path based only on base AVX-512 support (`VMAF_X86_CPU_FLAG_AVX512`).

AVX512_VBMI is a separate extension. CPUs with AVX-512F/BW/DQ/VL/CD but **without** VBMI are common, for example:

- Intel Skylake-X / Skylake-SP
- Intel Cascade Lake (no VBMI)
- Other server/workstation parts with “base” AVX-512 only

On those CPUs, a VBMI instruction emitted under `-mavx512vbmi` can fault with an illegal instruction (`SIGILL`).

## What I checked

A search of the AVX-512 C sources shows no explicit VBMI intrinsics (e.g. `*_permutexvar_epi8`, `vpmultishift`, `vpermb`). The only reference to VBMI was the compiler flag in `libvmaf/src/meson.build`.

So `-mavx512vbmi` was unnecessary for the current code and only widened the ISA requirement beyond what runtime gating guarantees.

## Change

Remove `-mavx512vbmi` (and a duplicated `-mavx512dq`) from the generic AVX-512 `c_args`, leaving:

- `-mavx512f`
- `-mavx512dq`
- `-mavx512bw`
- `-mavx512cd`
- `-mavx512vl`

This matches the base AVX-512 feature set expected by `VMAF_X86_CPU_FLAG_AVX512`.

If a future path truly needs VBMI, it should be compiled separately and gated with a stricter runtime flag (e.g. the existing `VMAF_X86_CPU_FLAG_AVX512ICL` / explicit VBMI), not folded into the generic AVX-512 objects.