### PR TITLE
Keep motion filter mirror() in bounds for tiny frames

### DIFF
--- a/libvmaf/src/feature/arm64/motion_neon.c
+++ b/libvmaf/src/feature/arm64/motion_neon.c
@@ -7,8 +7,18 @@
 
 static inline int mirror(int idx, int size)
 {
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
+    // Reflect out of range indices back into [0, size) using the same
+    // reflect 101 boundary the five tap motion filter expects (the edge
+    // sample is never repeated). One reflection is not enough when size
+    // is below 3, so fold repeatedly until the index lands in range.
+    if (size == 1)
+        return 0;
+    while (idx < 0 || idx >= size) {
+        if (idx < 0)
+            idx = -idx;
+        if (idx >= size)
+            idx = 2 * size - idx - 2;
+    }
     return idx;
 }
 

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -148,8 +148,18 @@ static const VmafOption options[] = {
 
 static inline int mirror(int idx, int size)
 {
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
+    // Reflect out of range indices back into [0, size) using the same
+    // reflect 101 boundary the five tap motion filter expects (the edge
+    // sample is never repeated). One reflection is not enough when size
+    // is below 3, so fold repeatedly until the index lands in range.
+    if (size == 1)
+        return 0;
+    while (idx < 0 || idx >= size) {
+        if (idx < 0)
+            idx = -idx;
+        if (idx >= size)
+            idx = 2 * size - idx - 2;
+    }
     return idx;
 }
 

--- a/libvmaf/src/feature/x86/motion_avx2.c
+++ b/libvmaf/src/feature/x86/motion_avx2.c
@@ -25,8 +25,18 @@
 
 static inline int mirror(int idx, int size)
 {
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
+    // Reflect out of range indices back into [0, size) using the same
+    // reflect 101 boundary the five tap motion filter expects (the edge
+    // sample is never repeated). One reflection is not enough when size
+    // is below 3, so fold repeatedly until the index lands in range.
+    if (size == 1)
+        return 0;
+    while (idx < 0 || idx >= size) {
+        if (idx < 0)
+            idx = -idx;
+        if (idx >= size)
+            idx = 2 * size - idx - 2;
+    }
     return idx;
 }
 

--- a/libvmaf/src/feature/x86/motion_avx512.c
+++ b/libvmaf/src/feature/x86/motion_avx512.c
@@ -25,8 +25,18 @@
 
 static inline int mirror(int idx, int size)
 {
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
+    // Reflect out of range indices back into [0, size) using the same
+    // reflect 101 boundary the five tap motion filter expects (the edge
+    // sample is never repeated). One reflection is not enough when size
+    // is below 3, so fold repeatedly until the index lands in range.
+    if (size == 1)
+        return 0;
+    while (idx < 0 || idx >= size) {
+        if (idx < 0)
+            idx = -idx;
+        if (idx >= size)
+            idx = 2 * size - idx - 2;
+    }
     return idx;
 }
 

--- a/libvmaf/test/test_motion_neon.c
+++ b/libvmaf/test/test_motion_neon.c
@@ -74,9 +74,11 @@ static int compute_motion_sad(unsigned w, unsigned h,
 
 static char *test_motion_neon_matches_scalar()
 {
-    // w/h < 3 excluded: mirror()'s radius-2 reflection goes out of bounds there
-    // (same bug in scalar/AVX2), so those sizes compare garbage against garbage.
+    // Sizes with width or height 1 or 2 are the regression case for issue
+    // 1580: mirror()'s reflection used to read out of bounds there. With the
+    // bounded reflection scalar and NEON must still agree bit exactly.
     static const struct { unsigned w, h; } sizes[] = {
+        {1, 1}, {2, 2}, {1, 2}, {2, 1}, {1, 5}, {5, 1}, {2, 5}, {5, 2},
         {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
         {15, 15}, {16, 16}, {17, 17}, {20, 4}, {33, 9}, {64, 48}, {65, 63},
     };


### PR DESCRIPTION
## Summary

The reflect 101 boundary helper used by the five tap motion filter reflects an out of range index only once. That single reflection is not enough when the frame width or height is 1 or 2, so it returns values outside [0, size) and motion feature extraction reads out of bounds on those sizes.

Examples from issue #1580, writing negative as neg:

* For size 1, an index of neg 2 reflected to 2, yet the only valid index is 0.
* For size 2, an index of neg 2 reflected to 2, yet valid indices are only 0 and 1.
* For size 2, an index of 3 reflected to neg 1, which is below the valid range.

## Fix

* Fold the index repeatedly until it lands inside [0, size), and treat size 1 as the single valid index 0.
* Behaviour is unchanged for size of 3 or more, where the existing single reflection already stayed in range, so scores on normal frames are untouched.
* The helper is duplicated across the scalar, AVX2, AVX512 and NEON motion paths, so all four copies are updated identically to stay consistent.

## Files changed

* libvmaf/src/feature/integer_motion.c
* libvmaf/src/feature/x86/motion_avx2.c
* libvmaf/src/feature/x86/motion_avx512.c
* libvmaf/src/feature/arm64/motion_neon.c
* libvmaf/test/test_motion_neon.c

## Testing

The NEON parity test previously skipped width or height below 3 because of this bug. Those small sizes are now included as the regression case, so scalar and NEON must agree bit exactly there. Built with meson and ninja on arm64 and ran the motion tests:

* test_motion_neon passes with the small sizes 1 and 2 enabled
* test_motion_blend passes

I also checked every tap offset for sizes 1 through 49 to confirm the new helper always returns an index inside [0, size) and matches the previous helper for size of 3 or more.

Fixes #1580
