### PR TITLE
Fix race condition with generated header under parallel builds

### DIFF
--- a/libvmaf/include/meson.build
+++ b/libvmaf/include/meson.build
@@ -8,5 +8,9 @@ rev_target = vcs_tag(command: [
     input: 'vcs_version.h.in',
     output: 'vcs_version.h'
 )
+rev_dep = declare_dependency(
+  sources: rev_target,
+  include_directories: include_directories('.'),
+)
 
 subdir('libvmaf')

--- a/libvmaf/src/meson.build
+++ b/libvmaf/src/meson.build
@@ -608,6 +608,7 @@ libvmaf = library(
       math_lib,
       stdatomic_dependency,
       cuda_dependency,
+	  rev_dep
     ],
     objects : [
         platform_specific_cpu_objects,

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -26,7 +26,7 @@ test_feature_collector = executable('test_feature_collector',
     ['test.c', 'test_feature_collector.c', '../src/log.c', '../src/predict.c', '../src/metadata_handler.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/feature/'), include_directories('../src')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
-    dependencies: cuda_dependency,
+    dependencies: [ cuda_dependency, rev_dep ],
     objects : libsvm_static_lib.extract_all_objects(recursive: true),
 )
 


### PR DESCRIPTION
When building with high parallelism, compilation of files that include
`vcs_version.h` could start before the header was generated by `vcs_tag()`,
causing intermittent "No such file or directory" errors.

Make the dependency on the generated target explicit so that the correct
build order is always enforced.

Closes #1541