### PR TITLE
cuda: Add compile test only for CI

### DIFF
--- a/.github/workflows/libvmaf.yml
+++ b/.github/workflows/libvmaf.yml
@@ -43,6 +43,18 @@ jobs:
             CC: ccache clang
             CXX: ccache clang++
             CROSS: ./libvmaf/test/meson-toolchains/i686-pc-linux-gnu-clang-cross.ini
+          - name: linux-x86_64-gcc-cuda
+            os: ubuntu-latest
+            CC: ccache gcc
+            CXX: ccache g++
+            enable_cuda: true
+            enable_nvcc: true
+          - name: linux-x86_64-clang-cuda
+            os: ubuntu-latest
+            CC: ccache clang-20
+            CXX: ccache clang++-20
+            enable_cuda: true
+            enable_nvcc: false
     runs-on: ${{ matrix.os }}
     env:
       CC: ${{ matrix.CC }}
@@ -59,15 +71,25 @@ jobs:
           pip install meson
 
       - name: Install dependencies (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           sudo apt-get update
-          sudo -E apt-get -yq install ccache ninja-build libomp-dev
+          sudo -E apt-get -yq install ccache ninja-build libomp-dev xxd
           case "$CC" in
           *gcc) sudo -E apt-get -yq install gcc g++ nasm ;;
           *gcc-9)
             sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
             sudo -E apt-get -yq install gcc-9 g++-9 nasm
+            ;;
+          *clang-20)
+            # >=clang-20 is needed to support CUDA without nvcc
+            sudo -E apt-get -yq install clang-20 llvm-20 nasm
+            sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 200
+            sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 200
+            sudo update-alternatives --set clang /usr/bin/clang-20
+            sudo update-alternatives --set clang++ /usr/bin/clang++-20
+            which clang
+            clang --version
             ;;
           *clang) sudo -E apt-get -yq install clang llvm nasm ;;
           esac
@@ -87,22 +109,52 @@ jobs:
           meson --version
           ccache --version
 
+      - name: Install CUDA toolkit
+        if: matrix.enable_cuda
+        uses: Jimver/cuda-toolkit@v0.2.36
+        with:
+          # 12.8.2 is the latest version that clang20 supports without nvcc
+          cuda: '12.8.2'
+          method: network
+          use-github-cache: false
+          use-local-cache: false
+          sub-packages: '["nvcc", "cudart", "cudart-dev"]'
+          non-cuda-sub-packages: '["libcurand-dev"]'
+
+      - name: Install nv-codec-headers
+        if: matrix.enable_cuda
+        run: |
+          git clone --depth 1 https://github.com/FFmpeg/nv-codec-headers.git
+          sudo make -C nv-codec-headers install PREFIX=/usr/local
+
       - uses: actions/checkout@v7
       - name: Run meson
         run: |
-          meson setup libvmaf libvmaf/build --buildtype release --prefix $PWD/install -Denable_float=true ${CROSS:+--cross-file $CROSS}
+          MESON_OPTS="--buildtype release --prefix $PWD/install -Denable_float=true"
+          if [ "${{ matrix.enable_cuda }}" = "true" ]; then
+            MESON_OPTS="$MESON_OPTS -Denable_cuda=true -Denable_nvcc=${{ matrix.enable_nvcc }}"
+            BUILD_DIR="$RUNNER_TEMP/libvmaf_build"
+          else
+            BUILD_DIR="libvmaf/build"
+          fi
+          echo "BUILD_DIR=$BUILD_DIR" >> "$GITHUB_ENV"
+          meson setup libvmaf "$BUILD_DIR" $MESON_OPTS ${CROSS:+--cross-file $CROSS}
+
       - name: Run ninja
         run: |
-          sudo ninja -vC libvmaf/build install
+          sudo ninja -vC "$BUILD_DIR" install
+
       - name: Run tests
+        if: matrix.enable_cuda != true
         run: |
-          sudo ninja -vC libvmaf/build test
+          sudo ninja -vC "$BUILD_DIR" test
       - name: Set up tox
