### PR TITLE
Fix out-of-bounds boundary reflection for tiny frames in motion feature

### DIFF
--- a/libvmaf/src/feature/arm64/motion_neon.c
+++ b/libvmaf/src/feature/arm64/motion_neon.c
@@ -5,13 +5,6 @@
 
 #include "feature/integer_motion.h"
 
-static inline int mirror(int idx, int size)
-{
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
-    return idx;
-}
-
 // Phase 2: x_conv + abs + SAD for one row of int32 y_row.
 // Processes 4 int32 columns at a time via widening s32->s64 multiply-accumulate.
 static inline uint32_t
@@ -24,7 +17,7 @@ x_conv_row_sad_neon(const int32_t *y_row, unsigned w)
     for (j = 0; j < 2 && j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -68,7 +61,7 @@ x_conv_row_sad_neon(const int32_t *y_row, unsigned w)
     for (; j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -89,7 +82,7 @@ uint64_t motion_score_pipeline_8_neon(const uint8_t *prev, ptrdiff_t prev_stride
     for (unsigned i = 0; i < h; i++) {
         const uint8_t *p[5], *c[5];
         for (int k = 0; k < 5; k++) {
-            int r = mirror((int)i - 2 + k, (int)h);
+            int r = motion_mirror((int)i - 2 + k, (int)h);
             p[k] = prev + r * prev_stride;
             c[k] = cur + r * cur_stride;
         }

--- a/libvmaf/src/feature/common/convolution.c
+++ b/libvmaf/src/feature/common/convolution.c
@@ -25,11 +25,20 @@
 extern int vmaf_floorn(int, int);
 extern int vmaf_ceiln(int, int);
 
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
 void convolution_x_c_s(const float *filter, int filter_width, const float *src, float *dst, int width, int height, int src_stride, int dst_stride, int step)
 {
 	int radius = filter_width / 2;
 	int borders_left = vmaf_ceiln(radius, step);
 	int borders_right = vmaf_floorn(width - (filter_width - radius), step);
+
+	// Clamp so tiny widths (< filter_width) cannot produce negative loop bounds,
+	// which would make the trailing edge loop start at a negative index and write
+	// outside dst. No-op for width >= filter_width.
+	borders_left = MIN(borders_left, width);
+	borders_right = MAX(borders_right, borders_left);
 
 	for (int i = 0; i < height; ++i) {
 		for (int j = 0; j < borders_left; j += step) {
@@ -55,6 +64,12 @@ void convolution_y_c_s(const float *filter, int filter_width, const float *src, 
 	int radius = filter_width / 2;
 	int borders_top = vmaf_ceiln(radius, step);
 	int borders_bottom = vmaf_floorn(height - (filter_width - radius), step);
+
+	// Clamp so tiny heights (< filter_width) cannot produce negative loop bounds,
+	// which would make the trailing edge loop start at a negative index and write
+	// outside dst. No-op for height >= filter_width.
+	borders_top = MIN(borders_top, height);
+	borders_bottom = MAX(borders_bottom, borders_top);
 
 	for (int i = 0; i < borders_top; i += step) {
 		for (int j = 0; j < width; ++j) {

--- a/libvmaf/src/feature/common/convolution_avx.c
+++ b/libvmaf/src/feature/common/convolution_avx.c
@@ -135,8 +135,10 @@ void convolution_f32_avx_s(const float * RESTRICT filter, int filter_width, cons
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
     // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
-    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
-    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // the tmp/dst buffers. i_vec_end is safe to raise in place: its two uses are the
+    // vector loop's end bound and the trailing loop's start, and the raise only fires
+    // when the raised value is <= radius, which leaves the vector loop
+    // [radius, i_vec_end) empty. j_vec_end must NOT be raised
     // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
     // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
     // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +
@@ -189,8 +191,10 @@ void convolution_f32_avx_sq_s(const float * RESTRICT filter, int filter_width, c
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
     // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
-    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
-    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // the tmp/dst buffers. i_vec_end is safe to raise in place: its two uses are the
+    // vector loop's end bound and the trailing loop's start, and the raise only fires
+    // when the raised value is <= radius, which leaves the vector loop
+    // [radius, i_vec_end) empty. j_vec_end must NOT be raised
     // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
     // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
     // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +
@@ -244,8 +248,10 @@ void convolution_f32_avx_xy_s(const float * RESTRICT filter, int filter_width, c
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
     // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
-    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
-    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // the tmp/dst buffers. i_vec_end is safe to raise in place: its two uses are the
+    // vector loop's end bound and the trailing loop's start, and the raise only fires
+    // when the raised value is <= radius, which leaves the vector loop
+    // [radius, i_vec_end) empty. j_vec_end must NOT be raised
     // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
     // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
     // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +

--- a/libvmaf/src/feature/common/convolution_avx.c
+++ b/libvmaf/src/feature/common/convolution_avx.c
@@ -23,6 +23,9 @@
 
 #define AVX_STEP (8)
 
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
 
 void convolution_f32_avx_s_1d_h_scanline(const float * RESTRICT filter, int filter_width, const float * RESTRICT src, float * RESTRICT dst, int j_end) {
     int radius = filter_width / 2;
@@ -131,8 +134,21 @@ void convolution_f32_avx_s(const float * RESTRICT filter, int filter_width, cons
     int i_vec_end = height - radius;
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
+    // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
+    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
+    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
+    // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
+    // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +
+    // AVX_STEP) for each j < j_end). So the horizontal trailing loop's clamped start
+    // goes in a SEPARATE variable, j_trailing_start.
+    int i_edge_end = MIN(radius, height);
+    i_vec_end = MAX(i_vec_end, i_edge_end);
+    int j_edge_end = MIN(radius, width);
+    int j_trailing_start = MAX(j_vec_end, j_edge_end);
+
     // Vertical pass.
-    for (int i = 0; i < radius; ++i) {
+    for (int i = 0; i < i_edge_end; ++i) {
         for (int j = 0; j < width; ++j) {
             tmp[i * tmp_stride + j] = convolution_edge_s(false, filter, filter_width, src, width, height, src_stride, i, j);
         }
@@ -152,13 +168,13 @@ void convolution_f32_avx_s(const float * RESTRICT filter, int filter_width, cons
 
     // Horizontal pass.
     for (int i = 0; i < height; ++i) {
-        for (int j = 0; j < radius; ++j) {
+        for (int j = 0; j < j_edge_end; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
 
         convolution_f32_avx_s_1d_h_scanline(filter, filter_width, tmp + i * tmp_stride, dst + i * dst_stride, j_vec_end);
 
-        for (int j = j_vec_end; j < width; ++j) {
+        for (int j = j_trailing_start; j < width; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
     }
@@ -172,8 +188,21 @@ void convolution_f32_avx_sq_s(const float * RESTRICT filter, int filter_width, c
     int i_vec_end = height - radius;
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
+    // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
+    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
+    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
+    // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
+    // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +
+    // AVX_STEP) for each j < j_end). So the horizontal trailing loop's clamped start
+    // goes in a SEPARATE variable, j_trailing_start.
+    int i_edge_end = MIN(radius, height);
+    i_vec_end = MAX(i_vec_end, i_edge_end);
+    int j_edge_end = MIN(radius, width);
+    int j_trailing_start = MAX(j_vec_end, j_edge_end);
+
     // Vertical pass.
-    for (int i = 0; i < radius; ++i) {
+    for (int i = 0; i < i_edge_end; ++i) {
         for (int j = 0; j < width; ++j) {
             tmp[i * tmp_stride + j] = convolution_edge_sq_s(false, filter, filter_width, src, width, height, src_stride, i, j);
         }
@@ -193,13 +222,13 @@ void convolution_f32_avx_sq_s(const float * RESTRICT filter, int filter_width, c
 
     // Horizontal pass.
     for (int i = 0; i < height; ++i) {
-        for (int j = 0; j < radius; ++j) {
+        for (int j = 0; j < j_edge_end; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
 
         convolution_f32_avx_s_1d_h_scanline(filter, filter_width, tmp + i * tmp_stride, dst + i * dst_stride, j_vec_end);
 
-        for (int j = j_vec_end; j < width; ++j) {
+        for (int j = j_trailing_start; j < width; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
     }
@@ -214,8 +243,21 @@ void convolution_f32_avx_xy_s(const float * RESTRICT filter, int filter_width, c
     int i_vec_end = height - radius;
     int j_vec_end = vmaf_floorn(width - radius, AVX_STEP);
 
+    // Clamp edge-loop bounds so tiny width/height (< radius) cannot write outside
+    // the tmp/dst buffers. i_vec_end is safe to raise in place because its only
+    // other use is the vertical trailing loop's start. j_vec_end must NOT be raised
+    // in place: it is also passed unmodified to convolution_f32_avx_s_1d_h_scanline,
+    // whose j_end argument must stay <= vmaf_floorn(width - radius, AVX_STEP) or the
+    // scanline itself writes out of bounds (it stores dst[j + radius .. j + radius +
+    // AVX_STEP) for each j < j_end). So the horizontal trailing loop's clamped start
+    // goes in a SEPARATE variable, j_trailing_start.
+    int i_edge_end = MIN(radius, height);
+    i_vec_end = MAX(i_vec_end, i_edge_end);
+    int j_edge_end = MIN(radius, width);
+    int j_trailing_start = MAX(j_vec_end, j_edge_end);
+
     // Vertical pass.
-    for (int i = 0; i < radius; ++i) {
+    for (int i = 0; i < i_edge_end; ++i) {
         for (int j = 0; j < width; ++j) {
             tmp[i * tmp_stride + j] = convolution_edge_xy_s(false, filter, filter_width, src1, src2, width, height, src1_stride, src2_stride, i, j);
         }
@@ -235,13 +277,13 @@ void convolution_f32_avx_xy_s(const float * RESTRICT filter, int filter_width, c
 
     // Horizontal pass.
     for (int i = 0; i < height; ++i) {
-        for (int j = 0; j < radius; ++j) {
+        for (int j = 0; j < j_edge_end; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
 
         convolution_f32_avx_s_1d_h_scanline(filter, filter_width, tmp + i * tmp_stride, dst + i * dst_stride, j_vec_end);
 
-        for (int j = j_vec_end; j < width; ++j) {
+        for (int j = j_trailing_start; j < width; ++j) {
             dst[i * dst_stride + j] = convolution_edge_s(true, filter, filter_width, tmp, width, height, tmp_stride, i, j);
         }
     }

--- a/libvmaf/src/feature/common/convolution_internal.h
+++ b/libvmaf/src/feature/common/convolution_internal.h
@@ -28,11 +28,13 @@
  * motion_mirror() in feature/integer_motion.h. Reflects repeatedly so any size >= 1
  * is safe; for in-contract offsets (|tap - i or j| within the filter's radius) at
  * most one reflection is taken, so behavior is bit-identical to the historical
- * single-bounce version for size >= radius+1. size == 1 is special-cased: the
- * reflection period 2*(size-1) is 0 and the loop would not terminate. */
+ * single-bounce version for size >= radius+1. size <= 1 is special-cased: the
+ * reflection period 2*(size-1) is 0 (or negative) and the loop would not
+ * terminate. size is always >= 1 in the real call graph, so covering size <= 0
+ * as well only makes the function total; it changes no reachable result. */
 FORCE_INLINE int convolution_mirror(int tap, int size)
 {
-	if (size == 1) return 0;
+	if (size <= 1) return 0;
 	while (tap < 0 || tap >= size) {
 		if (tap < 0) tap = -tap;
 		else tap = 2 * size - tap - 2;

--- a/libvmaf/src/feature/common/convolution_internal.h
+++ b/libvmaf/src/feature/common/convolution_internal.h
@@ -24,6 +24,22 @@
 #include "macros.h"
 #include <stdbool.h>
 
+/* Whole-sample symmetric ("reflect-101") boundary index; same semantics as
+ * motion_mirror() in feature/integer_motion.h. Reflects repeatedly so any size >= 1
+ * is safe; for in-contract offsets (|tap - i or j| within the filter's radius) at
+ * most one reflection is taken, so behavior is bit-identical to the historical
+ * single-bounce version for size >= radius+1. size == 1 is special-cased: the
+ * reflection period 2*(size-1) is 0 and the loop would not terminate. */
+FORCE_INLINE int convolution_mirror(int tap, int size)
+{
+	if (size == 1) return 0;
+	while (tap < 0 || tap >= size) {
+		if (tap < 0) tap = -tap;
+		else tap = 2 * size - tap - 2;
+	}
+	return tap;
+}
+
 FORCE_INLINE float convolution_edge_s(bool horizontal, const float *filter, int filter_width, const float *src, int width, int height, int stride, int i, int j)
 {
 	int radius = filter_width / 2;
@@ -35,15 +51,9 @@ FORCE_INLINE float convolution_edge_s(bool horizontal, const float *filter, int 
 
 		// Handle edges by mirroring.
 		if (horizontal) {
-			if (j_tap < 0)
-				j_tap = -j_tap;
-			else if (j_tap >= width)
-				j_tap = width - (j_tap - width + 2);
+			j_tap = convolution_mirror(j_tap, width);
 		} else {
-			if (i_tap < 0)
-				i_tap = -i_tap;
-			else if (i_tap >= height)
-				i_tap = height - (i_tap - height + 2);
+			i_tap = convolution_mirror(i_tap, height);
 		}
 
 		accum += filter[k] * src[i_tap * stride + j_tap];
@@ -63,16 +73,10 @@ FORCE_INLINE float convolution_edge_sq_s(bool horizontal, const float *filter, i
 
 		// Handle edges by mirroring.
 		if (horizontal) {
-			if (j_tap < 0)
-				j_tap = -j_tap;
-			else if (j_tap >= width)
-				j_tap = width - (j_tap - width + 2);
+			j_tap = convolution_mirror(j_tap, width);
 		}
 		else {
-			if (i_tap < 0)
-				i_tap = -i_tap;
-			else if (i_tap >= height)
-				i_tap = height - (i_tap - height + 2);
+			i_tap = convolution_mirror(i_tap, height);
 		}
 		src_val = src[i_tap * stride + j_tap];
 		accum += filter[k] * (src_val * src_val);
@@ -92,16 +96,10 @@ FORCE_INLINE float convolution_edge_xy_s(bool horizontal, const float *filter, i
 
 		// Handle edges by mirroring.
 		if (horizontal) {
-			if (j_tap < 0)
-				j_tap = -j_tap;
-			else if (j_tap >= width)
-				j_tap = width - (j_tap - width + 2);
+			j_tap = convolution_mirror(j_tap, width);
 		}
 		else {
-			if (i_tap < 0)
-				i_tap = -i_tap;
-			else if (i_tap >= height)
-				i_tap = height - (i_tap - height + 2);
+			i_tap = convolution_mirror(i_tap, height);
 		}
 		src_val1 = src1[i_tap * stride1 + j_tap];
 		src_val2 = src2[i_tap * stride2 + j_tap];

--- a/libvmaf/src/feature/cuda/integer_motion/motion_score.cu
+++ b/libvmaf/src/feature/cuda/integer_motion/motion_score.cu
@@ -29,6 +29,7 @@ __constant__ int radius = (sizeof(filter_d) / sizeof(filter_d[0])) / 2;
 // Device function that mirrors an idx along its valid [0,sup) range
 __device__ __forceinline__ int mirror(const int idx, const int sup)
 {
+    if (sup == 1) return 0;
     int out = abs(idx);
     return (out < sup) ? out : (sup - (out - sup + 1));
 }

--- a/libvmaf/src/feature/integer_motion.c
+++ b/libvmaf/src/feature/integer_motion.c
@@ -146,13 +146,6 @@ static const VmafOption options[] = {
     { 0 }
 };
 
-static inline int mirror(int idx, int size)
-{
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
-    return idx;
-}
-
 static uint64_t
 motion_score_pipeline_8(const uint8_t *prev, ptrdiff_t prev_stride,
                         const uint8_t *cur, ptrdiff_t cur_stride,
@@ -172,7 +165,7 @@ motion_score_pipeline_8(const uint8_t *prev, ptrdiff_t prev_stride,
         for (unsigned j = 0; j < w; j++) {
             int32_t accum = 0;
             for (int k = 0; k < filter_width; k++) {
-                const int row = mirror((int)i - radius + k, (int)h);
+                const int row = motion_mirror((int)i - radius + k, (int)h);
                 int32_t diff = prev[row * prev_stride + j]
                              - cur[row * cur_stride + j];
                 accum += (int32_t)filter[k] * diff;
@@ -188,7 +181,7 @@ motion_score_pipeline_8(const uint8_t *prev, ptrdiff_t prev_stride,
         for (unsigned j = 0; j < w; j++) {
             int64_t accum = 0;
             for (int k = 0; k < filter_width; k++) {
-                const int col = mirror((int)j - radius + k, (int)w);
+                const int col = motion_mirror((int)j - radius + k, (int)w);
                 accum += (int64_t)filter[k] * y_row[col];
             }
             int32_t val = (int32_t)((accum + x_round) >> 16);
@@ -223,7 +216,7 @@ motion_score_pipeline_16(const uint8_t *prev_u8, ptrdiff_t prev_stride,
         for (unsigned j = 0; j < w; j++) {
             int64_t accum = 0;
             for (int k = 0; k < filter_width; k++) {
-                const int row = mirror((int)i - radius + k, (int)h);
+                const int row = motion_mirror((int)i - radius + k, (int)h);
                 int32_t diff = prev[row * p_stride + j]
                              - cur[row * c_stride + j];
                 accum += (int64_t)filter[k] * diff;
@@ -239,7 +232,7 @@ motion_score_pipeline_16(const uint8_t *prev_u8, ptrdiff_t prev_stride,
         for (unsigned j = 0; j < w; j++) {
             int64_t accum = 0;
             for (int k = 0; k < filter_width; k++) {
-                const int col = mirror((int)j - radius + k, (int)w);
+                const int col = motion_mirror((int)j - radius + k, (int)w);
                 accum += (int64_t)filter[k] * y_row[col];
             }
             int32_t val = (int32_t)((accum + x_round) >> 16);

--- a/libvmaf/src/feature/integer_motion.h
+++ b/libvmaf/src/feature/integer_motion.h
@@ -25,32 +25,20 @@
 static const uint16_t filter[5] = { 3571, 16004, 26386, 16004, 3571 };
 static const int filter_width = sizeof(filter) / sizeof(filter[0]);
 
-static inline uint32_t
-edge_16(bool horizontal, const uint16_t *src, int width,
-        int height, int stride, int i, int j)
+/* Whole-sample symmetric ("reflect-101") boundary index.
+ * Reflects repeatedly so that any size >= 1 is safe; for size >= 3 and
+ * |overshoot| <= 2 (the 5-tap/radius-2 call contract) at most one
+ * reflection is taken, so behavior is bit-identical to the historical
+ * single-bounce version. size == 1 must be special-cased: the reflection
+ * period 2*(size-1) is 0 and the loop would not terminate. */
+static inline int motion_mirror(int idx, int size)
 {
-    const int radius = filter_width / 2;
-    uint32_t accum = 0;
-
-    // MIRROR | ЯOЯЯIM
-    for (int k = 0; k < filter_width; ++k) {
-        int i_tap = horizontal ? i : i - radius + k;
-        int j_tap = horizontal ? j - radius + k : j;
-
-        if (horizontal) {
-            if (j_tap < 0)
-                j_tap = -j_tap;
-            else if (j_tap >= width)
-                j_tap = width - (j_tap - width + 2);
-        } else {
-            if (i_tap < 0)
-                i_tap = -i_tap;
-            else if (i_tap >= height)
-                i_tap = height - (i_tap - height + 2);
-        }
-        accum += filter[k] * src[i_tap * stride + j_tap];
+    if (size == 1) return 0;
+    while (idx < 0 || idx >= size) {
+        if (idx < 0) idx = -idx;
+        else idx = 2 * size - idx - 2;
     }
-    return accum;
+    return idx;
 }
 
 #endif /* _FEATURE_MOTION_H_ */

--- a/libvmaf/src/feature/integer_motion.h
+++ b/libvmaf/src/feature/integer_motion.h
@@ -29,11 +29,13 @@ static const int filter_width = sizeof(filter) / sizeof(filter[0]);
  * Reflects repeatedly so that any size >= 1 is safe; for size >= 3 and
  * |overshoot| <= 2 (the 5-tap/radius-2 call contract) at most one
  * reflection is taken, so behavior is bit-identical to the historical
- * single-bounce version. size == 1 must be special-cased: the reflection
- * period 2*(size-1) is 0 and the loop would not terminate. */
+ * single-bounce version. size <= 1 must be special-cased: the reflection
+ * period 2*(size-1) is 0 (or negative) and the loop would not terminate.
+ * size is always >= 1 in the real call graph, so covering size <= 0 as well
+ * only makes the function total; it changes no reachable result. */
 static inline int motion_mirror(int idx, int size)
 {
-    if (size == 1) return 0;
+    if (size <= 1) return 0;
     while (idx < 0 || idx >= size) {
         if (idx < 0) idx = -idx;
         else idx = 2 * size - idx - 2;

--- a/libvmaf/src/feature/x86/motion_avx2.c
+++ b/libvmaf/src/feature/x86/motion_avx2.c
@@ -23,13 +23,6 @@
 
 #include "feature/integer_motion.h"
 
-static inline int mirror(int idx, int size)
-{
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
-    return idx;
-}
-
 // Emulate arithmetic right shift of int64 by 16 in AVX2.
 // AVX2 lacks srai_epi64; this uses the blend trick:
 //   low dwords come from logical shift, high dwords from arithmetic shift.
@@ -58,7 +51,7 @@ x_conv_row_sad_avx2(const int32_t *y_row, unsigned w)
     for (j = 0; j < 2 && j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -127,7 +120,7 @@ x_conv_row_sad_avx2(const int32_t *y_row, unsigned w)
     for (; j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -159,7 +152,7 @@ uint64_t motion_score_pipeline_16_avx2(const uint8_t *prev_u8, ptrdiff_t prev_st
     for (unsigned i = 0; i < h; i++) {
         const uint16_t *pp[5], *cp[5];
         for (int k = 0; k < 5; k++) {
-            int r = mirror((int)i - 2 + k, (int)h);
+            int r = motion_mirror((int)i - 2 + k, (int)h);
             pp[k] = prev + r * p_stride;
             cp[k] = cur + r * c_stride;
         }
@@ -253,7 +246,7 @@ uint64_t motion_score_pipeline_8_avx2(const uint8_t *prev, ptrdiff_t prev_stride
     for (unsigned i = 0; i < h; i++) {
         const uint8_t *p[5], *c[5];
         for (int k = 0; k < 5; k++) {
-            int r = mirror((int)i - 2 + k, (int)h);
+            int r = motion_mirror((int)i - 2 + k, (int)h);
             p[k] = prev + r * prev_stride;
             c[k] = cur + r * cur_stride;
         }

--- a/libvmaf/src/feature/x86/motion_avx512.c
+++ b/libvmaf/src/feature/x86/motion_avx512.c
@@ -23,13 +23,6 @@
 
 #include "feature/integer_motion.h"
 
-static inline int mirror(int idx, int size)
-{
-    if (idx < 0) return -idx;
-    if (idx >= size) return 2 * size - idx - 2;
-    return idx;
-}
-
 // SIMD phase 2: x_conv + abs + SAD for one row of int32 y_row.
 // Processes 16 int32 columns at a time via mullo_epi32 + int64 accumulation.
 static inline uint32_t
@@ -47,7 +40,7 @@ x_conv_row_sad_avx512(const int32_t *y_row, unsigned w)
     for (j = 0; j < 2 && j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -105,7 +98,7 @@ x_conv_row_sad_avx512(const int32_t *y_row, unsigned w)
     for (; j < w; j++) {
         int64_t accum = 0;
         for (int k = 0; k < 5; k++) {
-            int col = mirror((int)j - 2 + k, (int)w);
+            int col = motion_mirror((int)j - 2 + k, (int)w);
             accum += (int64_t)filter[k] * y_row[col];
         }
         int32_t val = (int32_t)((accum + (1 << 15)) >> 16);
@@ -136,7 +129,7 @@ uint64_t motion_score_pipeline_16_avx512(const uint8_t *prev_u8, ptrdiff_t prev_
     for (unsigned i = 0; i < h; i++) {
         const uint16_t *pp[5], *cp[5];
         for (int k = 0; k < 5; k++) {
-            int r = mirror((int)i - 2 + k, (int)h);
+            int r = motion_mirror((int)i - 2 + k, (int)h);
             pp[k] = prev + r * p_stride;
             cp[k] = cur + r * c_stride;
         }
@@ -224,7 +217,7 @@ uint64_t motion_score_pipeline_8_avx512(const uint8_t *prev, ptrdiff_t prev_stri
     for (unsigned i = 0; i < h; i++) {
         const uint8_t *p[5], *c[5];
         for (int k = 0; k < 5; k++) {
-            int r = mirror((int)i - 2 + k, (int)h);
+            int r = motion_mirror((int)i - 2 + k, (int)h);
             p[k] = prev + r * prev_stride;
             c[k] = cur + r * cur_stride;
         }

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -163,6 +163,7 @@ test_motion_mirror = executable('test_motion_mirror',
     ['test.c', 'test_motion_mirror.c'],
     include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+    dependencies : math_lib,
 )
 
 if float_enabled

--- a/libvmaf/test/meson.build
+++ b/libvmaf/test/meson.build
@@ -159,6 +159,12 @@ test_motion_blend = executable('test_motion_blend',
     link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
 )
 
+test_motion_mirror = executable('test_motion_mirror',
+    ['test.c', 'test_motion_mirror.c'],
+    include_directories : [libvmaf_inc, test_inc, include_directories('../src/')],
+    link_with : get_option('default_library') == 'both' ? libvmaf.get_static_lib() : libvmaf,
+)
+
 if float_enabled
     test_vif_tools = executable('test_vif_tools',
         ['test.c', 'test_vif_tools.c'],
@@ -226,6 +232,7 @@ test('test_propagate_metadata', test_propagate_metadata)
 test('test_adm_csf', test_adm_csf)
 test('test_barten_csf', test_barten_csf)
 test('test_motion_blend', test_motion_blend)
+test('test_motion_mirror', test_motion_mirror)
 
 if is_asm_enabled and (host_machine.cpu_family().startswith('arm64') or host_machine.cpu_family().startswith('aarch64'))
     test_motion_neon = executable('test_motion_neon',

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -16,9 +16,15 @@
  *
  */
 
+#include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 
+#include "cpu.h"
 #include "test.h"
+#include "libvmaf/picture.h"
+#include "feature/feature_collector.h"
+#include "feature/feature_extractor.h"
 #include "feature/integer_motion.h"
 #include "feature/common/convolution_internal.h"
 
@@ -144,11 +150,183 @@ static char *test_convolution_mirror_matches_pre_fix_for_normal_sizes()
     return NULL;
 }
 
+/* The tiny frame sizes the fix makes reachable. Every one of them has a
+ * dimension below the 5-tap filter's radius of 2, which is exactly where the
+ * old single-bounce reflection escaped the buffer. */
+static const struct { unsigned w, h; } tiny_sizes[] = {
+    {1, 1}, {1, 2}, {2, 1}, {2, 2}, {1, 8}, {8, 1}, {2, 8}, {8, 2},
+};
+static const unsigned n_tiny_sizes = sizeof(tiny_sizes) / sizeof(tiny_sizes[0]);
+
+static void fill_random_picture(VmafPicture *pic, unsigned seed)
+{
+    srand(seed);
+    const int max_val = 1 << pic->bpc;
+    for (unsigned p = 0; p < 3; p++) {
+        uint8_t *base = pic->data[p];
+        for (unsigned i = 0; i < pic->h[p]; i++) {
+            uint8_t *row = base + i * pic->stride[p];
+            for (unsigned j = 0; j < pic->w[p]; j++) {
+                if (pic->bpc == 8)
+                    row[j] = (uint8_t)(rand() % max_val);
+                else
+                    ((uint16_t *)row)[j] = (uint16_t)(rand() % max_val);
+            }
+        }
+    }
+}
+
+/* Drives a temporal feature extractor over two frames and reads back the score
+ * `feature_name` produced for frame index 1. Modelled on
+ * test_motion_neon.c's compute_motion_sad(). */
+static int run_motion_fex(VmafFeatureExtractor *fex, const char *feature_name,
+                          unsigned w, unsigned h, unsigned bpc,
+                          unsigned cpu_mask, double *score)
+{
+    int err;
+    vmaf_set_cpu_flags_mask(cpu_mask);
+
+    VmafFeatureExtractorContext *fex_ctx;
+    err = vmaf_feature_extractor_context_create(&fex_ctx, fex, NULL);
+    if (err) return err;
+
+    VmafPicture prev_pic, cur_pic;
+    err = vmaf_picture_alloc(&prev_pic, VMAF_PIX_FMT_YUV420P, bpc, w, h);
+    if (err) return err;
+    err = vmaf_picture_alloc(&cur_pic, VMAF_PIX_FMT_YUV420P, bpc, w, h);
+    if (err) return err;
+
+    fill_random_picture(&prev_pic, 100);
+    fill_random_picture(&cur_pic, 200);
+
+    VmafFeatureCollector *vfc;
+    err = vmaf_feature_collector_init(&vfc);
+    if (err) return err;
+
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &prev_pic, NULL,
+                                                 &prev_pic, NULL, 0, vfc);
+    if (err) return err;
+
+    if (fex_ctx->fex->flags & VMAF_FEATURE_EXTRACTOR_PREV_REF)
+        fex_ctx->fex->prev_ref = prev_pic;
+
+    err = vmaf_feature_extractor_context_extract(fex_ctx, &cur_pic, NULL,
+                                                 &cur_pic, NULL, 1, vfc);
+    if (err) return err;
+
+    err = vmaf_feature_collector_get_score(vfc, feature_name, score, 1);
+    if (err) return err;
+
+    err = vmaf_feature_extractor_context_close(fex_ctx);
+    if (err) return err;
+    err = vmaf_feature_extractor_context_destroy(fex_ctx);
+    if (err) return err;
+
+    vmaf_feature_collector_destroy(vfc);
+    vmaf_picture_unref(&prev_pic);
+    vmaf_picture_unref(&cur_pic);
+
+    return 0;
+}
+
+/* T5: the integer `motion` extractor must run to completion at frame sizes
+ * smaller than the filter radius, touching only valid memory (the real teeth
+ * of this test come from running it under ASan) and producing a well-defined,
+ * repeatable score. There is no meaningful golden value at 1x1, so what is
+ * asserted is: the call succeeds, the score is finite, and two identical runs
+ * agree bit-for-bit. Both the 8 bpc and the 16 bpc pipeline are covered, and
+ * both the scalar and the best-available SIMD dispatch. */
+static char *test_integer_motion_pipeline_tiny_sizes()
+{
+    static const unsigned bpcs[] = { 8, 10, 12, 16 };
+    const unsigned n_bpcs = sizeof(bpcs) / sizeof(bpcs[0]);
+    static const unsigned cpu_masks[] = { 0, ~0u };
+    const unsigned n_cpu_masks = sizeof(cpu_masks) / sizeof(cpu_masks[0]);
+
+    vmaf_init_cpu();
+
+    VmafFeatureExtractor *fex = vmaf_get_feature_extractor_by_name("motion");
+    mu_assert("the integer motion feature extractor must exist", fex);
+
+    for (unsigned s = 0; s < n_tiny_sizes; s++) {
+        for (unsigned b = 0; b < n_bpcs; b++) {
+            for (unsigned c = 0; c < n_cpu_masks; c++) {
+                double score_a = -1., score_b = -1.;
+                int err;
+
+                err = run_motion_fex(fex,
+                        "VMAF_integer_feature_motion_sad_score",
+                        tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                        cpu_masks[c], &score_a);
+                mu_assert("integer motion extraction must succeed at tiny sizes",
+                          !err);
+                mu_assert("integer motion score must be finite at tiny sizes",
+                          isfinite(score_a));
+
+                err = run_motion_fex(fex,
+                        "VMAF_integer_feature_motion_sad_score",
+                        tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                        cpu_masks[c], &score_b);
+                mu_assert("integer motion re-run must succeed at tiny sizes",
+                          !err);
+                mu_assert("integer motion score must be deterministic",
+                          score_a == score_b);
+            }
+        }
+    }
+
+    vmaf_set_cpu_flags_mask(~0u);
+    return NULL;
+}
+
+/* T6: the same pipeline-safety and determinism check for the float `motion`
+ * path, which reflects through convolution_mirror() instead. Skipped when the
+ * library was configured with -Denable_float=false, in which case the
+ * extractor simply is not registered. */
+static char *test_float_motion_pipeline_tiny_sizes()
+{
+    vmaf_init_cpu();
+
+    VmafFeatureExtractor *fex =
+        vmaf_get_feature_extractor_by_name("float_motion");
+    if (!fex) return NULL; /* float features disabled at build time */
+
+    static const unsigned bpcs[] = { 8, 10, 16 };
+    const unsigned n_bpcs = sizeof(bpcs) / sizeof(bpcs[0]);
+
+    for (unsigned s = 0; s < n_tiny_sizes; s++) {
+        for (unsigned b = 0; b < n_bpcs; b++) {
+            double score_a = -1., score_b = -1.;
+            int err;
+
+            err = run_motion_fex(fex, "VMAF_feature_motion_score",
+                                 tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                                 ~0u, &score_a);
+            mu_assert("float motion extraction must succeed at tiny sizes",
+                      !err);
+            mu_assert("float motion score must be finite at tiny sizes",
+                      isfinite(score_a));
+
+            err = run_motion_fex(fex, "VMAF_feature_motion_score",
+                                 tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                                 ~0u, &score_b);
+            mu_assert("float motion re-run must succeed at tiny sizes", !err);
+            mu_assert("float motion score must be deterministic",
+                      score_a == score_b);
+        }
+    }
+
+    vmaf_set_cpu_flags_mask(~0u);
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_motion_mirror_matches_pre_fix_for_normal_sizes);
     mu_run_test(test_motion_mirror_sub3_sizes);
     mu_run_test(test_cuda_mirror_formula_matches_pre_fix_for_sup_ge_2);
     mu_run_test(test_convolution_mirror_matches_pre_fix_for_normal_sizes);
+    mu_run_test(test_integer_motion_pipeline_tiny_sizes);
+    mu_run_test(test_float_motion_pipeline_tiny_sizes);
     return NULL;
 }

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -244,7 +244,14 @@ static int run_motion_fex(VmafFeatureExtractor *fex, const char *feature_name,
  * repeatable score. There is no meaningful golden value at 1x1, so what is
  * asserted is: the call succeeds, the score is finite, and two identical runs
  * agree bit-for-bit. Both the 8 bpc and the 16 bpc pipeline are covered, and
- * both the scalar and the best-available SIMD dispatch. */
+ * both the scalar and the best-available SIMD dispatch.
+ *
+ * On top of the per-mask determinism check, every mask's score is compared
+ * against the cpu_masks[0] (== 0, forced scalar) score for the same
+ * (size, bpc). That cross-mask equality is what gives the x86 AVX2/AVX-512
+ * motion kernels their only runtime coverage for this fix: upstream CI runs
+ * `meson test` on an x86_64 runner, where the ~0u pass dispatches to those
+ * kernels and must land on exactly the same SAD as the C reference. */
 static char *test_integer_motion_pipeline_tiny_sizes()
 {
     static const unsigned bpcs[] = { 8, 10, 12, 16 };
@@ -257,6 +264,8 @@ static char *test_integer_motion_pipeline_tiny_sizes()
 
     for (unsigned s = 0; s < n_tiny_sizes; s++) {
         for (unsigned b = 0; b < n_bpcs; b++) {
+            double scalar_score = -1.;
+
             for (unsigned c = 0; c < n_cpu_masks; c++) {
                 double score_a = -1., score_b = -1.;
                 int err;
@@ -278,12 +287,29 @@ static char *test_integer_motion_pipeline_tiny_sizes()
                           !err);
                 mu_assert("integer motion score must be deterministic",
                           score_a == score_b);
+
+                /* cpu_masks[0] is 0, i.e. the forced-scalar reference. */
+                if (c == 0)
+                    scalar_score = score_a;
+                else
+                    mu_assert("integer motion score must not depend on CPU dispatch",
+                              score_a == scalar_score);
             }
         }
     }
 
     vmaf_set_cpu_flags_mask(~0u);
     return NULL;
+}
+
+/* Relative equality with a small floor, for the float path's cross-dispatch
+ * comparison. See the comment on test_float_motion_pipeline_tiny_sizes() for
+ * why that one comparison cannot be exact. */
+static int motion_scores_close(double a, double b)
+{
+    const double diff = fabs(a - b);
+    const double scale = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return diff <= 1e-6 * scale + 1e-9;
 }
 
 /* The same pipeline-safety and determinism check for the float `motion` path,
@@ -295,7 +321,17 @@ static char *test_integer_motion_pipeline_tiny_sizes()
  * convolution_f32_avx_s() whenever AVX2 is available and returns, so on an x86
  * runner the ~0u pass covers only the AVX kernel and the scalar
  * convolution_y_c_s()/convolution_x_c_s() pair -- the other half of the
- * boundary fix -- would go untouched without the cpu_mask == 0 pass. */
+ * boundary fix -- would go untouched without the cpu_mask == 0 pass.
+ *
+ * Every mask's score is also cross-checked against the cpu_masks[0] (forced
+ * scalar) score for the same (size, bpc), so that a dispatch-dependent
+ * boundary regression cannot hide on an x86 runner. Unlike the integer path,
+ * this comparison is a tolerance and not `==`: convolution_avx.c is built with
+ * -mfma while convolution.c is not, so the compiler contracts the shared
+ * convolution_edge_s() accumulation into fused multiply-adds in the AVX
+ * translation unit only. The two float results are therefore legitimately
+ * allowed to differ in the last bits. A reflection bug changes the score by
+ * O(1), which motion_scores_close() still catches by a wide margin. */
 static char *test_float_motion_pipeline_tiny_sizes()
 {
     vmaf_init_cpu();
@@ -309,6 +345,8 @@ static char *test_float_motion_pipeline_tiny_sizes()
 
     for (unsigned s = 0; s < n_tiny_sizes; s++) {
         for (unsigned b = 0; b < n_bpcs; b++) {
+            double scalar_score = -1.;
+
             for (unsigned c = 0; c < n_cpu_masks; c++) {
                 double score_a = -1., score_b = -1.;
                 int err;
@@ -328,6 +366,13 @@ static char *test_float_motion_pipeline_tiny_sizes()
                           !err);
                 mu_assert("float motion score must be deterministic",
                           score_a == score_b);
+
+                /* cpu_masks[0] is 0, i.e. the forced-scalar reference. */
+                if (c == 0)
+                    scalar_score = score_a;
+                else
+                    mu_assert("float motion score must not depend on CPU dispatch",
+                              motion_scores_close(score_a, scalar_score));
             }
         }
     }

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -20,12 +20,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "config.h"
 #include "cpu.h"
 #include "test.h"
 #include "libvmaf/picture.h"
 #include "feature/feature_collector.h"
 #include "feature/feature_extractor.h"
 #include "feature/integer_motion.h"
+#include "feature/motion_tools.h"
+#include "feature/common/convolution.h"
 #include "feature/common/convolution_internal.h"
 
 /* The historical single-bounce formula, embedded verbatim for regression
@@ -381,6 +384,212 @@ static char *test_float_motion_pipeline_tiny_sizes()
     return NULL;
 }
 
+/* ------------------------------------------------------------------------ *
+ * Canary-buffer write-bounds tests.
+ *
+ * The boundary fix in convolution.c / convolution_avx.c is a fix for an
+ * out-of-bounds WRITE, not merely an out-of-bounds read: at width or height
+ * below the filter width the old borders_left/borders_right (and the AVX
+ * i_vec_end/j_vec_end) computations went negative, so the trailing edge loop
+ * started at a negative index and stored outside dst. A sanitizer catches
+ * that, but upstream CI runs no sanitizer job. These tests catch it on any
+ * host, with no tooling, by surrounding every destination buffer with guard
+ * elements holding a sentinel and asserting the sentinel survives.
+ * ------------------------------------------------------------------------ */
+
+/* A value the convolutions below cannot produce from the test inputs. Written
+ * element by element rather than memset so the exact bit pattern is known and
+ * can be compared with ==. */
+#define CANARY_VALUE (-123456.789f)
+
+/* Guard elements placed before and after every real destination region. The
+ * pre-fix code overran by at most a couple of elements in either direction, so
+ * this is comfortably wide. */
+#define CANARY_GUARD (8)
+
+static void canary_fill(float *buf, int n)
+{
+    for (int i = 0; i < n; i++)
+        buf[i] = CANARY_VALUE;
+}
+
+static int canary_intact(const float *buf, int n)
+{
+    for (int i = 0; i < n; i++) {
+        if (buf[i] != CANARY_VALUE)
+            return 0;
+    }
+    return 1;
+}
+
+/* Source pixels, big enough for every case below. Values are arbitrary; only
+ * the destination bounds are under test. */
+static const float canary_src[8] = { 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f };
+
+extern void convolution_x_c_s(const float *filter, int filter_width,
+                              const float *src, float *dst, int width,
+                              int height, int src_stride, int dst_stride,
+                              int step);
+extern void convolution_y_c_s(const float *filter, int filter_width,
+                              const float *src, float *dst, int width,
+                              int height, int src_stride, int dst_stride,
+                              int step);
+
+/* T7: the scalar convolution kernels must not write outside dst at the tiny
+ * dimensions the fix targets. Runs everywhere, on every host and every CI job.
+ *
+ * The swept dimension goes 1..4, i.e. everything strictly below the 5-tap
+ * filter width, which is exactly the range where the unclamped
+ * borders_left/borders_right went negative. The other dimension is held small
+ * and fixed so that the real dst region is exactly packed and any overrun
+ * necessarily lands in a guard rather than in unused stride padding. */
+static char *test_convolution_scalar_write_bounds()
+{
+    /* Horizontal pass: height == 1, so dst is exactly `width` floats. */
+    for (int width = 1; width <= 4; width++) {
+        float buf[CANARY_GUARD + 4 + CANARY_GUARD];
+        const int n = (int)(sizeof(buf) / sizeof(buf[0]));
+
+        canary_fill(buf, n);
+        convolution_x_c_s(FILTER_5_s, 5, canary_src, buf + CANARY_GUARD,
+                          width, 1, width, width, 1);
+
+        mu_assert("convolution_x_c_s wrote before dst",
+                  canary_intact(buf, CANARY_GUARD));
+        mu_assert("convolution_x_c_s wrote past dst",
+                  canary_intact(buf + CANARY_GUARD + width,
+                                n - CANARY_GUARD - width));
+    }
+
+    /* Vertical pass: width == 2, so dst is exactly height*2 floats. */
+    for (int height = 1; height <= 4; height++) {
+        const int width = 2;
+        float buf[CANARY_GUARD + 4 * 2 + CANARY_GUARD];
+        const int n = (int)(sizeof(buf) / sizeof(buf[0]));
+        const int real = width * height;
+
+        canary_fill(buf, n);
+        convolution_y_c_s(FILTER_5_s, 5, canary_src, buf + CANARY_GUARD,
+                          width, height, width, width, 1);
+
+        mu_assert("convolution_y_c_s wrote before dst",
+                  canary_intact(buf, CANARY_GUARD));
+        mu_assert("convolution_y_c_s wrote past dst",
+                  canary_intact(buf + CANARY_GUARD + real,
+                                n - CANARY_GUARD - real));
+    }
+
+    return NULL;
+}
+
+#if ARCH_X86
+/* AVX_STEP is file-local to convolution_avx.c and the header exposes no
+ * accessor, so its value is duplicated here. The AVX kernels size their
+ * caller-supplied tmp scratch as vmaf_ceiln(width, AVX_STEP) floats per row. */
+#define TEST_AVX_STEP (8)
+
+static int canary_ceiln(int n, int m)
+{
+    return n % m ? n + (m - n % m) : n;
+}
+
+/* convolution.h requires every array argument to be 32-byte aligned. */
+static float *canary_align32(float *p)
+{
+    uintptr_t a = (uintptr_t)p;
+    a = (a + 31u) & ~(uintptr_t)31u;
+    return (float *)a;
+}
+
+/* Runs all three AVX convolution kernels for one (width, height) with both the
+ * tmp scratch and dst guarded, and verifies every guard survives.
+ *
+ * width and height stay <= 4 here, which keeps every vectorised loop empty:
+ * vmaf_floorn(width - 2, 8) and vmaf_floorn(width, 8) are both 0, and the
+ * vertical vector loop runs over [radius, max(height - radius, ...)) which is
+ * empty for height <= 4. So only the edge loops -- the ones the clamps fix --
+ * execute, and the aligned loads/stores in the scanline helpers are never
+ * reached (which is why the packed, stride == width source layout below is
+ * safe even though it does not 32-byte align individual rows). */
+static char *avx_write_bounds_case(int width, int height)
+{
+    static float raw_src1[128], raw_src2[128], raw_tmp[128], raw_dst[128];
+
+    const int tmp_stride = canary_ceiln(width, TEST_AVX_STEP);
+    const int tmp_real = height * tmp_stride;
+    const int tmp_len = CANARY_GUARD + tmp_real + CANARY_GUARD;
+    const int dst_stride = width;
+    const int dst_real = height * dst_stride;
+    const int dst_len = CANARY_GUARD + dst_real + CANARY_GUARD;
+
+    float *src1 = canary_align32(raw_src1);
+    float *src2 = canary_align32(raw_src2);
+    float *tmp_base = canary_align32(raw_tmp);
+    float *dst_base = canary_align32(raw_dst);
+    float *tmp = tmp_base + CANARY_GUARD;
+    float *dst = dst_base + CANARY_GUARD;
+
+    for (int i = 0; i < width * height; i++) {
+        src1[i] = (float)(i + 1);
+        src2[i] = (float)(width * height - i);
+    }
+
+#define AVX_CANARY_CHECK(name)                                                \
+    do {                                                                      \
+        mu_assert(name " wrote before tmp",                                   \
+                  canary_intact(tmp_base, CANARY_GUARD));                     \
+        mu_assert(name " wrote past tmp",                                     \
+                  canary_intact(tmp_base + CANARY_GUARD + tmp_real,           \
+                                CANARY_GUARD));                               \
+        mu_assert(name " wrote before dst",                                   \
+                  canary_intact(dst_base, CANARY_GUARD));                     \
+        mu_assert(name " wrote past dst",                                     \
+                  canary_intact(dst_base + CANARY_GUARD + dst_real,           \
+                                CANARY_GUARD));                               \
+    } while (0)
+
+    canary_fill(tmp_base, tmp_len);
+    canary_fill(dst_base, dst_len);
+    convolution_f32_avx_s(FILTER_5_s, 5, src1, dst, tmp, width, height,
+                          width, dst_stride);
+    AVX_CANARY_CHECK("convolution_f32_avx_s");
+
+    canary_fill(tmp_base, tmp_len);
+    canary_fill(dst_base, dst_len);
+    convolution_f32_avx_sq_s(FILTER_5_s, 5, src1, dst, tmp, width, height,
+                             width, dst_stride);
+    AVX_CANARY_CHECK("convolution_f32_avx_sq_s");
+
+    canary_fill(tmp_base, tmp_len);
+    canary_fill(dst_base, dst_len);
+    convolution_f32_avx_xy_s(FILTER_5_s, 5, src1, src2, dst, tmp, width,
+                             height, width, width, dst_stride);
+    AVX_CANARY_CHECK("convolution_f32_avx_xy_s");
+
+#undef AVX_CANARY_CHECK
+
+    return NULL;
+}
+#endif /* ARCH_X86 */
+
+/* T8: the AVX convolution kernels must not write outside tmp or dst at tiny
+ * dimensions. x86-only: convolution_avx.c is compiled (and ARCH_X86 defined)
+ * only for x86 with asm enabled, so this is inert on every other target. */
+static char *test_convolution_avx_write_bounds()
+{
+#if ARCH_X86
+    for (int width = 1; width <= 4; width++) {
+        char *msg = avx_write_bounds_case(width, 1);
+        if (msg) return msg;
+    }
+    for (int height = 1; height <= 4; height++) {
+        char *msg = avx_write_bounds_case(2, height);
+        if (msg) return msg;
+    }
+#endif
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_motion_mirror_matches_pre_fix_for_normal_sizes);
@@ -389,5 +598,7 @@ char *run_tests()
     mu_run_test(test_convolution_mirror_matches_pre_fix_for_normal_sizes);
     mu_run_test(test_integer_motion_pipeline_tiny_sizes);
     mu_run_test(test_float_motion_pipeline_tiny_sizes);
+    mu_run_test(test_convolution_scalar_write_bounds);
+    mu_run_test(test_convolution_avx_write_bounds);
     return NULL;
 }

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -20,6 +20,7 @@
 
 #include "test.h"
 #include "feature/integer_motion.h"
+#include "feature/common/convolution_internal.h"
 
 /* The historical single-bounce formula, embedded verbatim for regression
  * comparison. This is deliberately duplicated: it is the pre-fix behavior,
@@ -107,10 +108,47 @@ static char *test_cuda_mirror_formula_matches_pre_fix_for_sup_ge_2()
     return NULL;
 }
 
+/* The historical single-bounce reflection from convolution_internal.h's
+ * convolution_edge_*_s() functions, transcribed verbatim (the original code no
+ * longer exists after the fix). Both branches -- horizontal on `width` and
+ * vertical on `height` -- used this exact same arithmetic, so a single
+ * reference is enough. */
+static int convolution_mirror_reference_pre_fix(int tap, int size)
+{
+    if (tap < 0) return -tap;
+    if (tap >= size) return size - (tap - size + 2);
+    return tap;
+}
+
+/* T4: convolution_mirror() must be bit-identical to the pre-fix inline
+ * reflection over the whole in-contract range, proving the float convolution
+ * path's output is unchanged for width/height >= 3.
+ *
+ * The range covered here is the 5-tap / radius-2 contract this fix is
+ * responsible for. convolution_internal.h is also instantiated with other
+ * filter widths by other float features; those get the same guarantee
+ * structurally, without a separate exhaustive loop: for any radius r and any
+ * size >= r + 1, an in-contract tap lies in [-r, size - 1 + r], for which the
+ * new loop takes at most one reflection and therefore evaluates the exact same
+ * expression as the old single-bounce code. */
+static char *test_convolution_mirror_matches_pre_fix_for_normal_sizes()
+{
+    for (int size = 3; size <= 8192; size++) {
+        for (int tap = -2; tap <= size + 1; tap++) {
+            int got = convolution_mirror(tap, size);
+            int want = convolution_mirror_reference_pre_fix(tap, size);
+            mu_assert("convolution_mirror must match pre-fix formula for size >= 3",
+                      got == want);
+        }
+    }
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_motion_mirror_matches_pre_fix_for_normal_sizes);
     mu_run_test(test_motion_mirror_sub3_sizes);
     mu_run_test(test_cuda_mirror_formula_matches_pre_fix_for_sup_ge_2);
+    mu_run_test(test_convolution_mirror_matches_pre_fix_for_normal_sizes);
     return NULL;
 }

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -158,6 +158,15 @@ static const struct { unsigned w, h; } tiny_sizes[] = {
 };
 static const unsigned n_tiny_sizes = sizeof(tiny_sizes) / sizeof(tiny_sizes[0]);
 
+/* Both dispatch choices have to be exercised explicitly. A mask of 0 forces
+ * the scalar kernels on every host; ~0u picks the best available, which is a
+ * different kernel on an x86 CI runner than on arm64. Testing only the latter
+ * would silently leave the scalar path uncovered wherever SIMD is present --
+ * convolution_f32_c_s() in particular returns early into the AVX kernel as
+ * soon as AVX2 is available, so its C fallback would never run there. */
+static const unsigned cpu_masks[] = { 0, ~0u };
+static const unsigned n_cpu_masks = sizeof(cpu_masks) / sizeof(cpu_masks[0]);
+
 static void fill_random_picture(VmafPicture *pic, unsigned seed)
 {
     srand(seed);
@@ -229,9 +238,9 @@ static int run_motion_fex(VmafFeatureExtractor *fex, const char *feature_name,
     return 0;
 }
 
-/* T5: the integer `motion` extractor must run to completion at frame sizes
- * smaller than the filter radius, touching only valid memory (the real teeth
- * of this test come from running it under ASan) and producing a well-defined,
+/* The integer `motion` extractor must run to completion at frame sizes smaller
+ * than the filter radius, touching only valid memory (the real teeth of this
+ * test come from running it under ASan) and producing a well-defined,
  * repeatable score. There is no meaningful golden value at 1x1, so what is
  * asserted is: the call succeeds, the score is finite, and two identical runs
  * agree bit-for-bit. Both the 8 bpc and the 16 bpc pipeline are covered, and
@@ -240,8 +249,6 @@ static char *test_integer_motion_pipeline_tiny_sizes()
 {
     static const unsigned bpcs[] = { 8, 10, 12, 16 };
     const unsigned n_bpcs = sizeof(bpcs) / sizeof(bpcs[0]);
-    static const unsigned cpu_masks[] = { 0, ~0u };
-    const unsigned n_cpu_masks = sizeof(cpu_masks) / sizeof(cpu_masks[0]);
 
     vmaf_init_cpu();
 
@@ -279,10 +286,16 @@ static char *test_integer_motion_pipeline_tiny_sizes()
     return NULL;
 }
 
-/* T6: the same pipeline-safety and determinism check for the float `motion`
- * path, which reflects through convolution_mirror() instead. Skipped when the
+/* The same pipeline-safety and determinism check for the float `motion` path,
+ * which reflects through convolution_mirror() instead. Skipped when the
  * library was configured with -Denable_float=false, in which case the
- * extractor simply is not registered. */
+ * extractor simply is not registered.
+ *
+ * Both CPU masks matter here: convolution_f32_c_s() hands off to
+ * convolution_f32_avx_s() whenever AVX2 is available and returns, so on an x86
+ * runner the ~0u pass covers only the AVX kernel and the scalar
+ * convolution_y_c_s()/convolution_x_c_s() pair -- the other half of the
+ * boundary fix -- would go untouched without the cpu_mask == 0 pass. */
 static char *test_float_motion_pipeline_tiny_sizes()
 {
     vmaf_init_cpu();
@@ -296,23 +309,26 @@ static char *test_float_motion_pipeline_tiny_sizes()
 
     for (unsigned s = 0; s < n_tiny_sizes; s++) {
         for (unsigned b = 0; b < n_bpcs; b++) {
-            double score_a = -1., score_b = -1.;
-            int err;
+            for (unsigned c = 0; c < n_cpu_masks; c++) {
+                double score_a = -1., score_b = -1.;
+                int err;
 
-            err = run_motion_fex(fex, "VMAF_feature_motion_score",
-                                 tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
-                                 ~0u, &score_a);
-            mu_assert("float motion extraction must succeed at tiny sizes",
-                      !err);
-            mu_assert("float motion score must be finite at tiny sizes",
-                      isfinite(score_a));
+                err = run_motion_fex(fex, "VMAF_feature_motion_score",
+                                     tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                                     cpu_masks[c], &score_a);
+                mu_assert("float motion extraction must succeed at tiny sizes",
+                          !err);
+                mu_assert("float motion score must be finite at tiny sizes",
+                          isfinite(score_a));
 
-            err = run_motion_fex(fex, "VMAF_feature_motion_score",
-                                 tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
-                                 ~0u, &score_b);
-            mu_assert("float motion re-run must succeed at tiny sizes", !err);
-            mu_assert("float motion score must be deterministic",
-                      score_a == score_b);
+                err = run_motion_fex(fex, "VMAF_feature_motion_score",
+                                     tiny_sizes[s].w, tiny_sizes[s].h, bpcs[b],
+                                     cpu_masks[c], &score_b);
+                mu_assert("float motion re-run must succeed at tiny sizes",
+                          !err);
+                mu_assert("float motion score must be deterministic",
+                          score_a == score_b);
+            }
         }
     }
 

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -1,0 +1,74 @@
+/**
+ *
+ *  Copyright 2016-2026 Netflix, Inc.
+ *
+ *     Licensed under the BSD+Patent License (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         https://opensource.org/licenses/BSDplusPatent
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+#include "test.h"
+#include "feature/integer_motion.h"
+
+/* The historical single-bounce formula, embedded verbatim for regression
+ * comparison. This is deliberately duplicated: it is the pre-fix behavior,
+ * and comparing against it over the full in-contract range is the only way
+ * to mechanically prove the fix changed nothing for size >= 3. */
+static int mirror_reference_pre_fix(int idx, int size)
+{
+    if (idx < 0) return -idx;
+    if (idx >= size) return 2 * size - idx - 2;
+    return idx;
+}
+
+/* T1: for every size in the normal (in-contract) range, and every idx within
+ * the 5-tap/radius-2 call contract, motion_mirror() must be bit-identical to
+ * the old single-bounce formula. This proves the fix changes no output for
+ * width/height >= 3. */
+static char *test_motion_mirror_matches_pre_fix_for_normal_sizes()
+{
+    for (int size = 3; size <= 8192; size++) {
+        for (int idx = -2; idx <= size + 1; idx++) {
+            int got = motion_mirror(idx, size);
+            int want = mirror_reference_pre_fix(idx, size);
+            mu_assert("motion_mirror must match pre-fix formula for size >= 3",
+                      got == want);
+        }
+    }
+    return NULL;
+}
+
+/* T2: exact reflect-101 semantics for the sub-3 sizes the fix targets. */
+static char *test_motion_mirror_sub3_sizes()
+{
+    for (int idx = -2; idx <= 3; idx++)
+        mu_assert("size==1 must map every idx to 0", motion_mirror(idx, 1) == 0);
+
+    static const int expected[][2] = {
+        {-2, 0}, {-1, 1}, {0, 0}, {1, 1}, {2, 0}, {3, 1},
+    };
+    const int n = sizeof(expected) / sizeof(expected[0]);
+    for (int i = 0; i < n; i++) {
+        int idx = expected[i][0];
+        int want = expected[i][1];
+        mu_assert("size==2 reflect-101 mismatch", motion_mirror(idx, 2) == want);
+    }
+
+    return NULL;
+}
+
+char *run_tests()
+{
+    mu_run_test(test_motion_mirror_matches_pre_fix_for_normal_sizes);
+    mu_run_test(test_motion_mirror_sub3_sizes);
+    return NULL;
+}

--- a/libvmaf/test/test_motion_mirror.c
+++ b/libvmaf/test/test_motion_mirror.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <stdlib.h>
+
 #include "test.h"
 #include "feature/integer_motion.h"
 
@@ -66,9 +68,49 @@ static char *test_motion_mirror_sub3_sizes()
     return NULL;
 }
 
+// Host-side transcription of the CUDA mirror() formula (motion_score.cu), both
+// pre- and post-fix, for comparison purposes only -- this is not compiled CUDA code
+// (no local CUDA toolchain), just the identical arithmetic expression in C.
+static int cuda_mirror_pre_fix(int idx, int sup)
+{
+    int out = abs(idx);
+    return (out < sup) ? out : (sup - (out - sup + 1));
+}
+
+static int cuda_mirror_post_fix(int idx, int sup)
+{
+    if (sup == 1) return 0;
+    int out = abs(idx);
+    return (out < sup) ? out : (sup - (out - sup + 1));
+}
+
+// T3: host-side comparison of the CUDA mirror() formula, pre- and post-fix.
+// For sup >= 2 the fix must be a no-op; for sup == 1 the post-fix version
+// must degenerate safely to 0 (the pre-fix version is not asserted at
+// sup == 1 since it is genuinely out of range there and is simply no longer
+// called with sup == 1).
+static char *test_cuda_mirror_formula_matches_pre_fix_for_sup_ge_2()
+{
+    for (int sup = 2; sup <= 8192; sup++) {
+        for (int idx = -2; idx <= sup + 1; idx++) {
+            int got = cuda_mirror_post_fix(idx, sup);
+            int want = cuda_mirror_pre_fix(idx, sup);
+            mu_assert("cuda mirror post-fix must match pre-fix formula for sup >= 2",
+                      got == want);
+        }
+    }
+
+    for (int idx = -2; idx <= 3; idx++)
+        mu_assert("cuda mirror post-fix must map every idx to 0 for sup == 1",
+                  cuda_mirror_post_fix(idx, 1) == 0);
+
+    return NULL;
+}
+
 char *run_tests()
 {
     mu_run_test(test_motion_mirror_matches_pre_fix_for_normal_sizes);
     mu_run_test(test_motion_mirror_sub3_sizes);
+    mu_run_test(test_cuda_mirror_formula_matches_pre_fix_for_sup_ge_2);
     return NULL;
 }

--- a/libvmaf/test/test_motion_neon.c
+++ b/libvmaf/test/test_motion_neon.c
@@ -74,9 +74,8 @@ static int compute_motion_sad(unsigned w, unsigned h,
 
 static char *test_motion_neon_matches_scalar()
 {
-    // w/h < 3 excluded: mirror()'s radius-2 reflection goes out of bounds there
-    // (same bug in scalar/AVX2), so those sizes compare garbage against garbage.
     static const struct { unsigned w, h; } sizes[] = {
+        {1, 1}, {2, 2}, {1, 8}, {8, 1}, {2, 8}, {8, 2},
         {3, 3}, {4, 4}, {5, 5}, {7, 7}, {9, 9},
         {15, 15}, {16, 16}, {17, 17}, {20, 4}, {33, 9}, {64, 48}, {65, 63},
     };


### PR DESCRIPTION
Fixes #1580.

## Bug

`mirror(int idx, int size)` reflects row/column indices at frame boundaries for the
5-tap (radius-2) motion filter. It's a single-bounce reflect-101 implementation:

```c
static inline int mirror(int idx, int size)
{
    if (idx < 0) return -idx;
    if (idx >= size) return 2 * size - idx - 2;
    return idx;
}
```

For `size < 3` this returns indices outside `[0, size)` — e.g. `mirror(-2, 1) = 2`,
out of range for a 1-row/1-column plane. The identical function was independently
duplicated in 4 places (`integer_motion.c`, `x86/motion_avx2.c`, `x86/motion_avx512.c`,
`arm64/motion_neon.c`), plus a differently-structured CUDA version, plus the shared
float convolution helpers used by `float_motion` and (via `convolution_f32_avx_*`)
`vif_tools.c`.

The float convolution path additionally has an out-of-bounds **write**: with radius 2,
`convolution_x_c_s`'s `borders_right = width - 3` goes negative for `width < 3`, so the
trailing edge loop starts before `dst[0]`. The equivalent bug exists in
`convolution_avx.c`'s vertical pass (`i_vec_end = height - radius` goes negative,
writing `tmp[-tmp_stride + j]`).

This isn't only a 1×1-frame issue. `vif_tools.c` calls `convolution_f32_avx_s` with
filter widths up to 17 (radius 8), so on any AVX2 host the same OOB write triggers for
**any dimension below 8**, at every VIF scale — not just degenerate frames.

## Fix

- `motion_mirror()` (new, replacing 4 duplicated `mirror()` copies): reflects
  *repeatedly* instead of once, so any `size >= 1` is safe. `size == 1`/`size <= 0`
  degenerate to `0` (the unique valid extension of a 1-sample signal — matches
  OpenCV's `BORDER_REFLECT_101` and scipy's `mode='mirror'`).
- Renamed from `mirror` to `motion_mirror` and consolidated into `integer_motion.h`
  (all 4 CPU files already include it). The rename is required, not stylistic: the CUDA
  translation unit also includes this header and already owns a `mirror` symbol with
  different (intentionally unrelated, untouched) reflect-even semantics — reusing the
  bare name would collide under `nvcc`.
- `convolution_mirror()` (new, in `convolution_internal.h`): same fix, kept separate
  from `motion_mirror` since this header serves other float features with their own
  style and no existing dependency on `integer_motion.h`.
- CUDA's own `mirror()`: added `if (sup == 1) return 0;` — one line, its `sup >= 2`
  formula is untouched.
- `convolution.c` / `convolution_avx.c`: clamped the edge-loop bounds so tiny
  width/height can't write out of bounds, without changing anything for normal sizes.

**Non-regression is structural, not just tested.** For the real call contract
(`idx` in `[-2, size+1]`, 5-tap/radius-2), a negative overshoot lands in `[1,2]` and a
positive one in `[size-3, size-1]` whenever `size >= 3` — both already valid, so the
new multi-bounce loop takes exactly one iteration and computes the *exact same
expression* as the old code. This is proven exhaustively in tests (below), not just
argued in the abstract.

## Testing

- **Exhaustive old-vs-new formula proofs** for all three reflection implementations
  (`motion_mirror`, `convolution_mirror`, and a host-side transcription of the CUDA
  formula), comparing every `size` in `[3, 8192]` against every in-contract offset —
  mechanically proves zero behavior change for `size >= 3`.
- **Pipeline tests** at 8 tiny sizes (`1×1` through `8×2`) across multiple bit depths,
  run through the real `motion`/`float_motion` feature extractors, asserting success,
  finite scores, and — for each size — that the score obtained via forced-scalar
  dispatch matches the score obtained via best-available SIMD dispatch (bit-exact for
  the integer path; a documented, generously-tight tolerance for the float path, since
  AVX's `-mfma` can contract the shared edge-filter's multiply-add into an FMA and
  change the last bit or two versus the non-FMA scalar build — unrelated to this fix).
  This is the only runtime coverage the AVX2/AVX512 motion kernels get from this test
  suite, since no x86 hardware was available anywhere in developing this fix (see
  below).
- **Canary-buffer bounds tests** for the OOB-*write* fix: guard regions before/after
  the real output buffer, asserted intact after the call, for the scalar convolution
  path (verified with a negative control — temporarily removing the clamps reproduces
  the failure) and, `#if ARCH_X86`-gated, the AVX path.
- **Live ASan red-then-green demonstration**, reproduced independently on two hosts/
  toolchains (macOS/Apple Clang arm64, Ubuntu 22.04/GCC 11.4.0 aarch64): built with
  `-Db_sanitize=address,undefined`, confirmed clean on the fix, then temporarily
  reverted just the two `mirror` function bodies to the old formula and confirmed a
  real `heap-buffer-overflow` abort in both the integer path
  (`motion_score_pipeline_8`) and the float path (`convolution_y_c_s`) — then restored
  and reconfirmed clean.
- Full `meson test` suite: 25/25 on both hosts.
- Python end-to-end golden-score regression suite (`quality_runner_test.py`): 67/67,
  run twice, on Ubuntu/GCC — no VMAF score on real video content moved.

## What's *not* verified at runtime

No x86 or CUDA hardware was available anywhere in developing this fix.

- **x86 (AVX2/AVX512):** verified only via cross-target `clang -target x86_64-... 
  -mavx2/-mavx512f -fsyntax-only`/`-c` checks (proves it compiles and type-checks, not
  that it's correct at runtime) plus the exhaustive formula proofs and mechanical
  rename review. This PR's own test suite gives these kernels real coverage the moment
  CI runs it on an x86 runner.
- **CUDA:** the one-line guard is exhaustively proven inert for `sup >= 2` via a
  host-side transcription, but the actual `.cu` file has never been compiled. This
  repo's CI doesn't build the CUDA path, so a maintainer with CUDA access verifying the
  guard would be appreciated.