+        if: matrix.enable_cuda != true
         run: |
           mkdir -p ~/.ccache && sudo chown -R $(whoami) ~/.ccache
           pip install tox
       - name: Run tox tests (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.enable_cuda != true
         run: |
           tox -c python
       - name: Run tox tests (mac)


### PR DESCRIPTION
## Summary

Adds a **CUDA compile check** to the `libvmaf` GitHub Actions workflow so that `-Denable_cuda=true` is exercised on every push/PR.

This implements the request in #1576: a lightweight CI job that installs the CUDA toolkit + `nv-codec-headers`, configures with Meson, and builds/installs. Runners do not have an NVIDIA GPU, so device tests are not run; the goal is to catch **configure/compile** regressions early.

Closes #1576

## Build directory (out-of-tree, CUDA jobs only)

**Only the CUDA matrix entries** configure the build in a temporary directory outside the source tree (e.g. `$RUNNER_TEMP/libvmaf_build`). All other jobs keep the existing in-tree layout (`libvmaf/build`), so tests, tox, and packaging behave as on master.

Out-of-tree for CUDA is intentional:

- With the **current** Meson CUDA rules, several `nvcc`/`clang` custom targets use **relative** include paths such as `-I ./src`, `-I ../src`, etc. Those paths work when the build directory is a subdirectory of the source root, but **break when the build dir is fully outside the tree**.
- Using an out-of-tree build for the CUDA jobs makes that class of failure visible instead of hiding it behind an in-tree layout.
- **#1573** fixes those relative includes (among other CUDA compile/test issues) by using absolute paths based on `meson.current_source_dir()` / the build directory, and adjusts related test wiring. Once #1573 is merged, the CUDA CI jobs should stay green for out-of-tree builds as well.

So this workflow both guards CUDA support and documents why out-of-tree builds matter for the CUDA path, without disrupting the rest of the matrix.

## What the CUDA jobs do

Two matrix entries on `ubuntu-latest` (x86_64):

| Job | Host compiler | Device compiler |
|-----|---------------|-----------------|
| `linux-x86_64-gcc-cuda` | GCC | **nvcc** (`-Denable_nvcc=true`) |
| `linux-x86_64-clang-cuda` | Clang | **clang** (`-Denable_nvcc=false`) |

Both:

- Enable CUDA with `-Denable_cuda=true`
- Install a compile-only CUDA toolkit (no driver/runtime metapackages that pull in `nvidia-open` and fail on CPU-only runners)
- Install **nv-codec-headers** (FFmpeg) so `ffnvcodec/dynlink_cuda.h` is available
- Run `meson setup` + `ninja install` only (no GPU tests)
- Use an **out-of-tree** build directory (`$RUNNER_TEMP/libvmaf_build`)

Existing non-CUDA jobs are unchanged (in-tree build, tests, tox, packaging).

## Notes

- Covering both **nvcc** and **clang** as device compilers matches the two paths exposed by `-Denable_nvcc`. Toolkit and Clang versions on the runner may need occasional bumps when Ubuntu/NVIDIA package sets change.
- MinGW/MSYS2 CUDA was not added here: cross-compiling CUDA for Windows from Linux is awkward and not a good fit for this check. Native Windows/MSVC CUDA coverage can follow once MSVC support is merged.
- **CUDA toolkit installation**: The workflow currently uses the third-party action `Jimver/cuda-toolkit` purely for convenience (precise version control + compile-only packages).  
  If the maintainers prefer to avoid external actions, this can be trivially replaced with a manual installation via `apt` (or the official NVIDIA runfile) on Ubuntu. Just let me know and I’ll update it.

## Test plan

- [x] Non-CUDA matrix jobs still configure, build, test, and package as before (in-tree `libvmaf/build`)
- [x] GCC + nvcc CUDA job installs toolkit + headers and completes `meson setup` + `ninja install` (out-of-tree)
- [x] Clang + clang-device CUDA job installs toolkit + headers and completes `meson setup` + `ninja install` (out-of-tree)
- [ ] After #1573: confirm out-of-tree CUDA builds remain green